### PR TITLE
Update FBbt mappings

### DIFF
--- a/src/ontology/mappings/fbbt-mappings.sssom.tsv
+++ b/src/ontology/mappings/fbbt-mappings.sssom.tsv
@@ -71,11 +71,9 @@ FBbt:00000186	embryonic optic lobe primordium	skos:exactMatch	UBERON:6000186	Hum
 FBbt:00000439	stomodeum	skos:exactMatch	UBERON:0000930	HumanCurated
 FBbt:00001055	presumptive embryonic/larval nervous system	skos:exactMatch	UBERON:6001055	HumanCurated
 FBbt:00001056	presumptive embryonic/larval central nervous system	skos:exactMatch	UBERON:6001056	HumanCurated
-FBbt:00001057	neurogenic region	skos:exactMatch	UBERON:6001057	HumanCurated
+FBbt:00001057	neurogenic region	skos:exactMatch	UBERON:0002346	HumanCurated
 FBbt:00001059	visual primordium	skos:exactMatch	UBERON:6001059	HumanCurated
 FBbt:00001060	embryonic brain	skos:exactMatch	UBERON:6001060	HumanCurated
-FBbt:00001061	ventral neurectoderm	skos:exactMatch	UBERON:0002346	HumanCurated
-FBbt:00001102	larval ventral nerve cord	skos:exactMatch	UBERON:0000934	HumanCurated
 FBbt:00001135	proneural cluster	skos:exactMatch	UBERON:6001135	HumanCurated
 FBbt:00001648	embryonic imaginal tissue	skos:exactMatch	UBERON:6001648	HumanCurated
 FBbt:00001649	imaginal disc primordium	skos:exactMatch	UBERON:6001649	HumanCurated
@@ -165,16 +163,13 @@ FBbt:00003020	adult prothoracic segment	skos:exactMatch	UBERON:6003020	HumanCura
 FBbt:00003021	adult mesothoracic segment	skos:exactMatch	UBERON:6003021	HumanCurated
 FBbt:00003023	adult abdomen	skos:exactMatch	UBERON:6003023	HumanCurated
 FBbt:00003024	adult abdominal segment	skos:exactMatch	UBERON:6003024	HumanCurated
+FBbt:00003039	adult dorsal trunk	skos:exactMatch	UBERON:6003039	HumanCurated
 FBbt:00003125	alimentary canal	skos:exactMatch	UBERON:0001555	HumanCurated
 FBbt:00003126	adult mouth	skos:exactMatch	UBERON:0000165	HumanCurated
-FBbt:00003148	adult anus	skos:exactMatch	UBERON:0001245	HumanCurated
-FBbt:00003152	adult dorsal vessel	skos:exactMatch	UBERON:0015231	HumanCurated
-FBbt:00003154	adult heart	skos:exactMatch	UBERON:0007100	HumanCurated
 FBbt:00003154	adult heart	skos:exactMatch	UBERON:0015230	HumanCurated
 FBbt:00003218	adult muscle system	skos:exactMatch	UBERON:6003218	HumanCurated
 FBbt:00003219	adepithelial cell	skos:exactMatch	CL:0000462	HumanCurated
 FBbt:00003259	adult somatic muscle	skos:exactMatch	UBERON:6003259	HumanCurated
-FBbt:00003525	adult visceral muscle	skos:exactMatch	UBERON:0001135	HumanCurated
 FBbt:00003559	adult nervous system	skos:exactMatch	UBERON:6003559	HumanCurated
 FBbt:00003623	adult central nervous system	skos:exactMatch	UBERON:6003623	HumanCurated
 FBbt:00003624	adult brain	skos:exactMatch	UBERON:6003624	HumanCurated
@@ -234,7 +229,6 @@ FBbt:00004850	phallus	skos:exactMatch	UBERON:0008811	HumanCurated
 FBbt:00004856	organ system	skos:exactMatch	UBERON:0000467	HumanCurated
 FBbt:00004857	reproductive system	skos:exactMatch	UBERON:0000990	HumanCurated
 FBbt:00004858	gonad	skos:exactMatch	UBERON:0000991	HumanCurated
-FBbt:00004859	gonadal sheath	skos:exactMatch	UBERON:0004909	HumanCurated
 FBbt:00004861	germline stem cell	skos:exactMatch	CL:0000086	HumanCurated
 FBbt:00004864	female reproductive system	skos:exactMatch	UBERON:0000474	HumanCurated
 FBbt:00004865	ovary	skos:exactMatch	UBERON:0000992	HumanCurated
@@ -242,7 +236,6 @@ FBbt:00004873	female germline stem cell	skos:exactMatch	CL:0000022	HumanCurated
 FBbt:00004878	nurse cell	skos:exactMatch	CL:0000026	HumanCurated
 FBbt:00004886	oocyte	skos:exactMatch	CL:0000023	HumanCurated
 FBbt:00004894	egg chamber	skos:exactMatch	UBERON:0003199	HumanCurated
