### PR TITLE
Remove rules to create `uberon-nif-merged`.

### DIFF
--- a/src/ontology/uberon.Makefile
+++ b/src/ontology/uberon.Makefile
@@ -523,31 +523,6 @@ $(TMPDIR)/uberon-taxon-constraints.owl: $(TMPDIR)/uberon-taxon-constraints.obo
 	grep ^name: $< | grep -v obsolete | perl -npe 's@name: @@' > $@.tmp && sort -u $@.tmp > $@
 
 
-# uberon-nif-merged: Uberon merged with the NIF Gross Anatomy
-# FIXME: currently broken, and of dubious usefulness
-# (https://github.com/obophenotype/uberon/issues/3018)
-# ----------------------------------------
-$(TMPDIR)/NIF-GrossAnatomy-src.owl:
-	wget http://ontology.neuinfo.org/NIF/BiomaterialEntities/NIF-GrossAnatomy.owl -O $@
-
-$(TMPDIR)/NIF-GrossAnatomy.owl: $(TMPDIR)/NIF-GrossAnatomy-src.owl
-	perl -npe 's@http://ontology.neuinfo.org/NIF/BiomaterialEntities/NIF-GrossAnatomy.owl#@http://purl.obolibrary.org/obo/NIF_GrossAnatomy_@g' $< > $@
-
-$(TMPDIR)/NIF-GrossAnatomy-orig.obo: $(TMPDIR)/NIF-GrossAnatomy.owl
-	$(ROBOT) convert -i $< --check false -f obo -o $@
-
-$(TMPDIR)/NIF-GrossAnatomy.obo: $(TMPDIR)/NIF-GrossAnatomy-orig.obo
-	$(SCRIPTSDIR)/fix-nif-ga.pl $< > $@
-
-uberon-nif-merged.owl: uberon.owl $(TMPDIR)/NIF-GrossAnatomy.obo $(BRIDGEDIR)/uberon-bridge-to-nif_gross_anatomy.owl
-	$(OWLTOOLS) $^ --merge-support-ontologies \
-		       --reasoner elk --merge-equivalent-classes -f -t UBERON -o $@.tmp && \
-		grep -v '<oboInOwl:id' $@.tmp > $@
-
-uberon-nif-merged.obo:  uberon-nif-merged.owl
-	$(ROBOT) convert -i $< --check false -f obo -o $@
-
-
 # ----------------------------------------
 # REPORTS
 # ----------------------------------------


### PR DESCRIPTION
The `uberon-nif-merged.owl` product has been impossible to build for (at least) several months (possibly much more than that) because the link we try to download the “NIF Gross Anatomy” from is dead.

Besides, the usefulness of this product, even if we could build it, is dubious since the latest available version of the “NIF Gross Anatomy” seems to only contain deprecated terms that have been replaced by Uberon terms.

Adding to that the fact that nobody raised a voice against the removal of the `uberon-nif-merged` product since such a removal was evoked (#3018), there is no obvious reason to keep in place the rules to create this product. So we remove them here.

closes #3018