### PR TITLE
generic pharnx changes, part 1. See #2728.

### DIFF
--- a/src/sparql/illegal-annotation-property-violation.sparql
+++ b/src/sparql/illegal-annotation-property-violation.sparql
@@ -10,6 +10,7 @@ SELECT DISTINCT ?annotation WHERE {
     <http://purl.obolibrary.org/obo/IAO_0000232>,
     <http://purl.obolibrary.org/obo/IAO_0000412>,
     <http://purl.obolibrary.org/obo/IAO_0000589>,
+    <http://purl.obolibrary.org/obo/IAO_0006012>,
     <http://purl.obolibrary.org/obo/IAO_0100001>,
     <http://purl.obolibrary.org/obo/RO_0002161>,
     <http://purl.obolibrary.org/obo/RO_0002171>,


### PR DESCRIPTION
This does not yet obsolete generic pharynx, but adds a scheduled-for-obsoletion.

This also adds a seperate insecr pharynx.

See #2728
