### PR TITLE
Make base for GO import

### DIFF
--- a/src/ontology/Makefile
+++ b/src/ontology/Makefile
@@ -427,8 +427,10 @@ mirror-cl: | $(TMPDIR)
 .PHONY: mirror-go
 .PRECIOUS: $(MIRRORDIR)/go.owl
 mirror-go: | $(TMPDIR)
-	if [ $(MIR) = true ] && [ $(IMP) = true ]; then curl -L $(OBOBASE)/go/go-base.owl --create-dirs -o $(MIRRORDIR)/go.owl --retry 4 --max-time 200 &&\
-		$(ROBOT) convert -i $(MIRRORDIR)/go.owl -o $@.tmp.owl && mv $@.tmp.owl $(TMPDIR)/$@.owl; fi
+	if [ $(MIR) = true ] && [ $(IMP) = true ]; then curl -L $(OBOBASE)/go.owl --create-dirs -o $(MIRRORDIR)/go.owl --retry 4 --max-time 200 &&\
+		$(ROBOT) convert -i $(MIRRORDIR)/go.owl -o $@.tmp.owl && \
+		$(ROBOT) remove -i $@.tmp.owl --base-iri http://purl.obolibrary.org/obo/GO_ --base-iri http://purl.obolibrary.org/obo/GOREL_ --base-iri http://purl.obolibrary.org/obo/GOCHE_ --axioms external --preserve-structure false --trim false -o $@.tmp.owl &&\
+		mv $@.tmp.owl $(TMPDIR)/$@.owl; fi
 
 
 ## ONTOLOGY: envo

--- a/src/ontology/Makefile
+++ b/src/ontology/Makefile
@@ -427,8 +427,7 @@ mirror-cl: | $(TMPDIR)
 .PHONY: mirror-go
 .PRECIOUS: $(MIRRORDIR)/go.owl
 mirror-go: | $(TMPDIR)
-	if [ $(MIR) = true ] && [ $(IMP) = true ]; then curl -L $(OBOBASE)/go.owl --create-dirs -o $(MIRRORDIR)/go.owl --retry 4 --max-time 200 &&\
-		$(ROBOT) convert -i $(MIRRORDIR)/go.owl -o $@.tmp.owl && \
+	if [ $(MIR) = true ] && [ $(IMP) = true ]; then $(ROBOT) convert -I http://purl.obolibrary.org/obo/go/go-base.owl -o $@.tmp.owl && \
 		$(ROBOT) remove -i $@.tmp.owl --base-iri http://purl.obolibrary.org/obo/GO_ --base-iri http://purl.obolibrary.org/obo/GOREL_ --base-iri http://purl.obolibrary.org/obo/GOCHE_ --axioms external --preserve-structure false --trim false -o $@.tmp.owl &&\
 		mv $@.tmp.owl $(TMPDIR)/$@.owl; fi
 

--- a/src/ontology/uberon-odk.yaml
+++ b/src/ontology/uberon-odk.yaml
@@ -44,7 +44,7 @@ import_group:
     - id: cl
       use_base: TRUE
     - id: go
-      use_base: TRUE
+      make_base: TRUE
       base_iris:
         - http://purl.obolibrary.org/obo/GO_
         - http://purl.obolibrary.org/obo/GOREL_

--- a/src/ontology/uberon-odk.yaml
+++ b/src/ontology/uberon-odk.yaml
@@ -45,6 +45,7 @@ import_group:
       use_base: TRUE
     - id: go
       make_base: TRUE
+      mirror_from: http://purl.obolibrary.org/obo/go/go-base.owl
       base_iris:
         - http://purl.obolibrary.org/obo/GO_
         - http://purl.obolibrary.org/obo/GOREL_


### PR DESCRIPTION
~The artefact `go-base.owl` is in reality a base plus artefact (base + the inferred axioms). This reduces the size of the `merged_import.owl` by half.~

Fixes #3057