### PR TITLE
Remove restriction to latin-9 character set.

### DIFF
--- a/src/ontology/uberon.Makefile
+++ b/src/ontology/uberon.Makefile
@@ -669,7 +669,7 @@ $(REPORTDIR)/%.obo-OWL-check: %.obo
 
 # test any file for non UTF-8 characters
 $(REPORTDIR)/%-iconv: %
-	iconv -f UTF-8 -t ISO-8859-15 $< > $@
+	iconv -f UTF-8 -t UTF-8 $< > $@
 
 # run subset of syntax and structure checks used by GO
 # (see .travis.yml for dependencies)


### PR DESCRIPTION
We had a historical restriction that all files in the ontology should only use characters from the Latin-9 character set, even if is encoded in UTF-8. Such a restriction is no longer warranted.

Besides, if the intention behind this restriction was to avoid characters coded on more than 1 byte, then it failed at doing so, as the ontology already contains at least one character outside of the ASCII character set: “ö“ (in the definition of `atlanto-occipital joint`, UBERON:0000220), which is encoded on two bytes in UTF-8 (0xC3 0xB6). The fact that nobody seemingly ever complained about it reinforces the case for dropping the character set restriction.

We keep a check intended to verify that the ontology only contains *valid* UTF-8.

close #2292