### PR TITLE
Add ID range for Damien Goutte-Gattat.

### DIFF
--- a/src/ontology/uberon-idranges.owl
+++ b/src/ontology/uberon-idranges.owl
@@ -127,3 +127,7 @@ EquivalentTo: xsd:integer[> 8430000, <= 8439999]
 Datatype: idrange:27
 Annotations: allocatedto: "Shawn Tan",
 EquivalentTo: xsd:integer[> 8440000, <= 8449999]
+
+Datatype: idrange:28
+Annotations: allocatedto: "Damien Goutte-Gattat",
+EquivalentTo: xsd:integer[> 8450000, <= 8459999]


### PR DESCRIPTION
This PR adds a new ID range allocated to FlyBase ontology editor Damien Goutte-Gattat (@gouttegd).