### PR TITLE
[Test] Provide explanations for TC-induced failures

### DIFF
--- a/.github/workflows/qc.yml
+++ b/.github/workflows/qc.yml
@@ -27,6 +27,7 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: Run ontology QC checks
+        id: check
         env:
           DEFAULT_BRANCH: master
           ROBOT_JAVA_ARGS: -Xmx6G
@@ -34,3 +35,22 @@ jobs:
       - name: Last rows of QC report
         if: ${{ failure() }}
         run: tail -20 src/ontology/TESTLOG.log
+
+      - name: Reason over taxon constraints
+        id: explaintc
+        if: steps.check.outputs.status >= 1
+        run: |
+          if [ -s src/ontology/reports/taxon-constraint-check.txt ] then
+            robot explain -i src/ontology/tmp/uberon-edit-plus-tax-equivs.owl -M unsatisfiability -u all -r ELK -e taxon-unsats.md
+            echo "<details>\n<summary>This PR violates some taxon constraints. Here is what the reasoner has to say:</summary>\n" > comment.md
+            cat taxon-unsats.md >> comment.md
+            echo "</details>" >> comment.md
+            exit 1
+          fi
+      - name: Post explanation for taxon constraint violations
+        if: steps.explaintc.outputs.status >= 1
+        uses: NejcZdoc/comment-pr@v2
+        with:
+          github_token: ${{secrets.GITHUB_TOKEN}}
+          file: "comment.md"
+          identifier: "TAXON_CONSTRAINTS_REASONING"


### PR DESCRIPTION
If the online QC check fails, check if the failure is due to violations of the taxon constraints and if it is, post a comment to the PR with the reasoner's explanations for the violations.