### PR TITLE
Add a workflow to automatically close stale issues.

### DIFF
--- a/.github/workflows/stale-issues.yml
+++ b/.github/workflows/stale-issues.yml
@@ -15,4 +15,4 @@ jobs:
           days-before-issue-close: 30
           close-issue-label: 'autoclosed-unfixed'
           close-issue-message: 'This issue has been closed automatically because it has not been updated in 6 months. Please re-open if you still need this to be addressed.'
-          start-date: '2018-09-01T00:00:00Z'
+          start-date: '2021-03-01T00:00:00Z'

--- a/.github/workflows/stale-issues.yml
+++ b/.github/workflows/stale-issues.yml
@@ -1,0 +1,18 @@
+name: 'Mark and close stale issues'
+
+on:
+  schedule:
+    - cron: '0 1 * * *'
+
+jobs:
+  stale:
+    runs-ons: ubuntu-latest
+    steps:
+      - uses: actions/stale@v4
+        with:
+          days-before-issue-stale: 150
+          days-before-pr-stale: -1
+          days-before-issue-close: 30
+          close-issue-label: 'autoclosed-unfixed'
+          close-issue-message: 'This issue has been closed automatically because it has not been updated in 6 months. Please re-open if you still need this to be addressed.'
+          start-date: '2018-09-01T00:00:00Z'


### PR DESCRIPTION
Add a new GitHub Actions workflow to be executed daily to:
- mark issues that have not been updated in 5 months as 'Stale';
- close 'Stale' issues that have not been updated in 1 month.

This workflow will only apply to issues that were created or updated *after* March 1st, 2021, to avoid auto-closing all the issues from the past 3 years.