-FBbt:00004896	ovarian sheath	skos:exactMatch	UBERON:0004911	HumanCurated
 FBbt:00004903	follicle stem cell	skos:exactMatch	CL:0000441	HumanCurated
 FBbt:00004904	follicle cell	skos:exactMatch	CL:0000477	HumanCurated
 FBbt:00004905	border follicle cell	skos:exactMatch	CL:0000579	HumanCurated
@@ -259,7 +252,6 @@ FBbt:00004936	spermatocyte	skos:exactMatch	CL:0000017	HumanCurated
 FBbt:00004941	secondary spermatocyte	skos:exactMatch	CL:0000657	HumanCurated
 FBbt:00004942	spermatid	skos:exactMatch	CL:0000018	HumanCurated
 FBbt:00004954	spermatozoon	skos:exactMatch	CL:0000019	HumanCurated
-FBbt:00004955	testis sheath	skos:exactMatch	UBERON:0004910	HumanCurated
 FBbt:00004958	seminal vesicle	skos:exactMatch	UBERON:0006868	HumanCurated
 FBbt:00004969	integumentary system	skos:exactMatch	UBERON:0002416	HumanCurated
 FBbt:00004970	cuticle	skos:exactMatch	UBERON:0001001	HumanCurated
@@ -277,11 +269,11 @@ FBbt:00005024	tracheal system	skos:exactMatch	UBERON:0005155	HumanCurated
 FBbt:00005036	tracheal pit	skos:exactMatch	UBERON:6005036	HumanCurated
 FBbt:00005037	tracheal primordium	skos:exactMatch	UBERON:6005037	HumanCurated
 FBbt:00005038	tracheocyte	skos:exactMatch	CL:0000307	HumanCurated
-FBbt:00005043	trachea	skos:exactMatch	UBERON:0003127	HumanCurated
+FBbt:00005043	trachea	skos:exactMatch	UBERON:6005043	HumanCurated
 FBbt:00005054	spiracle	skos:exactMatch	UBERON:6005054	HumanCurated
 FBbt:00005055	digestive system	skos:exactMatch	UBERON:0001007	HumanCurated
 FBbt:00005056	excretory system	skos:exactMatch	UBERON:0001008	HumanCurated
-FBbt:00005057	circulatory system	skos:exactMatch	UBERON:0001009	HumanCurated
+FBbt:00005057	circulatory system	skos:exactMatch	UBERON:0009054	HumanCurated
 FBbt:00005058	pericardial cell	skos:exactMatch	CL:0000474	HumanCurated
 FBbt:00005059	garland cell	skos:exactMatch	CL:0000486	HumanCurated
 FBbt:00005060	hemocoel	skos:exactMatch	UBERON:0002323	HumanCurated
@@ -291,34 +283,31 @@ FBbt:00005063	hemocyte	skos:exactMatch	CL:0000387	HumanCurated
 FBbt:00005066	fat body	skos:exactMatch	UBERON:0003917	HumanCurated
 FBbt:00005068	endocrine system	skos:exactMatch	UBERON:0000949	HumanCurated
 FBbt:00005069	muscle system	skos:exactMatch	UBERON:0000383	HumanCurated
-FBbt:00005073	somatic muscle	skos:exactMatch	UBERON:0005090	HumanCurated
-FBbt:00005073	somatic muscle	skos:exactMatch	UBERON:0014895	HumanCurated
+FBbt:00005070	visceral muscle cell	skos:exactMatch	CL:0008007	HumanCurated
+FBbt:00005073	somatic muscle cell	skos:exactMatch	CL:0008004	HumanCurated
 FBbt:00005074	muscle cell	skos:exactMatch	CL:0000187	HumanCurated
 FBbt:00005083	myoblast	skos:exactMatch	CL:0000056	HumanCurated
 FBbt:00005093	nervous system	skos:exactMatch	UBERON:0001016	HumanCurated
 FBbt:00005094	central nervous system	skos:exactMatch	UBERON:0001017	HumanCurated
 FBbt:00005095	brain	skos:exactMatch	UBERON:0000955	HumanCurated
 FBbt:00005096	stomatogastric nervous system	skos:exactMatch	UBERON:6005096	HumanCurated
+FBbt:00005097	ventral nerve cord	skos:exactMatch	UBERON:0000934	HumanCurated
 FBbt:00005098	peripheral nervous system	skos:exactMatch	UBERON:0000010	HumanCurated
 FBbt:00005099	neuron projection bundle	skos:exactMatch	UBERON:0000122	HumanCurated
 FBbt:00005100	tract	skos:exactMatch	UBERON:0001018	HumanCurated
-FBbt:00005103	symmetrical commissure	skos:exactMatch	UBERON:0001020	HumanCurated
 FBbt:00005105	nerve	skos:exactMatch	UBERON:0001021	HumanCurated
 FBbt:00005106	neuron	skos:exactMatch	CL:0000540	HumanCurated
 FBbt:00005123	motor neuron	skos:exactMatch	CL:0000100	HumanCurated
 FBbt:00005124	sensory neuron	skos:exactMatch	CL:0000101	HumanCurated
 FBbt:00005125	interneuron	skos:exactMatch	CL:0000099	HumanCurated
