### PR TITLE
Update README.md file to direct to editors SOP file

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,3 +32,5 @@ To trigger an automated human readable diff, add the following tag to a comment 
 ## Editors:
 
 See the file [README-editors.txt](bridge/../README-editors.txt)
+
+See the [Standard Operating Procedure for Uberon Curators](bridge/../docs/uberon-editor-sop.md).

--- a/mkdocs.yaml
+++ b/mkdocs.yaml
@@ -34,6 +34,7 @@ nav:
           - Your ODK Repository Overview: odk-workflows/RepositoryFileStructure.md
   - Uberon Internal Docs: 
       - Uberon Release: uberon-release.md
+      - Standard Operating Procedure for Uberon Curators: https://github.com/obophenotype/uberon/tree/master/docs/uberon-editor-sop.md
   - References:
       - Wiki: https://github.com/obophenotype/uberon/wiki
       - Uberon Manual: https://github.com/obophenotype/uberon/wiki/Manual

--- a/mkdocs.yaml
+++ b/mkdocs.yaml
@@ -11,7 +11,7 @@ nav:
       - Acknowledgements: acknowledgements.md
       - Cite: cite.md
   - Browse:
-      - OLS: https://www.ebi.ac.uk/ols/ontologies/uberon
+      - OLS: https://www.ebi.ac.uk/ols4/ontologies/uberon
       - Ontobee: http://www.ontobee.org/ontology/UBERON
       - BioPortal: https://bioportal.bioontology.org/ontologies/UBERON
       - Bgee Anatomical Homology: https://bgee.org/?page=anat_similarities
@@ -34,7 +34,7 @@ nav:
           - Your ODK Repository Overview: odk-workflows/RepositoryFileStructure.md
   - Uberon Internal Docs: 
       - Uberon Release: uberon-release.md
-      - Standard Operating Procedure for Uberon Curators: https://github.com/obophenotype/uberon/tree/master/docs/uberon-editor-sop.md
+      - Standard Operating Procedure for Uberon Curators: uberon-editor-sop.md
   - References:
       - Wiki: https://github.com/obophenotype/uberon/wiki
       - Uberon Manual: https://github.com/obophenotype/uberon/wiki/Manual


### PR DESCRIPTION
The README file was not pointing to the SOP for curators and ontology editors.
OLS link also has been updated to OLS4