### PR TITLE
uberon-idranges.owl range for InterLex requests

### DIFF
--- a/uberon-idranges.owl
+++ b/uberon-idranges.owl
@@ -103,3 +103,7 @@ EquivalentTo: xsd:integer[> 8300000, <= 8305000]
 Datatype: idrange:21
 Annotations: allocatedto: "Sebastian Koehler",
 EquivalentTo: xsd:integer[> 8305001, <= 8309999]
+
+Datatype: idrange:22
+Annotations: allocatedto: "InterLex",
+EquivalentTo: xsd:integer[> 8310000, <= 8399999]


### PR DESCRIPTION
Add an idrange for anatomical terms coming from InterLex. This will
greatly simplify the process of automatically generating pull requests
so that terms will already have a valid uberon id and will not have to
be manually mapped back into InterLex, only confirmed/rejected for
inclusion.