### PR TITLE
Replace myself as PR creator by `GitHub-actions` when ontobot creates a PR

### DIFF
--- a/.github/workflows/auto-pr-ontobot.yml
+++ b/.github/workflows/auto-pr-ontobot.yml
@@ -65,6 +65,8 @@ jobs:
           labels: Automated
           body: ${{ env.PR_BODY }}
           title: ${{ env.PR_TITLE }}
+          author: ${{ env.ISSUE_CREATOR }} <${{ env.ISSUE_CREATOR }}@users.noreply.github.com>
+          committer: ${{ env.ISSUE_CREATOR }} <${{ env.ISSUE_CREATOR }}@users.noreply.github.com>
           base: ${{ github.head_ref }}
           branch: ${{ env.branch-name }}
-          token: ${{ secrets.GH_TOKEN }}
+          # token: ${{ secrets.GH_TOKEN }}


### PR DESCRIPTION
Added
- `author` 
- `committer`
Which will be the person who creates the issue.

Removed:
- `token`

NOTE: `token` was generated from my account and hence all PRs generated by `ontobot` seemed to have been requested by me. This will put an end to it but the presence of `token` triggered QC GitHub Actions which will not happen henceforth (once this PR is merged). With this change the PR requester will be `github-actions` user.