### PR TITLE
Check for both Label and Synonym polysemy across Terms

### DIFF
--- a/src/ontology/Makefile
+++ b/src/ontology/Makefile
@@ -39,7 +39,7 @@ REPORT_FAIL_ON =            ERROR
 REPORT_LABEL =              
 REPORT_PROFILE_OPTS =       --profile $(ROBOT_PROFILE)
 OBO_FORMAT_OPTIONS =        
-SPARQL_VALIDATION_CHECKS =  equivalent-classes owldef-self-reference illegal-annotation-property taxon-range orcid-contributor obsolete-replaced_by xrefs-mesh-pattern 
+SPARQL_VALIDATION_CHECKS =  equivalent-classes owldef-self-reference illegal-annotation-property taxon-range orcid-contributor obsolete-replaced_by xrefs-mesh-pattern label-synonym-polysemy 
 SPARQL_EXPORTS =            basic-report 
 ODK_VERSION_MAKEFILE =      v1.3.1
 

--- a/src/ontology/uberon-odk.yaml
+++ b/src/ontology/uberon-odk.yaml
@@ -104,6 +104,7 @@ robot_report:
     - orcid-contributor
     - obsolete-replaced_by
     - xrefs-mesh-pattern
+    - label-synonym-polysemy
   custom_sparql_exports:
     - basic-report
 owltools_memory: '20G'

--- a/src/sparql/label-synonym-polysemy-violation.sparql
+++ b/src/sparql/label-synonym-polysemy-violation.sparql
@@ -17,7 +17,7 @@ SELECT ?entity ?property ?value WHERE {
       }
       ?entity ?property ?name .
       OPTIONAL {
-      ?abbr a owl:Axiom;
+        ?abbr a owl:Axiom;
               owl:annotatedSource ?entity;
               owl:annotatedProperty oboInOwl:hasExactSynonym;
               owl:annotatedTarget ?name;
@@ -28,9 +28,9 @@ SELECT ?entity ?property ?value WHERE {
       FILTER (!isBlank(?entity) && !BOUND(?abbr))
       FILTER NOT EXISTS { ?entity owl:deprecated true }
     } GROUP BY ?iname HAVING (?cnt > 1)
-  } .
-  ?entity ?property ?value
+  }
+  ?entity ?property ?value .
   FILTER (!isBlank(?entity))
   FILTER NOT EXISTS { ?entity owl:deprecated true }
   FILTER (UCASE(?value) = ?iname)
-} ORDER BY ?iname ?entity
+} ORDER BY ?entity

--- a/src/sparql/label-synonym-polysemy-violation.sparql
+++ b/src/sparql/label-synonym-polysemy-violation.sparql
@@ -1,0 +1,36 @@
+PREFIX obo: <http://purl.obolibrary.org/obo/>
+PREFIX oboInOwl: <http://www.geneontology.org/formats/oboInOwl#>
+PREFIX owl: <http://www.w3.org/2002/07/owl#>
+PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+
+SELECT ?entity ?property ?value WHERE {
+  VALUES ?property {
+    obo:IAO_0000118
+    oboInOwl:hasExactSynonym
+    rdfs:label
+  }
+  { SELECT DISTINCT ?iname (COUNT(DISTINCT ?entity) AS ?cnt) WHERE {
+      VALUES ?property {
+        obo:IAO_0000118
+        oboInOwl:hasExactSynonym
+        rdfs:label
+      }
+      ?entity ?property ?name .
+      OPTIONAL {
+      ?abbr a owl:Axiom;
+              owl:annotatedSource ?entity;
+              owl:annotatedProperty oboInOwl:hasExactSynonym;
+              owl:annotatedTarget ?name;
+              oboInOwl:hasSynonymType <http://purl.obolibrary.org/obo/uberon/core#ABBREVIATION>.
+      }
+
+      BIND(UCASE((?name)) AS ?iname)
+      FILTER (!isBlank(?entity) && !BOUND(?abbr))
+      FILTER NOT EXISTS { ?entity owl:deprecated true }
+    } GROUP BY ?iname HAVING (?cnt > 1)
+  } .
+  ?entity ?property ?value
+  FILTER (!isBlank(?entity))
+  FILTER NOT EXISTS { ?entity owl:deprecated true }
+  FILTER (UCASE(?value) = ?iname)
+} ORDER BY ?iname ?entity


### PR DESCRIPTION
Check for both Label and Synonym polysemy across Terms

This PR started as #2640 but then I tried to outsmart github and I managed to close it.

This PR detects synonym-synonym and label-synonym across different Terms (UBERON Ids).
Another implementation (but with the same logic and functionality) of this check was
used to detect and fix (merged) the followings issues:

* https://github.com/obophenotype/uberon/pull/2465
* https://github.com/obophenotype/uberon/pull/2470
* https://github.com/obophenotype/uberon/pull/2506

The backstory is in https://github.com/obophenotype/uberon/issues/2424

The existing check
https://robot.obolibrary.org/report_queries/duplicate_exact_synonym detects
only synonym-synonym violations. It was reported in
https://github.com/ontodev/robot/issues/607 but closed at the time.

The existing check
https://robot.obolibrary.org/report_queries/duplicate_label_synonym
detects all label-synonym duplication both in the same Term and across
different terms. The duplicity in the same term is a warning but the
duplicity across different terms should be an error.

In this PR the test is case insensitive because downstream applications
have a strong possibility to be case insensitive in order to maximize
coverage.

Finally I have added an exemption for ABBREVIATION per @shawntanzk suggestion for
cases like #2643, #2641.

The errors should look like this. Note that for the example below a fix is already
merged and thus it is not a problem anymore.

entity,property,value
http://purl.obolibrary.org/obo/UBERON_0002633,http://www.geneontology.org/formats/oboInOwl#hasExactSynonym,nV
http://purl.obolibrary.org/obo/UBERON_2005093,http://www.geneontology.org/formats/oboInOwl#hasExactSynonym,NV

Thanks @matentzn and @anitacaron for the guidance and the hand-holding.
