### PR TITLE
Fix classification for disconnected entities

### DIFF
--- a/src/ontology/bridge/uberon-bridge-to-mba.obo
+++ b/src/ontology/bridge/uberon-bridge-to-mba.obo
@@ -967,14 +967,17 @@ property_value: IAO:0000589 "efferent cochleovestibular bundle" xsd:string
 property_value: status "Verified" xsd:string {source="https://ror.org/03cpe7c52"}
 
 [Term]
-id: MBA:1079
-intersection_of: UBERON:0002985
+id: MBA:1078
 intersection_of: UBERON:8440077
 intersection_of: BFO:0000050 NCBITaxon:10090
-intersection_of: BFO:0000050 NCBITaxon:10090
-property_value: IAO:0000589 "medial geniculate complex, ventral part" xsd:string
 property_value: IAO:0000589 "rhinal incisure" xsd:string
 property_value: status "Curated" xsd:string {source="https://orcid.org/0000-0001-7258-9596"}
+
+[Term]
+id: MBA:1079
+intersection_of: UBERON:0002985
+intersection_of: BFO:0000050 NCBITaxon:10090
+property_value: IAO:0000589 "medial geniculate complex, ventral part" xsd:string
 property_value: status "Verified" xsd:string {source="https://ror.org/03cpe7c52"}
 
 [Term]
@@ -5826,6 +5829,13 @@ relationship: BFO:0000050 NCBITaxon:10090
 relationship: BFO:0000050 UBERON:0001393
 property_value: IAO:0000589 "posterior auditory area, layer 4" xsd:string
 property_value: status "Verified" xsd:string {source="https://ror.org/03cpe7c52"}
+
+[Term]
+id: MBA:76
+intersection_of: UBERON:8440074
+intersection_of: BFO:0000050 NCBITaxon:10090
+property_value: IAO:0000589 "interstitial nucleus of the vestibular nerve" xsd:string
+property_value: status "Curated" xsd:string {source="https://orcid.org/0000-0001-7258-9596"}
 
 [Term]
 id: MBA:763

--- a/src/ontology/bridge/uberon-bridge-to-mba.owl
+++ b/src/ontology/bridge/uberon-bridge-to-mba.owl
@@ -4268,6 +4268,32 @@
     
 
 
+    <!-- http://purl.obolibrary.org/obo/MBA_1078 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/MBA_1078">
+        <owl:equivalentClass>
+            <owl:Class>
+                <owl:intersectionOf rdf:parseType="Collection">
+                    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_8440077"/>
+                    <owl:Restriction>
+                        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/BFO_0000050"/>
+                        <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_10090"/>
+                    </owl:Restriction>
+                </owl:intersectionOf>
+            </owl:Class>
+        </owl:equivalentClass>
+        <obo:IAO_0000589 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">rhinal incisure</obo:IAO_0000589>
+        <oboInOwl:status rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Curated</oboInOwl:status>
+    </owl:Class>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/MBA_1078"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#status"/>
+        <owl:annotatedTarget rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Curated</owl:annotatedTarget>
+        <oboInOwl:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">https://orcid.org/0000-0001-7258-9596</oboInOwl:source>
+    </owl:Axiom>
+    
+
+
     <!-- http://purl.obolibrary.org/obo/MBA_1079 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MBA_1079">
@@ -4282,28 +4308,9 @@
                 </owl:intersectionOf>
             </owl:Class>
         </owl:equivalentClass>
-        <owl:equivalentClass>
-            <owl:Class>
-                <owl:intersectionOf rdf:parseType="Collection">
-                    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_8440077"/>
-                    <owl:Restriction>
-                        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/BFO_0000050"/>
-                        <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_10090"/>
-                    </owl:Restriction>
-                </owl:intersectionOf>
-            </owl:Class>
-        </owl:equivalentClass>
         <obo:IAO_0000589 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">medial geniculate complex, ventral part</obo:IAO_0000589>
-        <obo:IAO_0000589 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">rhinal incisure</obo:IAO_0000589>
-        <oboInOwl:status rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Curated</oboInOwl:status>
         <oboInOwl:status rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Verified</oboInOwl:status>
     </owl:Class>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/MBA_1079"/>
-        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#status"/>
-        <owl:annotatedTarget rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Curated</owl:annotatedTarget>
-        <oboInOwl:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">https://orcid.org/0000-0001-7258-9596</oboInOwl:source>
-    </owl:Axiom>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/MBA_1079"/>
         <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#status"/>
@@ -23493,6 +23500,32 @@
     
 
 
+    <!-- http://purl.obolibrary.org/obo/MBA_76 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/MBA_76">
+        <owl:equivalentClass>
+            <owl:Class>
+                <owl:intersectionOf rdf:parseType="Collection">
+                    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_8440074"/>
+                    <owl:Restriction>
+                        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/BFO_0000050"/>
+                        <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_10090"/>
+                    </owl:Restriction>
+                </owl:intersectionOf>
+            </owl:Class>
+        </owl:equivalentClass>
+        <obo:IAO_0000589 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">interstitial nucleus of the vestibular nerve</obo:IAO_0000589>
+        <oboInOwl:status rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Curated</oboInOwl:status>
+    </owl:Class>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/MBA_76"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#status"/>
+        <owl:annotatedTarget rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Curated</owl:annotatedTarget>
+        <oboInOwl:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">https://orcid.org/0000-0001-7258-9596</oboInOwl:source>
+    </owl:Axiom>
+    
+
+
     <!-- http://purl.obolibrary.org/obo/MBA_763 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/MBA_763">
@@ -33095,6 +33128,12 @@
     <!-- http://purl.obolibrary.org/obo/UBERON_8440073 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/UBERON_8440073"/>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/UBERON_8440074 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/UBERON_8440074"/>
     
 
 


### PR DESCRIPTION
This PR re-classifies several terms to fix inconsistencies regarding the “connectedness” of anatomical entities.

We distinguish between anatomical entities that are made of parts that are all connected (`anatomical structure`) and entities that are made of parts that are not all connected (`disconnected anatomical group`). But we do not enforce the distinction, and as a result we have terms referring to disconnected entities that are classified as (connected) `anatomical structure`.

This cause massive satisfiability problems when merging Uberon and FBbt, because FBbt does enforce a strict separation (with an explicit disjointness axiom) between `anatomical structure` and `disconnected anatomical group`.

This PR implements the fixes proposed in #2682:

* classify `non-connected functional system` as a `disconnected anatomical group`;
* classify `anatomical cluster` as a `disconnected anatomical group`;
* classify `insect synaptic neuropil block` as a `disconnected anatomical group`;
* classify `insect synaptic neuropil` as a `material anatomical entity`;
* classify `endocrine system` and `sensory system` as a `non-connected functional system`.

In addition (not discussed in #2682):

* classify `immune system` as a `non-connected functional system` (on the same rationale as for `endocrine system` and `sensory system`);
* classify `multi cell part structure` as an `anatomical structure`.

closes #2682