### PR TITLE
Do not ping unreviewed draft PRs.

### DIFF
--- a/.github/workflows/stale-issues.yml
+++ b/.github/workflows/stale-issues.yml
@@ -21,3 +21,4 @@ jobs:
           stale-pr-message: 'This PR has not seen any activity in the past month; if nobody comments or reviews it in the next week, the PR editor will be allowed to proceed with merging without explicit approval, should they wish to do so.'
           stale-pr-label: 'unreviewed'
           exempt-pr-labels: 'approval required'
+          exempt-draft-pr: true


### PR DESCRIPTION
Explicitly exclude draft PRs from the automatic ping normally sent on PR that have not seen any activity for one month.