### PR TITLE
Auto refresh fbbt mappings

### DIFF
--- a/src/ontology/components/mappings.owl
+++ b/src/ontology/components/mappings.owl
@@ -82,9 +82,6 @@
   <Class rdf:about="http://purl.obolibrary.org/obo/UBERON_0009571">
     <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">FBbt:00000093</oboInOwl:hasDbXref>
   </Class>
-  <Class rdf:about="http://purl.obolibrary.org/obo/UBERON_6000094">
-    <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">FBbt:00000094</oboInOwl:hasDbXref>
-  </Class>
   <Class rdf:about="http://purl.obolibrary.org/obo/UBERON_0010302">
     <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">FBbt:00000095</oboInOwl:hasDbXref>
   </Class>
@@ -123,12 +120,6 @@
   </Class>
   <Class rdf:about="http://purl.obolibrary.org/obo/UBERON_6000130">
     <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">FBbt:00000130</oboInOwl:hasDbXref>
-  </Class>
-  <Class rdf:about="http://purl.obolibrary.org/obo/UBERON_6000131">
-    <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">FBbt:00000131</oboInOwl:hasDbXref>
-  </Class>
-  <Class rdf:about="http://purl.obolibrary.org/obo/UBERON_6000132">
-    <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">FBbt:00000132</oboInOwl:hasDbXref>
   </Class>
   <Class rdf:about="http://purl.obolibrary.org/obo/UBERON_0000927">
     <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">FBbt:00000136</oboInOwl:hasDbXref>
@@ -826,9 +817,6 @@
   <Class rdf:about="http://purl.obolibrary.org/obo/UBERON_6005413">
     <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">FBbt:00005413</oboInOwl:hasDbXref>
   </Class>
-  <Class rdf:about="http://purl.obolibrary.org/obo/UBERON_6005425">
-    <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">FBbt:00005425</oboInOwl:hasDbXref>
-  </Class>
   <Class rdf:about="http://purl.obolibrary.org/obo/UBERON_0007688">
     <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">FBbt:00005426</oboInOwl:hasDbXref>
   </Class>
@@ -867,9 +855,6 @@
   </Class>
   <Class rdf:about="http://purl.obolibrary.org/obo/UBERON_6005538">
     <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">FBbt:00005538</oboInOwl:hasDbXref>
-  </Class>
-  <Class rdf:about="http://purl.obolibrary.org/obo/UBERON_6005541">
-    <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">FBbt:00005541</oboInOwl:hasDbXref>
   </Class>
   <Class rdf:about="http://purl.obolibrary.org/obo/UBERON_6005558">
     <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">FBbt:00005558</oboInOwl:hasDbXref>
@@ -1080,24 +1065,6 @@
   </Class>
   <Class rdf:about="http://purl.obolibrary.org/obo/UBERON_6017021">
     <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">FBbt:00017021</oboInOwl:hasDbXref>
-  </Class>
-  <Class rdf:about="http://purl.obolibrary.org/obo/UBERON_0004121">
-    <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">FBbt:00025990</oboInOwl:hasDbXref>
-  </Class>
-  <Class rdf:about="http://purl.obolibrary.org/obo/UBERON_6025991">
-    <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">FBbt:00025991</oboInOwl:hasDbXref>
-  </Class>
-  <Class rdf:about="http://purl.obolibrary.org/obo/UBERON_6025993">
-    <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">FBbt:00025993</oboInOwl:hasDbXref>
-  </Class>
-  <Class rdf:about="http://purl.obolibrary.org/obo/UBERON_0004120">
-    <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">FBbt:00025998</oboInOwl:hasDbXref>
-  </Class>
-  <Class rdf:about="http://purl.obolibrary.org/obo/UBERON_6026000">
-    <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">FBbt:00026000</oboInOwl:hasDbXref>
-  </Class>
-  <Class rdf:about="http://purl.obolibrary.org/obo/UBERON_6026002">
-    <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">FBbt:00026002</oboInOwl:hasDbXref>
   </Class>
   <Class rdf:about="http://purl.obolibrary.org/obo/UBERON_6040003">
     <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">FBbt:00040003</oboInOwl:hasDbXref>

--- a/src/ontology/mappings/fbbt-mappings.sssom.tsv
+++ b/src/ontology/mappings/fbbt-mappings.sssom.tsv
@@ -32,7 +32,6 @@ FBbt:00000046	dorsal appendage	skos:exactMatch	UBERON:6000046	HumanCurated
 FBbt:00000052	embryo	skos:exactMatch	UBERON:0000922	HumanCurated
 FBbt:00000092	primordial germ cell	skos:exactMatch	CL:0000301	HumanCurated
 FBbt:00000093	ventral midline of embryo	skos:exactMatch	UBERON:0009571	HumanCurated
-FBbt:00000094	clypeo-labral anlage in statu nascendi	skos:exactMatch	UBERON:6000094	HumanCurated
 FBbt:00000095	amnioserosa	skos:exactMatch	UBERON:0010302	HumanCurated
 FBbt:00000096	ventral furrow	skos:exactMatch	UBERON:6000096	HumanCurated
 FBbt:00000097	cephalic furrow	skos:exactMatch	UBERON:6000097	HumanCurated
@@ -47,8 +46,6 @@ FBbt:00000125	endoderm	skos:exactMatch	UBERON:0000925	HumanCurated
 FBbt:00000126	mesoderm	skos:exactMatch	UBERON:0000926	HumanCurated
 FBbt:00000128	trunk mesoderm	skos:exactMatch	UBERON:6000128	HumanCurated
 FBbt:00000130	visceral mesoderm	skos:exactMatch	UBERON:6000130	HumanCurated
