### PR TITLE
Merge the mappings component early in the pipeline.

### DIFF
--- a/src/ontology/uberon.Makefile
+++ b/src/ontology/uberon.Makefile
@@ -92,7 +92,7 @@ checks: $(REPORTDIR)/uberon-edit-xp-check $(REPORTDIR)/uberon-edit-obscheck.txt 
 # TODO: Huge number of printouts that pollute the general logs
 $(OWLSRC): $(SRC) $(COMPONENTSDIR)/disjoint_union_over.ofn $(REPORTDIR)/$(SRC)-gocheck $(REPORTDIR)/$(SRC)-iconv $(SCRIPTSDIR)/expand-dbxref-literals.pl
 	echo "STRONG WARNING: issues/contributor.owl needs to be manually updated."
-	$(OWLTOOLS) --no-logging $< $(COMPONENTSDIR)/disjoint_union_over.ofn issues/contributor.owl --merge-support-ontologies --expand-macros -o  $@.tmp &&  $(SCRIPTSDIR)/expand-dbxref-literals.pl $@.tmp
+	$(OWLTOOLS) --no-logging $< $(COMPONENTSDIR)/disjoint_union_over.ofn issues/contributor.owl --merge-support-ontologies --merge-import http://purl.obolibrary.org/obo/uberon/components/mappings.owl --expand-macros -o  $@.tmp &&  $(SCRIPTSDIR)/expand-dbxref-literals.pl $@.tmp
 	$(ROBOT) query -i $@.tmp --update $(SPARQLDIR)/taxon_constraint_never_in_taxon.ru --update $(SPARQLDIR)/remove_axioms.ru -o $@
 
 $(TMPDIR)/NORMALIZE.obo: $(SRC)


### PR DESCRIPTION
Make sure the cross-references for mappings (that have been moved to the components/mappings.owl file) are merged back early in the pipeline (in the first file derived from the -edit file), so that they end up in all generated artefacts.

This is the least disruptive option, as it allows to mimic closely the situation that existed before the mappings were moved to a separate component.

Without that, the mappings component is only merged at the end of the pipeline (when producing `uberon.owl`), when all other imports are merged.