### PR TITLE
Add draft configuration from mapping sets and bridges.

### DIFF
--- a/src/ontology/uberon-odk.yaml
+++ b/src/ontology/uberon-odk.yaml
@@ -127,7 +127,7 @@ bridges:
       from_sssom: fbbt-mappings.sssom.tsv
     - filename: uberon-to-wbbt-bridge.owl
       from_sssom: wbbt-mappings.sssom.tsv
-    - filename: uberon-to-mba-mappings.owl
+    - filename: uberon-to-mba-bridge.owl
     - filename: uberon-to-zfa-bridge.owl
       from_xref: ZFA
     - filename: uberon-to-zfs-bridge.owl

--- a/src/ontology/uberon-odk.yaml
+++ b/src/ontology/uberon-odk.yaml
@@ -113,3 +113,22 @@ components:
     - filename: in-subset.owl
     - filename: hra_subset.owl
     - filename: vasculature_class.owl
+mappings:
+  products:
+    - filename: fbbt-mappings.sssom.tsv
+      mirror_from: http://purl.obolibrary.org/obo/fbbt/fbbt-mappings.sssom.tsv
+      release: false
+    - filename: wbbt-mappings.sssom.tsv
+    - filename: legacy-mappings.sssom.tsv
+      type: xref-generated
+bridges:
+  products:
+    - filename: uberon-to-fbbt-bridge.owl
+      from_sssom: fbbt-mappings.sssom.tsv
+    - filename: uberon-to-wbbt-bridge.owl
+      from_sssom: wbbt-mappings.sssom.tsv
+    - filename: uberon-to-mba-mappings.owl
+    - filename: uberon-to-zfa-bridge.owl
+      from_xref: ZFA
+    - filename: uberon-to-zfs-bridge.owl
+      from_xref: ZFS


### PR DESCRIPTION
/!\ PR for testing purposes, do not merge /!\

This PR updates the ODK configuration file to what it could look like when support for managing mapping sets and bridge files is built in the ODK (INCATools/ontology-development-kit#626).

It defines three mapping sets:

* `fbbt-mappings.sssom.tsv`, to be fetched from the FBbt ontology;
* `wbbt-mappings.sssom.tsv`, which in this example is assumed to be locally maintained within Uberon by Uberon editors (no such mapping set currently exists, this is for the sake of the example);
* `legacy-mappings.sssom.tsv`, which is to be generated from the existing xrefs in uberon-edit.owl;

and 5 example bridges:

* `uberon-to-fbbt-bridge.owl`, to be generated from the FBbt mapping set;
* `uberon-to-wbbt-bridge.owl`, likewise from the WBbt mapping set;
* `uberon-to-mba-bridge.owl`, to be generated by a custom rule;
* `uberon-to-zfa-bridge.owl`, to be generated from the `ZFA:` xrefs;
* `uberon-to-zfs-bridge.owl`, to be generated from the `ZFS:` xrefs.

(In real conditions _all_ cross-species bridges would be listed here.)

@matentzn For you to play with. :)