### PR TITLE
Closes #2230 'glomerular visceral epithelium' should be part of (or merged with) glomerular visceral layer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -174,4 +174,5 @@ src/ontology/basic.json
 src/ontology/basic.obo
 src/ontology/basic.owl
 src/ontology/test_obo_serialiser.sh
+src/ontology/uberon-edit.properties
 src/ontology/.token

--- a/src/ontology/uberon-edit.properties
+++ b/src/ontology/uberon-edit.properties
@@ -1,5 +1,0 @@
-#Fri Feb 04 10:12:43 CET 2022
-jdbc.url=
-jdbc.driver=
-jdbc.user=
-jdbc.password=


### PR DESCRIPTION
Closes #2230 'glomerular visceral epithelium' should be part of (or merged with) glomerular visceral layer.

Outcome: Manually 'merged' UBERON:0005751 ‘visceral layer of glomerular capsule’ with UBERON:0006852 ‘glomerular visceral epithelium’ by updating the label of the former to 'glomerular visceral epithelium’ and obsoleting the latter.

