### PR TITLE
Use disjointWith instead of equivalence to Nothing, to avoid pathological reasoner behavior.

### DIFF
--- a/src/sparql/taxon_constraint_never_in_taxon.ru
+++ b/src/sparql/taxon_constraint_never_in_taxon.ru
@@ -6,12 +6,10 @@ prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
 
 
 INSERT {
-  owl:Nothing owl:equivalentClass [ owl:intersectionOf ( ?term
-                                       [ rdf:type owl:Restriction ;
-                                         owl:onProperty RO:0002162 ;
-                                         owl:someValuesFrom ?taxon
-                                       ]
-                                  )] .
+  ?term owl:disjointWith [ rdf:type owl:Restriction ;
+                           owl:onProperty RO:0002162 ;
+                           owl:someValuesFrom ?taxon
+                         ] .
 }
 WHERE 
 { 


### PR DESCRIPTION
This fixes the issue of out of control memory usage in computing taxon subsets. This morning I had done a test in Protege and concluded the problem must lie within owltools, but this was a mistake. I was using the current Uberon release, but the problem only manifests with the increased number of never_in_taxon constraints in the edit file. There were previously 706, but the current number (2460) pushed ELK into some kind of bad behavior.

Instead of modeling disjoints as an intersection which is equivalent to Nothing, this change just uses a direct disjoint axiom, which it seems the ELK algorithm is better prepared to handle.

With this fix there is no need for the Ammonite script I proposed.