### PR TITLE
Reformat the ID ranges file to proper Manchester syntax.

### DIFF
--- a/src/ontology/uberon-idranges.owl
+++ b/src/ontology/uberon-idranges.owl
@@ -1,141 +1,209 @@
-Prefix: idrange:=<http://purl.obolibrary.org/obo/uberon/idrange/>
-Prefix: allocatedto:=<http://purl.obolibrary.org/obo/IAO_0000597>
-Prefix: iddigits:=<http://purl.obolibrary.org/obo/IAO_0000596>
-Prefix: idprefix:=<http://purl.obolibrary.org/obo/IAO_0000599>
-Prefix: idsfor:=<http://purl.obolibrary.org/obo/IAO_0000598>
-Prefix: comment:=<http://www.w3.org/2000/01/rdf-schema#comment>
+## ID Ranges File
+Prefix: idrange: <http://purl.obolibrary.org/obo/uberon/idrange/>
+Prefix: allocatedto: <http://purl.obolibrary.org/obo/IAO_0000597>
+Prefix: iddigits: <http://purl.obolibrary.org/obo/IAO_0000596>
+Prefix: idprefix: <http://purl.obolibrary.org/obo/IAO_0000599>
+Prefix: idsfor: <http://purl.obolibrary.org/obo/IAO_0000598>
+Prefix: comment: <http://www.w3.org/2000/01/rdf-schema#comment>
 
-Ontology: <http://purl.obolibrary.org/obo/uberon/phenoscape-idranges.owl>
-  Annotations: idprefix: "http://purl.obolibrary.org/obo/UBERON_", iddigits: 7, idsfor: "UBERON"
+Ontology: <http://purl.obolibrary.org/obo/uberon/uberon-idranges.owl>
 
-annotationproperty: allocatedto:
+Annotations:
+    idprefix: "http://purl.obolibrary.org/obo/UBERON_",
+    iddigits: 7,
+    idsfor: "UBERON"
+
+AnnotationProperty: allocatedto:
+
 AnnotationProperty: idprefix:
+
 AnnotationProperty: iddigits: 
+
 AnnotationProperty: idsfor: 
+
 AnnotationProperty: comment: 
 
 Datatype: idrange:1
-Annotations: allocatedto: "Chris Mungall"
-EquivalentTo: xsd:integer[> 1 , <= 499999]
+    Annotations:
+        allocatedto: "Chris Mungall"
+    EquivalentTo:
+        xsd:integer[> 1 , <= 499999]
 
 Datatype: idrange:2
-Annotations: allocatedto: "TBD"
-EquivalentTo: xsd:integer[> 500000 , <= 999999]
+    Annotations:
+        allocatedto: "TBD"
+    EquivalentTo:
+        xsd:integer[> 500000 , <= 999999]
 
 Datatype: idrange:3
-Annotations: allocatedto: "Erik Segerdell"
-EquivalentTo: xsd:integer[> 1000000 , <= 1099999]
+    Annotations:
+        allocatedto: "Erik Segerdell"
+    EquivalentTo:
+        xsd:integer[> 1000000 , <= 1099999]
 
 Datatype: idrange:12
-Annotations: allocatedto: "David Osumi-Sutherland"
-EquivalentTo: xsd:integer[> 1100000 , <= 1199999]
+    Annotations:
+        allocatedto: "David Osumi-Sutherland"
+    EquivalentTo:
+        xsd:integer[> 1100000 , <= 1199999]
 
 Datatype: idrange:4
-Annotations: allocatedto: "Melissa Haendel"
-EquivalentTo: xsd:integer[> 1500000 , <= 1999999]
+    Annotations:
+        allocatedto: "Melissa Haendel"
+    EquivalentTo:
+        xsd:integer[> 1500000 , <= 1999999]
 
 Datatype: idrange:5
-Annotations: allocatedto: "Terms uplifted from TAO",
- comment: "Classes unique to TAO were migrated to this block, but
-           there is no implicit taxonomic constraint here"
-EquivalentTo: xsd:integer[> 2000000 , <= 2999999]
+    Annotations:
+        allocatedto: "Terms uplifted from TAO",
+        comment: "Classes unique to TAO were migrated to this block, but there is no implicit taxonomic constraint here"
+    EquivalentTo:
+        xsd:integer[> 2000000 , <= 2999999]
 
 Datatype: idrange:6
