### PR TITLE
fix typo Ubeorn

### DIFF
--- a/mkdocs.yaml
+++ b/mkdocs.yaml
@@ -32,13 +32,13 @@ nav:
           - Managing the documentation: odk-workflows/ManageDocumentation.md
           - Continuous Integration: odk-workflows/ContinuousIntegration.md
           - Your ODK Repository Overview: odk-workflows/RepositoryFileStructure.md
-  - Ubeorn Internal Docs: 
+  - Uberon Internal Docs: 
       - Uberon Release: uberon-release.md
-  - Reference:
+  - References:
       - Wiki: https://github.com/obophenotype/uberon/wiki
       - Uberon Manual: https://github.com/obophenotype/uberon/wiki/Manual
       - User Documentation: https://github.com/obophenotype/uberon/wiki/Manual#user-docs
-      - Editors documentation: https://github.com/obophenotype/uberon/wiki/Manual#editor-docs
+      - Editors Documentation: https://github.com/obophenotype/uberon/wiki/Manual#editor-docs
       - Design Patterns: https://github.com/obophenotype/uberon/wiki/Manual#design-patterns
       - Anatomical Structures: https://github.com/obophenotype/uberon/wiki/Manual#anatomical-structures
       - Uberon Build Pipeline: uberon_build_pipeline.md


### PR DESCRIPTION
also capitalized Editors Documentation to match Title Case of other references (even though my preference would be to make them all Sentence case)