### PR TITLE
Add a comment on an issue when marking it as stale.

### DIFF
--- a/.github/workflows/stale-issues.yml
+++ b/.github/workflows/stale-issues.yml
@@ -14,5 +14,6 @@ jobs:
           days-before-pr-stale: -1
           days-before-issue-close: 365
           close-issue-label: 'autoclosed-unfixed'
-          close-issue-message: 'This issue has been closed automatically because it has not been updated in 6 months. Please re-open if you still need this to be addressed.'
+          stale-issue-message: 'This issue has not seen activity any in the past 6 months; it will be closed automatically in one year from now if no action is taken.'
+          close-issue-message: 'This issue has been closed automatically because it has not been updated in 18 months. Please re-open if you still need this to be addressed.'
           start-date: '2021-04-01T00:00:00Z'


### PR DESCRIPTION
As discussed in the September 20th 2021 Uberon/CL call, make sure the auto-closing process adds a comment on any issue that is to be marked with the 'Stale' label, so that editors are automatically alerted when that happens.

(The original PR did not ensure that; instead a comment was only added at the time an issue was about to be _closed_, not labelled as stale.)