### PR TITLE
Update the stale-issues workflow.

### DIFF
--- a/.github/workflows/stale-issues.yml
+++ b/.github/workflows/stale-issues.yml
@@ -8,8 +8,9 @@ jobs:
   stale:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/stale@v4
+      - uses: actions/stale@v7
         with:
+          operations-per-run: 100
           days-before-issue-stale: 180
           days-before-issue-close: 365
           close-issue-label: 'autoclosed-unfixed'


### PR DESCRIPTION
This commit updates the `stale-issues.yml` workflow to:

- upgrade to version 7 of the `stale` action (needed to cope with changes to GitHub Actions, notably the deprecation of Node.js v12);
- raise the `operations-per-run` limit from 30 (default) to 100; this should allow to process more issues in a single run while still keeping us from hitting the rate limits (set to 1,000 operations per hour for GitHub Actions).