### PR TITLE
Add IAO:0000233 to the list of allowed annotation properties.

### DIFF
--- a/src/sparql/illegal-annotation-property-violation.sparql
+++ b/src/sparql/illegal-annotation-property-violation.sparql
@@ -8,6 +8,7 @@ SELECT DISTINCT ?annotation WHERE {
     <http://purl.obolibrary.org/obo/IAO_0000116>,
     <http://purl.obolibrary.org/obo/IAO_0000231>,
     <http://purl.obolibrary.org/obo/IAO_0000232>,
+    <http://purl.obolibrary.org/obo/IAO_0000233>,
     <http://purl.obolibrary.org/obo/IAO_0000412>,
     <http://purl.obolibrary.org/obo/IAO_0000589>,
     <http://purl.obolibrary.org/obo/IAO_0006012>,


### PR DESCRIPTION
IAO:0000233 is [supposedly the annotation property to use](https://github.com/information-artifact-ontology/ontology-metadata/issues/102) for linking to a bug tracker issue, but it is still flagged as an “illegal” annotation. I assume this is an oversight.