-FBbt:00000131	mesodermal crest	skos:exactMatch	UBERON:6000131	HumanCurated
-FBbt:00000132	mesodermal crest of segment T3	skos:exactMatch	UBERON:6000132	HumanCurated
 FBbt:00000136	mesectoderm	skos:exactMatch	UBERON:0000927	HumanCurated
 FBbt:00000137	embryonic tagma	skos:exactMatch	UBERON:6000137	HumanCurated
 FBbt:00000154	embryonic segment	skos:exactMatch	UBERON:6000154	HumanCurated
@@ -337,7 +334,6 @@ FBbt:00005393	embryonic/larval integumentary system	skos:exactMatch	UBERON:60053
 FBbt:00005396	adult integumentary system	skos:exactMatch	UBERON:6005396	HumanCurated
 FBbt:00005412	gamete	skos:exactMatch	CL:0000300	HumanCurated
 FBbt:00005413	anlage in statu nascendi	skos:exactMatch	UBERON:6005413	HumanCurated
-FBbt:00005425	visual anlage in statu nascendi	skos:exactMatch	UBERON:6005425	HumanCurated
 FBbt:00005426	anlage	skos:exactMatch	UBERON:0007688	HumanCurated
 FBbt:00005427	ectoderm anlage	skos:exactMatch	UBERON:6005427	HumanCurated
 FBbt:00005428	dorsal ectoderm anlage	skos:exactMatch	UBERON:6005428	HumanCurated
@@ -351,7 +347,6 @@ FBbt:00005514	clypeo-labral disc primordium	skos:exactMatch	UBERON:6005514	Human
 FBbt:00005526	dorsal epidermis primordium	skos:exactMatch	UBERON:6005526	HumanCurated
 FBbt:00005533	ventral epidermis primordium	skos:exactMatch	UBERON:6005533	HumanCurated
 FBbt:00005538	clypeo-labral primordium	skos:exactMatch	UBERON:6005538	HumanCurated
-FBbt:00005541	cardiogenic mesoderm	skos:exactMatch	UBERON:6005541	HumanCurated
 FBbt:00005558	ventral ectoderm	skos:exactMatch	UBERON:6005558	HumanCurated
 FBbt:00005569	presumptive embryonic/larval tracheal system	skos:exactMatch	UBERON:6005569	HumanCurated
 FBbt:00005756	rectum	skos:exactMatch	UBERON:0006866	HumanCurated
@@ -426,12 +421,6 @@ FBbt:00007474	epithelial tube	skos:exactMatch	UBERON:0003914	HumanCurated
 FBbt:00007692	sensory system	skos:exactMatch	UBERON:0001032	HumanCurated
 FBbt:00016022	abdominal histoblast primordium	skos:exactMatch	UBERON:6016022	HumanCurated
 FBbt:00017021	abdominal histoblast anlage	skos:exactMatch	UBERON:6017021	HumanCurated
-FBbt:00025990	ectodermal derivative	skos:exactMatch	UBERON:0004121	HumanCurated
-FBbt:00025991	anterior ectoderm derivative	skos:exactMatch	UBERON:6025991	HumanCurated
-FBbt:00025993	ventral ectoderm derivative	skos:exactMatch	UBERON:6025993	HumanCurated
-FBbt:00025998	mesodermal derivative	skos:exactMatch	UBERON:0004120	HumanCurated
-FBbt:00026000	trunk mesoderm derivative	skos:exactMatch	UBERON:6026000	HumanCurated
-FBbt:00026002	visceral mesoderm derivative	skos:exactMatch	UBERON:6026002	HumanCurated
 FBbt:00040003	non-connected developing system	skos:exactMatch	UBERON:6040003	HumanCurated
 FBbt:00040005	synaptic neuropil	skos:exactMatch	UBERON:6040005	HumanCurated
 FBbt:00040007	synaptic neuropil domain	skos:exactMatch	UBERON:6040007	HumanCurated

--- a/src/ontology/uberon.Makefile
+++ b/src/ontology/uberon.Makefile
@@ -1196,6 +1196,16 @@ $(TMPDIR)/uberon-taxmod-%.owl: ext.owl
 # BRIDGES
 # ----------------------------------------
 
+# Download the FBbt mapping file
+.PHONY: $(TMPDIR)/fbbt-mappings.sssom.tsv
+$(TMPDIR)/fbbt-mappings.sssom.tsv:
+	if [ $(IMP) = true ]; then wget -O $@ http://purl.obolibrary.org/obo/fbbt/fbbt-mappings.sssom.tsv ; fi
+
+# Attempt to update the canonical FBbt mapping file from a freshly downloaded one
+# (no update if the downloaded file is absent or identical to the one we already have)
+mappings/fbbt-mappings.sssom.tsv: $(TMPDIR)/fbbt-mappings.sssom.tsv
+	if [ -f $< ]; then if ! cmp $< $@ ; then cat $< > $@ ; fi ; fi
+
 # Generate cross-references from the FBbt mapping file
 $(COMPONENTSDIR)/mappings.owl: mappings/fbbt-mappings.sssom.tsv ../scripts/sssom2xrefs.awk
 	awk -f ../scripts/sssom2xrefs.awk $< > $@


### PR DESCRIPTION
Update the custom Makefile to automatically download the FBbt SSSOM file from the FBbt repository, and therefore automatically update the FBbt mappings.

Downloading the SSSOM file is made conditional on the `IMP` variable, so that the file is only refreshed when running with `IMP=true`. Updating the mappings is thus considered similar to refreshing the imports, which I believe is sensible.