### PR TITLE
Add ROBOT option to prevent NCBITaxon axioms being copied into Uberon.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -126,7 +126,7 @@ is_ok: unreasoned.owl
 
 materialized.owl: unreasoned.owl is_ok
 	$(ROBOT) relax -i $< materialize -T basic_properties.txt -r elk \
-		 reason -r elk \
+		 reason -r elk --exclude-duplicate-axioms true \
 		 annotate -O $(OBO)/uberon/$@ -V  $(RELEASE)/$@ -o $@ >& $@.LOG
 .PRECIOUS: materialized.owl
 


### PR DESCRIPTION
The `materialized.owl` makefile target causes the NCBITaxon hierarchy axioms to be duplicated into the main Uberon file:

https://github.com/obophenotype/uberon/blob/f96afbf9df79f5abca742b68fcea2c2f282be75b/Makefile#L127-L130

I added `--exclude-duplicate-axioms` to prevent this. I'm not sure why ROBOT is even treating these as inferred; will need to look into that separately. This should fix https://github.com/geneontology/go-ontology/issues/12218.