### PR TITLE
Do not (try to) rebuild the merged developmental stage ontologies.

### DIFF
--- a/src/ontology/uberon.Makefile
+++ b/src/ontology/uberon.Makefile
@@ -1141,9 +1141,7 @@ $(REPORTDIR)/%-synclash: %.obo
 $(TMPDIR)/update-stages: $(SRC) | $(TMPDIR)
 	rm -rf $(TMPDIR)/developmental-stage-ontologies && \
 	cd $(TMPDIR) && \
-	git clone https://github.com/obophenotype/developmental-stage-ontologies.git && \
-	cd developmental-stage-ontologies/src && make OWLTOOLS=owltools all ssso-merged.obo -B && cd ../../../ && \
-	touch $@
+	git clone https://github.com/obophenotype/developmental-stage-ontologies.git
 
 CSTAGES := $(filter-out %bridge-to-uberon.obo, $(wildcard $(TMPDIR)/developmental-stage-ontologies/*/*-uberon.obo))
 #CSTAGES := $(wildcard $(TMPDIR)/developmental-stage-ontologies/*/*-uberon.obo)


### PR DESCRIPTION
After cloning the `developmental-stage-ontologies` repo, we should use the products that have been committed there as they are, without trying to rebuild them.

This may mean we'll end up with less up-to-date things (if one of the taxon-specific stage ontology has been updated since the last time product files were committed to `developmental-stage-ontologies`), but it will prevent a failure of the `developmental-stage-ontologies` pipeline to cause a failure of the Uberon pipeline. If someone wants ultra-fresh developmental stage ontologies, then someone can take care of updating the `developmental-stage-ontologies` repo.

closes #3009