### PR TITLE
Undo using dev in QC and change "see also" in synonym annotation to xref

### DIFF
--- a/.github/workflows/qc.yml
+++ b/.github/workflows/qc.yml
@@ -19,7 +19,7 @@ jobs:
   ontology_qc:
     # The type of runner that the job will run on
     runs-on: ubuntu-latest
-    container: obolibrary/odkfull:dev
+    container: obolibrary/odkfull:1.4.1
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:

--- a/.github/workflows/qc.yml
+++ b/.github/workflows/qc.yml
@@ -19,7 +19,7 @@ jobs:
   ontology_qc:
     # The type of runner that the job will run on
     runs-on: ubuntu-latest
-    container: obolibrary/odkfull:1.4.1
+    container: obolibrary/odkfull:v1.4.1
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:


### PR DESCRIPTION
Fixes #3025 

This commit undoes the evil (my bad) which is switching to an unstable development snapshot for dev.

Sorry about the noise all, my bad.

@bvarner-ebi it is important that we do not use axiom annotations so freely; for synonyms, we consistently use oio:hasDbXref (even with URLs). If the URL is not evidence that the term can be used as a synonym, do not add it at all. 

@anitacaron the time has come to not listen to my technical advice too much anymore; switching to dev for QC was a wrong call by me, sorry about that! For the future, the only suggestion I do make is that, PRs should separate concerns: as @gouttegd suggests, we should at all times keep PRs to logical units that are easily reviewable, and have meaningful title like ("Using unstable development snapshot for QC (temp fix)" so that the white knights of software development have a chance to intervene when they see it.

