### PR TITLE
Make gogoeditdiff manual

### DIFF
--- a/.github/workflows/diff.yml
+++ b/.github/workflows/diff.yml
@@ -1,19 +1,18 @@
 name: 'Create ROBOT diffs on Pull requests'
 
-on:
-  # Triggers the workflow on pull request events for the master branch
-  pull_request:
-    branches: [ master ]
-    paths:
-      - 'src/ontology/uberon-edit.obo'
+on: 
 
-  # Allows you to run this workflow manually from the Actions tab
-  workflow_dispatch:
+  issue_comment:
+        types: [created]
 
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
   diff-reports:
+    if: ${{ github.event.issue.pull_request }}
     runs-on: macos-latest
+    permissions:
+      contents: read
+      pull-requests: read
     steps:
       - uses: khan/pull-request-comment-trigger@v1.1.0
         id: check
@@ -31,8 +30,12 @@ jobs:
         run: docker pull obolibrary/odklite
         if: steps.check.outputs.triggered == 'true'
       # Checks-out current branch
+      - uses: xt0rted/pull-request-comment-branch@v1
+        id: comment-branch
       - uses: actions/checkout@v3
         if: steps.check.outputs.triggered == 'true'
+        with:
+          ref: ${{ steps.comment-branch.outputs.head_ref }}
       # Checks-out master branch under "master" directory
       - uses: actions/checkout@v3
         if: steps.check.outputs.triggered == 'true'
@@ -113,4 +116,6 @@ jobs:
         with:
           file: "../../edit-comment.md"
           identifier: "UNREASONED"
+
+
 


### PR DESCRIPTION
This PR makes it so that gogoeditdiff will only be triggered with a comment saying #gogoeditdiff With new pushes, this will not change until someone comments #gogoeditdiff again.
This action will only work when it is merged into master, but as a proof of concept, see my fork: https://github.com/shawntanzk/uberon/pull/2