### PR TITLE
Fix download docs

### DIFF
--- a/docs/current_release.md
+++ b/docs/current_release.md
@@ -1,5 +1,10 @@
-# Under construction:
+# Canonical Release:
 
-Please check GitHub in the meantime:
+For the latest canonical release, please use http://purl.obolibrary.org/obo/uberon.owl
 
-https://github.com/obophenotype/uberon/releases
+# Variants:
+
+For variants of, use the following pattern: 
+http://purl.obolibrary.org/obo/uberon-{variant}.{format}
+Where variant is the type (eg base, simple, basic) and format is the file format (eg owl, obo, json)
+For full explanation of variants, please see https://oboacademy.github.io/obook/explanation/owl-format-variants/

--- a/docs/current_release.md
+++ b/docs/current_release.md
@@ -7,4 +7,5 @@ For the latest canonical release, please use http://purl.obolibrary.org/obo/uber
 For variants of, use the following pattern: 
 http://purl.obolibrary.org/obo/uberon-{variant}.{format}
 Where variant is the type (eg base, simple, basic) and format is the file format (eg owl, obo, json)
+For example, for a simple file in obo format, use http://purl.obolibrary.org/obo/uberon-simple.obo
 For full explanation of variants, please see https://oboacademy.github.io/obook/explanation/owl-format-variants/

--- a/docs/current_release.md
+++ b/docs/current_release.md
@@ -6,7 +6,7 @@ For the latest canonical release, please use http://purl.obolibrary.org/obo/uber
 
 For variants of, use the following pattern: 
 
-http://purl.obolibrary.org/obo/uberon-{variant}.{format}
+http://purl.obolibrary.org/obo/uberon/uberon-{variant}.{format}
 
 Where variant is the type (eg base, simple, basic) and format is the file format (eg owl, obo, json)
 

--- a/docs/current_release.md
+++ b/docs/current_release.md
@@ -5,7 +5,11 @@ For the latest canonical release, please use http://purl.obolibrary.org/obo/uber
 # Variants:
 
 For variants of, use the following pattern: 
+
 http://purl.obolibrary.org/obo/uberon-{variant}.{format}
+
 Where variant is the type (eg base, simple, basic) and format is the file format (eg owl, obo, json)
+
 For example, for a simple file in obo format, use http://purl.obolibrary.org/obo/uberon-simple.obo
+
 For full explanation of variants, please see https://oboacademy.github.io/obook/explanation/owl-format-variants/

--- a/docs/current_release.md
+++ b/docs/current_release.md
@@ -4,7 +4,7 @@ For the latest canonical release, please use http://purl.obolibrary.org/obo/uber
 
 # Variants:
 
-For variants of, use the following pattern: 
+For variants of Uberon, use the following pattern: 
 
 http://purl.obolibrary.org/obo/uberon/uberon-{variant}.{format}
 

--- a/docs/current_release.md
+++ b/docs/current_release.md
@@ -10,6 +10,6 @@ http://purl.obolibrary.org/obo/uberon/uberon-{variant}.{format}
 
 Where variant is the type (eg base, simple, basic) and format is the file format (eg owl, obo, json)
 
-For example, for a simple file in obo format, use http://purl.obolibrary.org/obo/uberon-simple.obo
+For example, for a simple file in obo format, use http://purl.obolibrary.org/obo/uberon/uberon-simple.obo
 
 For full explanation of variants, please see https://oboacademy.github.io/obook/explanation/owl-format-variants/


### PR DESCRIPTION
Fixes https://github.com/obophenotype/uberon/issues/2849
Readme contains a redirect to documentation - not sure if we want to also just drop the purl link there? 
Happy for anyone to make changes directly on branch
Forgot if docs needs deployment or is on an automated github actions here