### PR TITLE
bridges: Change relation to life cycle terms to BFO:0000066.

### DIFF
--- a/src/ontology/make-bridge-ontologies-from-xrefs.pl
+++ b/src/ontology/make-bridge-ontologies-from-xrefs.pl
@@ -84,7 +84,7 @@ while (<>) {
                 elsif ($t eq 'gd') {
                     print $fh "intersection_of: $id ! $n\n";
                     if (exists($lsxrefs{$x})) {
-                        $rel = "BFO:0000066";
+                        $rel = "occurs_in";
                     }
                     print $fh "intersection_of: $rel $filler\n";
                 }
@@ -127,6 +127,9 @@ foreach my $s (keys %fhmap) {
     print $fh "[Typedef]\n";
     print $fh "id: develops_from\n";
     print $fh "xref: RO:0002225\n\n";
+    print $fh "[Typedef]\n";
+    print $fh "id: occurs_in\n";
+    print $fh "xref: BFO:0000066\n\n";
 
     open(F,"ftr.obo");
     while(<F>) {

--- a/src/ontology/make-bridge-ontologies-from-xrefs.pl
+++ b/src/ontology/make-bridge-ontologies-from-xrefs.pl
@@ -9,6 +9,7 @@ my $n;
 my $n_xrefs = 0;
 my $stype;
 my %nh = ();
+my %lsxrefs = ();
 
 my @fns = ();
 my $base = 'uberon';
@@ -17,6 +18,14 @@ while ($ARGV[0] =~ /^\-/) {
     my $opt = shift @ARGV;
     if ($opt eq '-b' || $opt eq '--base') {
         $base = shift @ARGV;
+    }
+    elsif ($opt eq '-l' || $opt eq '--life-cycle-xrefs') {
+        open(F, shift @ARGV);
+        while (<F>) {
+            chomp;
+            $lsxrefs{$_} = 1;
+        }
+        close(F);
     }
 }
 
@@ -74,6 +83,9 @@ while (<>) {
                 }
                 elsif ($t eq 'gd') {
                     print $fh "intersection_of: $id ! $n\n";
+                    if (exists($lsxrefs{$x})) {
+                        $rel = "BFO:0000066";
+                    }
                     print $fh "intersection_of: $rel $filler\n";
                 }
                 else {

--- a/src/ontology/uberon.Makefile
+++ b/src/ontology/uberon.Makefile
@@ -23,8 +23,6 @@ BASICRELS = BFO:0000050 RO:0002202 immediate_transformation_of transformation_of
 RELSIM = BFO:0000050 RO:0002202 immediate_transformation_of
 TAXON_GCI_RELS = RO:0002202 RO:0002496 RO:0002497 BFO:0000051
 
-BRIDGE_LSXREFS =
-
 
 all: uberon-qc
 	echo "make $@ succeeded..."

--- a/src/ontology/uberon.Makefile
+++ b/src/ontology/uberon.Makefile
@@ -1229,7 +1229,7 @@ make-bridge-ontologies-from-xrefs.pl:
 	cp $(SCRIPTSDIR)/make-bridge-ontologies-from-xrefs.pl $@
 
 $(BRIDGEDIR)/bridges: $(TMPDIR)/seed.obo $(TMPDIR)/cl-with-xrefs.obo $(TMPDIR)/cl-zfa-xrefs.obo $(BRIDGEDIR)/uberon-bridge-to-nifstd.owl make-bridge-ontologies-from-xrefs.pl $(REPORTDIR)/life-cycle-xrefs.txt
-	if [ $(BRI) = true ]; then cd $(BRIDGEDIR) && perl ../make-bridge-ontologies-from-xrefs.pl -l $(REPORTDIR)/life-cycle-xrefs.txt ../$(TMPDIR)/seed.obo && perl ../make-bridge-ontologies-from-xrefs.pl -l $(REPORTDIR)/life-cycle-xrefs.txt -b cl ../$(TMPDIR)/cl-with-xrefs.obo ../$(TMPDIR)/cl-zfa-xrefs.obo && touch bridges; fi
+	if [ $(BRI) = true ]; then cd $(BRIDGEDIR) && perl ../make-bridge-ontologies-from-xrefs.pl -l ../$(REPORTDIR)/life-cycle-xrefs.txt ../$(TMPDIR)/seed.obo && perl ../make-bridge-ontologies-from-xrefs.pl -l ../$(REPORTDIR)/life-cycle-xrefs.txt -b cl ../$(TMPDIR)/cl-with-xrefs.obo ../$(TMPDIR)/cl-zfa-xrefs.obo && touch bridges; fi
 
 $(TMPDIR)/cl-with-xrefs.obo: $(TMPDIR)/cl-core.obo $(SCRIPTSDIR)/expand-idspaces.pl
 	if [ $(BRI) = true ]; then egrep '^(idspace|treat-)' $(SRC) > $@.tmp && cat $< >> $@.tmp && $(SCRIPTSDIR)/expand-idspaces.pl $@.tmp > $@; fi
@@ -1244,7 +1244,7 @@ $(BRIDGEDIR)/uberon-bridge-to-emap.owl: $(BRIDGEDIR)/uberon-bridge-to-emap.obo
 	$(MAKEOBO)
 
 $(BRIDGEDIR)/uberon-ext-bridge-to-zfa.obo: $(BRIDGEDIR)/ext-xref.obo make-bridge-ontologies-from-xrefs.pl $(REPORTDIR)/life-cycle-xrefs.txt
-	cd bridge && ../make-bridge-ontologies-from-xrefs.pl -l $(REPORTDIR)/life-cycle-xrefs.txt -b uberon-ext ext-xref.obo
+	cd bridge && ../make-bridge-ontologies-from-xrefs.pl -l ../$(REPORTDIR)/life-cycle-xrefs.txt -b uberon-ext ext-xref.obo
 
 # see #157
 # TODO @matentzn dont spend much time but perhaps make ticket

--- a/src/ontology/uberon.Makefile
+++ b/src/ontology/uberon.Makefile
@@ -730,6 +730,9 @@ $(REPORTDIR)/extra-full-bridge-check-caro.txt: | $(CATALOG_DYNAMIC)
 	echo "STRONG WARNING $@ currently set to NOT FAIL because of unsatisfiable classes!"
 	$(OWLTOOLS_CAT_DYNAMIC) --no-debug $^  --merge-support-ontologies $(QELK) --run-reasoner -r elk -u $(ROPTS) > $@ || true
 
+$(REPORTDIR)/life-cycle-xrefs.txt: $(SPARQLDIR)/life-cycle-xrefs.sparql
+	$(ROBOT) reason -i $(SRC) query --use-graphs true --query $< $@.tmp.tsv
+	sed -e '/?xref/d' -e 's/"//g' <$@.tmp.tsv >$@ && rm $@.tmp.tsv
 
 # @Deprecated
 $(REPORTDIR)/core-bridge-check-%.txt: tmp/core.owl $(BRIDGEDIR)/bridges $(TMPDIR)/external-disjoints.owl $(CATALOG_DYNAMIC)
@@ -1225,8 +1228,8 @@ $(BRIDGEDIR)/%.owl: $(BRIDGEDIR)/%.obo
 make-bridge-ontologies-from-xrefs.pl:
 	cp $(SCRIPTSDIR)/make-bridge-ontologies-from-xrefs.pl $@
 
-$(BRIDGEDIR)/bridges: $(TMPDIR)/seed.obo $(TMPDIR)/cl-with-xrefs.obo $(TMPDIR)/cl-zfa-xrefs.obo $(BRIDGEDIR)/uberon-bridge-to-nifstd.owl make-bridge-ontologies-from-xrefs.pl
-	if [ $(BRI) = true ]; then cd $(BRIDGEDIR) && perl ../make-bridge-ontologies-from-xrefs.pl $(BRIDGE_LSXREFS) ../$(TMPDIR)/seed.obo && perl ../make-bridge-ontologies-from-xrefs.pl $(BRIDGE_LSXREFS) -b cl ../$(TMPDIR)/cl-with-xrefs.obo ../$(TMPDIR)/cl-zfa-xrefs.obo && touch bridges; fi
+$(BRIDGEDIR)/bridges: $(TMPDIR)/seed.obo $(TMPDIR)/cl-with-xrefs.obo $(TMPDIR)/cl-zfa-xrefs.obo $(BRIDGEDIR)/uberon-bridge-to-nifstd.owl make-bridge-ontologies-from-xrefs.pl $(REPORTDIR)/life-cycle-xrefs.txt
+	if [ $(BRI) = true ]; then cd $(BRIDGEDIR) && perl ../make-bridge-ontologies-from-xrefs.pl -l $(REPORTDIR)/life-cycle-xrefs.txt ../$(TMPDIR)/seed.obo && perl ../make-bridge-ontologies-from-xrefs.pl -l $(REPORTDIR)/life-cycle-xrefs.txt -b cl ../$(TMPDIR)/cl-with-xrefs.obo ../$(TMPDIR)/cl-zfa-xrefs.obo && touch bridges; fi
 
 $(TMPDIR)/cl-with-xrefs.obo: $(TMPDIR)/cl-core.obo $(SCRIPTSDIR)/expand-idspaces.pl
 	if [ $(BRI) = true ]; then egrep '^(idspace|treat-)' $(SRC) > $@.tmp && cat $< >> $@.tmp && $(SCRIPTSDIR)/expand-idspaces.pl $@.tmp > $@; fi
@@ -1240,8 +1243,8 @@ $(BRIDGEDIR)/uberon-bridge-to-emap.obo: mapping_EMAP_to_EMAPA.txt $(TMPDIR)/upda
 $(BRIDGEDIR)/uberon-bridge-to-emap.owl: $(BRIDGEDIR)/uberon-bridge-to-emap.obo
 	$(MAKEOBO)
 
-$(BRIDGEDIR)/uberon-ext-bridge-to-zfa.obo: $(BRIDGEDIR)/ext-xref.obo make-bridge-ontologies-from-xrefs.pl
-	cd bridge && ../make-bridge-ontologies-from-xrefs.pl $(BRIDGE_LSXREFS) -b uberon-ext ext-xref.obo
+$(BRIDGEDIR)/uberon-ext-bridge-to-zfa.obo: $(BRIDGEDIR)/ext-xref.obo make-bridge-ontologies-from-xrefs.pl $(REPORTDIR)/life-cycle-xrefs.txt
+	cd bridge && ../make-bridge-ontologies-from-xrefs.pl -l $(REPORTDIR)/life-cycle-xrefs.txt -b uberon-ext ext-xref.obo
 
 # see #157
 # TODO @matentzn dont spend much time but perhaps make ticket

--- a/src/ontology/uberon.Makefile
+++ b/src/ontology/uberon.Makefile
@@ -23,6 +23,8 @@ BASICRELS = BFO:0000050 RO:0002202 immediate_transformation_of transformation_of
 RELSIM = BFO:0000050 RO:0002202 immediate_transformation_of
 TAXON_GCI_RELS = RO:0002202 RO:0002496 RO:0002497 BFO:0000051
 
+BRIDGE_LSXREFS =
+
 
 all: uberon-qc
 	echo "make $@ succeeded..."
@@ -1224,7 +1226,7 @@ make-bridge-ontologies-from-xrefs.pl:
 	cp $(SCRIPTSDIR)/make-bridge-ontologies-from-xrefs.pl $@
 
 $(BRIDGEDIR)/bridges: $(TMPDIR)/seed.obo $(TMPDIR)/cl-with-xrefs.obo $(TMPDIR)/cl-zfa-xrefs.obo $(BRIDGEDIR)/uberon-bridge-to-nifstd.owl make-bridge-ontologies-from-xrefs.pl
-	if [ $(BRI) = true ]; then cd $(BRIDGEDIR) && perl ../make-bridge-ontologies-from-xrefs.pl ../$(TMPDIR)/seed.obo && perl ../make-bridge-ontologies-from-xrefs.pl -b cl ../$(TMPDIR)/cl-with-xrefs.obo ../$(TMPDIR)/cl-zfa-xrefs.obo && touch bridges; fi
+	if [ $(BRI) = true ]; then cd $(BRIDGEDIR) && perl ../make-bridge-ontologies-from-xrefs.pl $(BRIDGE_LSXREFS) ../$(TMPDIR)/seed.obo && perl ../make-bridge-ontologies-from-xrefs.pl $(BRIDGE_LSXREFS) -b cl ../$(TMPDIR)/cl-with-xrefs.obo ../$(TMPDIR)/cl-zfa-xrefs.obo && touch bridges; fi
 
 $(TMPDIR)/cl-with-xrefs.obo: $(TMPDIR)/cl-core.obo $(SCRIPTSDIR)/expand-idspaces.pl
 	if [ $(BRI) = true ]; then egrep '^(idspace|treat-)' $(SRC) > $@.tmp && cat $< >> $@.tmp && $(SCRIPTSDIR)/expand-idspaces.pl $@.tmp > $@; fi
@@ -1239,7 +1241,7 @@ $(BRIDGEDIR)/uberon-bridge-to-emap.owl: $(BRIDGEDIR)/uberon-bridge-to-emap.obo
 	$(MAKEOBO)
 
 $(BRIDGEDIR)/uberon-ext-bridge-to-zfa.obo: $(BRIDGEDIR)/ext-xref.obo make-bridge-ontologies-from-xrefs.pl
-	cd bridge && ../make-bridge-ontologies-from-xrefs.pl -b uberon-ext ext-xref.obo
+	cd bridge && ../make-bridge-ontologies-from-xrefs.pl $(BRIDGE_LSXREFS) -b uberon-ext ext-xref.obo
 
 # see #157
 # TODO @matentzn dont spend much time but perhaps make ticket

--- a/src/sparql/life-cycle-xrefs.sparql
+++ b/src/sparql/life-cycle-xrefs.sparql
@@ -1,0 +1,10 @@
+PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+PREFIX UBERON: <http://purl.obolibrary.org/obo/UBERON_>
+PREFIX oboInOwl: <http://www.geneontology.org/formats/oboInOwl#>
+PREFIX life_cycle: <http://purl.obolibrary.org/obo/UBERON_0000104>
+
+SELECT DISTINCT ?xref WHERE {
+  ?sub rdfs:subClassOf* life_cycle: .
+  ?sub oboInOwl:hasDbXref ?xref .
+}


### PR DESCRIPTION
Update the bridge generation scripts so that, in species-specific bridges, terms that are cross-referenced with Uberon’s `life cycle` (UBERON:0000104 or its subclasses) are defined in the generated bridges as equivalent to the Uberon term `occuring in` (BFO:0000066) the specific taxon, rather than the Uberon term `being part of` (BF:0000050) the specific taxon.

This is dependent on having a list of all terms that are cross-referenced to the Uberon's `life cycle` hierarchy. Generating such a list is outside the scope of this patch.

Assuming the list of cross-referenced terms is available in a file named `lsxrefs.txt`, generate the bridges with

```sh
./run.sh make bridge/bridges BRIDGE_LSXREFS='-l ../lsxrefs.txt'
```

Here is an example of the effects of this patch on the `uberon-bridge-to-fbdv.obo` bridge file (FBdv:00000000 being cross-referenced to Uberon’s UBERON:0000104):

```diff
 [Term]
 id: FBdv:00000000 ! 
 property_value: IAO:0000589 "life cycle (FBdv)" xsd:string
 intersection_of: UBERON:0000104 ! life cycle
-intersection_of: part_of NCBITaxon:7227
+intersection_of: BFO:0000066 NCBITaxon:7227
 
 [Term]
 id: FBdv:00007012 ! 
```