-Annotations: allocatedto: "Terms uplifted from AAO",
- comment: "Classes unique to AAO were migrated to this block, but
-           there is no implicit taxonomic constraint here"
-EquivalentTo: xsd:integer[> 3000000 , <= 3999999]
+    Annotations:
+        allocatedto: "Terms uplifted from AAO",
+        comment: "Classes unique to AAO were migrated to this block, but there is no implicit taxonomic constraint here"
+    EquivalentTo:
+        xsd:integer[> 3000000 , <= 3999999]
 
 Datatype: idrange:7
-Annotations: allocatedto: "Terms uplifted from VSAO",
- comment: "Classes unique to VSAO were migrated to this block, but
-           there is no implicit taxonomic constraint here"
-EquivalentTo: xsd:integer[> 4000000 , <= 4000182]
+    Annotations:
+        allocatedto: "Terms uplifted from VSAO",
+        comment: "Classes unique to VSAO were migrated to this block, but there is no implicit taxonomic constraint here"
+    EquivalentTo:
+        xsd:integer[> 4000000 , <= 4000182]
 
 Datatype: idrange:8
-Annotations: allocatedto: "Nizar Ibrahim",
-EquivalentTo: xsd:integer[> 4100000 , <= 4199999]
+    Annotations:
+        allocatedto: "Nizar Ibrahim"
+    EquivalentTo:
+        xsd:integer[> 4100000 , <= 4199999]
 
 Datatype: idrange:9
-Annotations: allocatedto: "Alex Dececchi",
-EquivalentTo: xsd:integer[> 4200000 , <= 4299999]
+    Annotations:
+        allocatedto: "Alex Dececchi"
+    EquivalentTo:
+        xsd:integer[> 4200000 , <= 4299999]
 
 Datatype: idrange:10
-Annotations: allocatedto: "Wasila Dahdul",
-EquivalentTo: xsd:integer[> 4300000 , <= 4399999]
+    Annotations:
+        allocatedto: "Wasila Dahdul"
+    EquivalentTo:
+        xsd:integer[> 4300000 , <= 4399999]
 
 Datatype: idrange:11
-Annotations: allocatedto: "Chris Mungall (ext editing)",
-EquivalentTo: xsd:integer[> 4400000 , <= 4499999]
+    Annotations:
+        allocatedto: "Chris Mungall (ext editing)"
+    EquivalentTo:
+        xsd:integer[> 4400000 , <= 4499999]
 
 Datatype: idrange:13
-Annotations: allocatedto: "Robert Druzinsky",
-EquivalentTo: xsd:integer[> 5000000 , <= 5499999]
+    Annotations:
+        allocatedto: "Robert Druzinsky"
+    EquivalentTo:
+        xsd:integer[> 5000000 , <= 5499999]
 
 Datatype: idrange:14
-Annotations: allocatedto: "Trish Whetzel",
-EquivalentTo: xsd:integer[> 5500000 , <= 5599999]
+    Annotations:
+        allocatedto: "Trish Whetzel"
+    EquivalentTo:
+        xsd:integer[> 5500000 , <= 5599999]
 
 Datatype: idrange:15
-Annotations: allocatedto: "Insect Anatomy",
-EquivalentTo: xsd:integer[> 6000000 , <= 6099999]
+    Annotations:
+        allocatedto: "Insect Anatomy"
+    EquivalentTo:
+        xsd:integer[> 6000000 , <= 6099999]
 
 Datatype: idrange:16
-Annotations: allocatedto: "Nico Matentzoglu",
-EquivalentTo: xsd:integer[> 7000000 , <= 7499999]
+    Annotations:
+        allocatedto: "Nico Matentzoglu"
+    EquivalentTo:
+        xsd:integer[> 7000000 , <= 7499999]
 
 Datatype: idrange:17
-Annotations: allocatedto: "Ramona Walls",
-EquivalentTo: xsd:integer[> 7500000 , <= 7999999]
+    Annotations:
+        allocatedto: "Ramona Walls"
+    EquivalentTo:
+        xsd:integer[> 7500000 , <= 7999999]
 
 Datatype: idrange:18