-FBbt:00005127	amacrine neuron	skos:exactMatch	CL:0000561	HumanCurated
 FBbt:00005128	pioneer neuron	skos:exactMatch	CL:0000116	HumanCurated
 FBbt:00005130	neurosecretory neuron	skos:exactMatch	CL:0000381	HumanCurated
 FBbt:00005133	serotonergic neuron	skos:exactMatch	CL:0000403	HumanCurated
 FBbt:00005136	sensory nerve	skos:exactMatch	UBERON:0001027	HumanCurated
-FBbt:00005137	ganglion	skos:exactMatch	UBERON:0000045	HumanCurated
 FBbt:00005139	neuropil	skos:exactMatch	UBERON:0002606	HumanCurated
-FBbt:00005140	neuromere	skos:exactMatch	UBERON:0004732	HumanCurated
 FBbt:00005144	glial cell	skos:exactMatch	CL:0000125	HumanCurated
 FBbt:00005145	glioblast	skos:exactMatch	CL:0000340	HumanCurated
-FBbt:00005146	neuroblast	skos:exactMatch	CL:0000031	HumanCurated
+FBbt:00005146	neuroblast	skos:exactMatch	CL:0000338	HumanCurated
 FBbt:00005147	neuroglioblast	skos:exactMatch	CL:0000468	HumanCurated
 FBbt:00005148	neuroepidermoblast	skos:exactMatch	CL:0000405	HumanCurated
 FBbt:00005149	ganglion mother cell	skos:exactMatch	CL:0000469	HumanCurated
@@ -333,9 +322,7 @@ FBbt:00005171	tormogen cell	skos:exactMatch	CL:0000372	HumanCurated
 FBbt:00005177	chaeta	skos:exactMatch	UBERON:6005177	HumanCurated
 FBbt:00005215	chordotonal organ	skos:exactMatch	UBERON:0001038	HumanCurated
 FBbt:00005219	scolopale cell	skos:exactMatch	CL:0000382	HumanCurated
-FBbt:00005219	scolopale cell	skos:exactMatch	CL:0000409	HumanCurated
 FBbt:00005221	scolopidial ligament cell	skos:exactMatch	CL:0000407	HumanCurated
-FBbt:00005222	chordotonal neuron	skos:exactMatch	CL:00003828	HumanCurated
 FBbt:00005317	gastrula embryo	skos:exactMatch	UBERON:0004734	HumanCurated
 FBbt:00005333	late embryo	skos:exactMatch	UBERON:0000323	HumanCurated
 FBbt:00005338	second instar larva	skos:exactMatch	UBERON:0018382	HumanCurated
@@ -422,7 +409,7 @@ FBbt:00007240	embryonic/larval sensillum	skos:exactMatch	UBERON:6007240	HumanCur
 FBbt:00007242	embryonic/larval head sensillum	skos:exactMatch	UBERON:6007242	HumanCurated
 FBbt:00007245	cuticular specialization	skos:exactMatch	UBERON:6007245	HumanCurated
 FBbt:00007248	chorionic specialization	skos:exactMatch	UBERON:6007248	HumanCurated
-FBbt:00007276	anatomical group	skos:exactMatch	UBERON:0000480	HumanCurated
+FBbt:00007276	anatomical group	skos:exactMatch	UBERON:0034923	HumanCurated
 FBbt:00007277	anatomical cluster	skos:exactMatch	UBERON:0000477	HumanCurated
 FBbt:00007278	non-connected functional system	skos:exactMatch	UBERON:0015203	HumanCurated
 FBbt:00007280	embryonic/larval head sense organ	skos:exactMatch	UBERON:6007280	HumanCurated
@@ -449,8 +436,10 @@ FBbt:00040003	non-connected developing system	skos:exactMatch	UBERON:6040003	Hum
 FBbt:00040005	synaptic neuropil	skos:exactMatch	UBERON:6040005	HumanCurated
 FBbt:00040007	synaptic neuropil domain	skos:exactMatch	UBERON:6040007	HumanCurated
 FBbt:00041000	synaptic neuropil block	skos:exactMatch	UBERON:6041000	HumanCurated
+FBbt:00047153	anus	skos:exactMatch	UBERON:0001245	HumanCurated
 FBbt:00057001	anterior-posterior subdivision of organism	skos:exactMatch	UBERON:6057001	HumanCurated
 FBbt:00057012	female germline cell	skos:exactMatch	CL:0000025	HumanCurated
+FBbt:00058291	dorsal vessel	skos:exactMatch	UBERON:0015231	HumanCurated
 FBbt:00100152	row	skos:exactMatch	UBERON:0034926	HumanCurated
 FBbt:00100153	sensillum row	skos:exactMatch	UBERON:6100153	HumanCurated
 FBbt:00100313	multicellular structure	skos:exactMatch	UBERON:0010000	HumanCurated


### PR DESCRIPTION
Manual update of the FBbt mappings (this is not automated yet).

This update brings small corrections to the mappings – the kind of corrections that does not require changing the _terms_ that are mapped, on either side; only the mappings themselves are changed.