### PR TITLE
Fix invalid IRI to RO relation in preprocessing step.

### DIFF
--- a/src/ontology/uberon.Makefile
+++ b/src/ontology/uberon.Makefile
@@ -95,7 +95,7 @@ $(OWLSRC): $(SRC) $(COMPONENTSDIR)/disjoint_union_over.ofn $(REPORTDIR)/$(SRC)-g
 	$(ROBOT) merge -i $< \
 			-i $(COMPONENTSDIR)/disjoint_union_over.ofn \
 			-i issues/contributor.owl \
-		expand --no-expand-term http://purl.obolibrary.org/RO_0002175 \
+		expand --no-expand-term http://purl.obolibrary.org/obo/RO_0002175 \
 			-o $@
 
 $(TMPDIR)/NORMALIZE.obo: $(SRC)


### PR DESCRIPTION
The recent overhaul of the preproprecessing step (#2968) introduced an invalid reference to RO:0002175. As a result, that annotation was now expanded along with the other annotations, instead of being explicitly left unexpanded as was the intention.

This PR fixes the invalid reference to restore the non-expansion of RO:00002175.