### PR TITLE
Fix composite unsats

### DIFF
--- a/src/ontology/imports/local-cteno.owl
+++ b/src/ontology/imports/local-cteno.owl
@@ -12857,12 +12857,6 @@
     
 
 
-    <!-- http://purl.obolibrary.org/obo/UBERON_0006846 -->
-
-    <owl:Class rdf:about="http://purl.obolibrary.org/obo/UBERON_0006846">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/UBERON_0003102"/>
-        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">surface groove</rdfs:label>
-    </owl:Class>
     
 
 

--- a/src/ontology/imports/local-ehdaa2.owl
+++ b/src/ontology/imports/local-ehdaa2.owl
@@ -25905,7 +25905,6 @@ SubClassOf(<http://purl.obolibrary.org/obo/EHDAA2_0004738> ObjectSomeValuesFrom(
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/EHDAA2_0004739> "extraembryonic coelum"^^xsd:string)
 SubClassOf(<http://purl.obolibrary.org/obo/EHDAA2_0004739> <http://purl.obolibrary.org/obo/AEO_0000221>)
 SubClassOf(<http://purl.obolibrary.org/obo/EHDAA2_0004739> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0001025> <http://purl.obolibrary.org/obo/EHDAA2_0000472>))
-SubClassOf(<http://purl.obolibrary.org/obo/EHDAA2_0004739> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002371> <http://purl.obolibrary.org/obo/EHDAA2_0000267>))
 SubClassOf(<http://purl.obolibrary.org/obo/EHDAA2_0004739> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002496> <http://purl.obolibrary.org/obo/HsapDv_0000016>))
 
 # Class: <http://purl.obolibrary.org/obo/EHDAA2_0004740> (urogenital sinus epithelium vesical part)


### PR DESCRIPTION
This PR fixes unsatisfiable classes recently found in composite-metazoan by:

1. removing a bogus axiom (likely coming from an old version of Uberon) in the local CTENO mirror;
2. removing a bogus axiom in the local EHDAA2 mirror;
3. removing the bogus mappings between Uberon’s `serous sac` and EMAPA:16060 and MA:0000005.

See individual commit messages for more details about each issue.