### PR TITLE
Fix the comment emited when marking an issue as stale.

### DIFF
--- a/.github/workflows/stale-issues.yml
+++ b/.github/workflows/stale-issues.yml
@@ -14,6 +14,6 @@ jobs:
           days-before-pr-stale: -1
           days-before-issue-close: 365
           close-issue-label: 'autoclosed-unfixed'
-          stale-issue-message: 'This issue has not seen activity any in the past 6 months; it will be closed automatically in one year from now if no action is taken.'
+          stale-issue-message: 'This issue has not seen any activity in the past 6 months; it will be closed automatically in one year from now if no action is taken.'
           close-issue-message: 'This issue has been closed automatically because it has not been updated in 18 months. Please re-open if you still need this to be addressed.'
           start-date: '2021-04-01T00:00:00Z'


### PR DESCRIPTION
This PR fixes the fact that _some people_ (i.e. me) can’t be trusted to write a one-line message without messing with the phrasing…