### PR TITLE
Extend SPARQL to delete dot-definition

### DIFF
--- a/src/sparql/delete-definition-dot.ru
+++ b/src/sparql/delete-definition-dot.ru
@@ -15,5 +15,5 @@ WHERE {
           owl:annotatedProperty definition: ;
    	 	  owl:annotatedTarget ?def .
     }
-    FILTER (ISIRI(?term) && STRSTARTS(STR(?term), "http://purl.obolibrary.org/obo/UBERON_") && !REGEX(?def, "\\w.", "i"))
+    FILTER (ISIRI(?term) && (STRSTARTS(STR(?term), "http://purl.obolibrary.org/obo/UBERON_") || STRSTARTS(STR(?term), "http://purl.obolibrary.org/obo/uberon/core"))  && !REGEX(?def, "\\w.", "i"))
 }


### PR DESCRIPTION
Update sparql query to also take some properties from `http://purl.obolibrary.org/obo/uberon/core`
Fixes #2129