-Annotations: allocatedto: "Nicole Vasilevsky",
-EquivalentTo: xsd:integer[> 8000000 , <= 8199999]
+    Annotations:
+        allocatedto: "Nicole Vasilevsky"
+    EquivalentTo:
+        xsd:integer[> 8000000 , <= 8199999]
 
 Datatype: idrange:19
-Annotations: allocatedto: "Anne Thessen",
-EquivalentTo: xsd:integer[> 8200000 , <= 8299999]
+    Annotations:
+        allocatedto: "Anne Thessen"
+    EquivalentTo:
+        xsd:integer[> 8200000 , <= 8299999]
 
 Datatype: idrange:20
-Annotations: allocatedto: "Bonita Lam",
-EquivalentTo: xsd:integer[> 8300000, <= 8305000]
+    Annotations:
+        allocatedto: "Bonita Lam"
+    EquivalentTo:
+        xsd:integer[> 8300000, <= 8305000]
 
 Datatype: idrange:21
-Annotations: allocatedto: "Sebastian Koehler",
-EquivalentTo: xsd:integer[> 8305001, <= 8309999]
+    Annotations:
+        allocatedto: "Sebastian Koehler"
+    EquivalentTo:
+        xsd:integer[> 8305001, <= 8309999]
 
 Datatype: idrange:22
-Annotations: allocatedto: "InterLex",
-EquivalentTo: xsd:integer[> 8310000, <= 8399999]
+    Annotations:
+        allocatedto: "InterLex"
+    EquivalentTo:
+        xsd:integer[> 8310000, <= 8399999]
 
 Datatype: idrange:23
-Annotations: allocatedto: "Maria Keays",
-EquivalentTo: xsd:integer[> 8400000, <= 8409999]
+    Annotations:
+        allocatedto: "Maria Keays"
+    EquivalentTo:
+        xsd:integer[> 8400000, <= 8409999]
 
 Datatype: idrange:24
-Annotations: allocatedto: "Paola Roncaglia",
-EquivalentTo: xsd:integer[> 8410000, <= 8419999]
+    Annotations:
+        allocatedto: "Paola Roncaglia"
+    EquivalentTo:
+        xsd:integer[> 8410000, <= 8419999]
 
 Datatype: idrange:25
-Annotations: allocatedto: "Ray Stefancsik",
-EquivalentTo: xsd:integer[> 8420000, <= 8429999]
+    Annotations:
+        allocatedto: "Ray Stefancsik"
+    EquivalentTo:
+        xsd:integer[> 8420000, <= 8429999]
 
 Datatype: idrange:26
-Annotations: allocatedto: "Joshua Fortriede",
-EquivalentTo: xsd:integer[> 8430000, <= 8439999]
+    Annotations:
+        allocatedto: "Joshua Fortriede"
+    EquivalentTo:
+        xsd:integer[> 8430000, <= 8439999]
 
 Datatype: idrange:27
-Annotations: allocatedto: "Shawn Tan",
-EquivalentTo: xsd:integer[> 8440000, <= 8449999]
+    Annotations:
+        allocatedto: "Shawn Tan"
+    EquivalentTo:
+        xsd:integer[> 8440000, <= 8449999]
 
 Datatype: idrange:28
-Annotations: allocatedto: "Damien Goutte-Gattat",
-EquivalentTo: xsd:integer[> 8450000, <= 8459999]
+    Annotations:
+        allocatedto: "Damien Goutte-Gattat"
+    EquivalentTo:
+        xsd:integer[> 8450000, <= 8459999]
 
 Datatype: idrange:29
-Annotations: allocatedto: "Ellen Quardokus",
-EquivalentTo: xsd:integer[> 8460000, <= 8469999]
+    Annotations:
+        allocatedto: "Ellen Quardokus"
+    EquivalentTo:
+        xsd:integer[> 8460000, <= 8469999]
 
 Datatype: idrange:30
-Annotations: allocatedto: "Bradley Varner",
-EquivalentTo: xsd:integer[> 8470000, <= 8479999]
+    Annotations:
+        allocatedto: "Bradley Varner"
+    EquivalentTo:
+        xsd:integer[> 8470000, <= 8479999]
+
+


### PR DESCRIPTION
The `uberon-idranges.owl` file was incorrectly formatted, preventing its use by Protégé. Reformat it so that ID range policies can be automatically applied when the next version of Protégé will be available.

No changes to the actual content of the file.