### PR TITLE
Removing uberon:2x never in taxon

### DIFF
--- a/src/ontology/uberon.Makefile
+++ b/src/ontology/uberon.Makefile
@@ -1876,7 +1876,10 @@ docs/releases.md: uberon-odk.yaml
 ### Removing uberon_2 contraints 
 ### refer to https://github.com/obophenotype/uberon/discussions/2158
 remove_uberon_two_constraints:
-	$(ROBOT) query -i $(SRC) --update ../sparql/delete_uberon_two_constraints.ru -o $(SRC)
+	$(ROBOT) query -i $(SRC) --update ../sparql/delete_uberon_two_constraints.ru convert -f obo -o $(SRC)
+
+select_uberon_two_constraints:
+	$(ROBOT) query -i $(SRC) --query ../sparql/select_uberon_two_constraints.sparql $@.tsv
 
 explain_humans:
 	$(ROBOT) merge -i ../../ext.owl -i contexts/context-human.owl explain --reasoner ELK --axiom "'nose' SubClassOf owl:Nothing" --explanation $@.md

--- a/src/ontology/uberon.Makefile
+++ b/src/ontology/uberon.Makefile
@@ -1872,3 +1872,9 @@ docs/releases.md: uberon-odk.yaml
 	# Amazing: only generate links to release artefacts if they truly exist:
 	# if http://purl.obolibrary.org/obo/mondo/releases/2021-01-01/mondo.owl exists, include it in overview.
 	# Use Github or obo purls (include switch that we can conficgue with ODK)
+
+### Removing uberon_2 contraints 
+### refer to https://github.com/obophenotype/uberon/discussions/2158
+remove_uberon_two_constraints:
+		$(ROBOT) query -i $(SRC) --update ../sparql/delete_uberon_two_constraints.ru -o $(SRC)
+		

--- a/src/sparql/delete_uberon_two_constraints.ru
+++ b/src/sparql/delete_uberon_two_constraints.ru
@@ -5,8 +5,20 @@ PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
 
 DELETE {
   ?subj RO:0002161 ?taxon .
+  ?ax a owl:Axiom ;
+          owl:annotatedSource ?subj ;
+          owl:annotatedProperty RO:0002161 ;
+          owl:annotatedTarget ?taxon ;
+          ?p ?v .
 }
 WHERE {
   ?subj RO:0002161 ?taxon . 
+  OPTIONAL {
+  ?ax a owl:Axiom ;
+          owl:annotatedSource ?subj ;
+          owl:annotatedProperty RO:0002161 ;
+          owl:annotatedTarget ?taxon ;
+          ?p ?v .
+   }
    FILTER (isIRI(?subj) && STRSTARTS(str(?subj), "http://purl.obolibrary.org/obo/UBERON_2"))
 }

--- a/src/sparql/delete_uberon_two_constraints.ru
+++ b/src/sparql/delete_uberon_two_constraints.ru
@@ -1,0 +1,12 @@
+PREFIX RO: <http://purl.obolibrary.org/obo/RO_>
+PREFIX owl: <http://www.w3.org/2002/07/owl#>
+PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+
+DELETE {
+  ?subj RO:0002161 ?taxon  
+}
+WHERE {
+  ?subj RO:0002161 ?taxon  
+   FILTER (isIRI(?subj) && STRSTARTS(str(?subj), "http://purl.obolibrary.org/obo/UBERON_2"))
+}

--- a/src/sparql/delete_uberon_two_constraints.ru
+++ b/src/sparql/delete_uberon_two_constraints.ru
@@ -4,9 +4,9 @@ PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
 PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
 
 DELETE {
-  ?subj RO:0002161 ?taxon  
+  ?subj RO:0002161 ?taxon .
 }
 WHERE {
-  ?subj RO:0002161 ?taxon  
+  ?subj RO:0002161 ?taxon . 
    FILTER (isIRI(?subj) && STRSTARTS(str(?subj), "http://purl.obolibrary.org/obo/UBERON_2"))
 }


### PR DESCRIPTION
added command `remove_uberon_two_constraints` that removes all never_in_taxon axioms for uberon:2x and implemented it