### PR TITLE
3051 Fix 'insect pharynx' bogus ID and add ID format check

### DIFF
--- a/src/ontology/Makefile
+++ b/src/ontology/Makefile
@@ -42,7 +42,7 @@ REPORT_FAIL_ON =            ERROR
 REPORT_LABEL =              
 REPORT_PROFILE_OPTS =       --profile $(ROBOT_PROFILE)
 OBO_FORMAT_OPTIONS =        
-SPARQL_VALIDATION_CHECKS =  equivalent-classes owldef-self-reference illegal-annotation-property taxon-range orcid-contributor obsolete-replaced_by xrefs-mesh-pattern label-synonym-polysemy 
+SPARQL_VALIDATION_CHECKS =  equivalent-classes owldef-self-reference illegal-annotation-property taxon-range orcid-contributor obsolete-replaced_by xrefs-mesh-pattern label-synonym-polysemy id-format 
 SPARQL_EXPORTS =            basic-report 
 ODK_VERSION_MAKEFILE =      v1.4.1
 

--- a/src/ontology/uberon-odk.yaml
+++ b/src/ontology/uberon-odk.yaml
@@ -108,6 +108,7 @@ robot_report:
     - obsolete-replaced_by
     - xrefs-mesh-pattern
     - label-synonym-polysemy
+    - id-format
   custom_sparql_exports:
     - basic-report
 owltools_memory: '20G'

--- a/src/sparql/id-format-violation.sparql
+++ b/src/sparql/id-format-violation.sparql
@@ -1,0 +1,10 @@
+PREFIX owl: <http://www.w3.org/2002/07/owl#>
+PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+
+SELECT ?cls WHERE {
+	?cls a owl:Class .
+	FILTER (strstarts(str(?cls), "http://purl.obolibrary.org/obo/UBERON_") &&
+	        ! regex(str(?cls), "^http://purl.obolibrary.org/obo/UBERON_[0-9]{7}$"))
+	FILTER NOT EXISTS { ?cls owl:deprecated ?v }
+}


### PR DESCRIPTION
This PR fixes the bogus ID of 'insect pharynx' (8-digits ID instead of the standard 7-digits format) by obsoleting the original term and replacing it with a new term with a correctly minted ID.

It also adds a new QC check to help prevent any occurrence of similar bogus IDs in the future.

closes #3051 