### PR TITLE
Automatically import Biomappings cross-references

### DIFF
--- a/src/ontology/components/mappings.owl
+++ b/src/ontology/components/mappings.owl
@@ -1,1078 +1,5958 @@
 <?xml version="1.0"?>
-<rdf:RDF xmlns="http://www.w3.org/2002/07/owl#"
-  xml:base="http://www.w3.org/2002/07/owl"
-  xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-  xmlns:oboInOwl="http://www.geneontology.org/formats/oboInOwl#">
-  <Ontology rdf:about="http://purl.obolibrary.org/obo/uberon/components/mappings.owl"/>
-  <Class rdf:about="http://purl.obolibrary.org/obo/UBERON_0000468">
-    <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">FBbt:00000001</oboInOwl:hasDbXref>
-  </Class>
-  <Class rdf:about="http://purl.obolibrary.org/obo/UBERON_6000002">
-    <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">FBbt:00000002</oboInOwl:hasDbXref>
-  </Class>
-  <Class rdf:about="http://purl.obolibrary.org/obo/UBERON_0000914">
-    <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">FBbt:00000003</oboInOwl:hasDbXref>
-  </Class>
-  <Class rdf:about="http://purl.obolibrary.org/obo/UBERON_6000004">
-    <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">FBbt:00000004</oboInOwl:hasDbXref>
-  </Class>
-  <Class rdf:about="http://purl.obolibrary.org/obo/UBERON_6000005">
-    <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">FBbt:00000005</oboInOwl:hasDbXref>
-  </Class>
-  <Class rdf:about="http://purl.obolibrary.org/obo/UBERON_6000006">
-    <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">FBbt:00000006</oboInOwl:hasDbXref>
-  </Class>
-  <Class rdf:about="http://purl.obolibrary.org/obo/UBERON_6000007">
-    <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">FBbt:00000007</oboInOwl:hasDbXref>
-  </Class>
-  <Class rdf:about="http://purl.obolibrary.org/obo/UBERON_6000008">
-    <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">FBbt:00000008</oboInOwl:hasDbXref>
-  </Class>
-  <Class rdf:about="http://purl.obolibrary.org/obo/UBERON_6000009">
-    <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">FBbt:00000009</oboInOwl:hasDbXref>
-  </Class>
-  <Class rdf:about="http://purl.obolibrary.org/obo/UBERON_6000011">
-    <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">FBbt:00000011</oboInOwl:hasDbXref>
-  </Class>
-  <Class rdf:about="http://purl.obolibrary.org/obo/UBERON_6000014">
-    <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">FBbt:00000014</oboInOwl:hasDbXref>
-  </Class>
-  <Class rdf:about="http://purl.obolibrary.org/obo/UBERON_6000015">
-    <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">FBbt:00000015</oboInOwl:hasDbXref>
-  </Class>
-  <Class rdf:about="http://purl.obolibrary.org/obo/UBERON_6000016">
-    <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">FBbt:00000016</oboInOwl:hasDbXref>
-  </Class>
-  <Class rdf:about="http://purl.obolibrary.org/obo/UBERON_6000017">
-    <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">FBbt:00000017</oboInOwl:hasDbXref>
-  </Class>
-  <Class rdf:about="http://purl.obolibrary.org/obo/UBERON_6000018">
-    <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">FBbt:00000018</oboInOwl:hasDbXref>
-  </Class>
-  <Class rdf:about="http://purl.obolibrary.org/obo/UBERON_6000019">
-    <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">FBbt:00000019</oboInOwl:hasDbXref>
-  </Class>
-  <Class rdf:about="http://purl.obolibrary.org/obo/UBERON_6000020">
-    <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">FBbt:00000020</oboInOwl:hasDbXref>
-  </Class>
-  <Class rdf:about="http://purl.obolibrary.org/obo/UBERON_6000021">
-    <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">FBbt:00000021</oboInOwl:hasDbXref>
-  </Class>
-  <Class rdf:about="http://purl.obolibrary.org/obo/UBERON_6000029">
-    <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">FBbt:00000029</oboInOwl:hasDbXref>
-  </Class>
-  <Class rdf:about="http://purl.obolibrary.org/obo/UBERON_6000030">
-    <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">FBbt:00000030</oboInOwl:hasDbXref>
-  </Class>
-  <Class rdf:about="http://purl.obolibrary.org/obo/UBERON_0000920">
-    <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">FBbt:00000038</oboInOwl:hasDbXref>
-  </Class>
-  <Class rdf:about="http://purl.obolibrary.org/obo/UBERON_0003125">
-    <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">FBbt:00000042</oboInOwl:hasDbXref>
-  </Class>
-  <Class rdf:about="http://purl.obolibrary.org/obo/UBERON_6000046">
-    <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">FBbt:00000046</oboInOwl:hasDbXref>
-  </Class>
-  <Class rdf:about="http://purl.obolibrary.org/obo/UBERON_0000922">
-    <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">FBbt:00000052</oboInOwl:hasDbXref>
-  </Class>
-  <Class rdf:about="http://purl.obolibrary.org/obo/UBERON_0009571">
-    <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">FBbt:00000093</oboInOwl:hasDbXref>
-  </Class>
-  <Class rdf:about="http://purl.obolibrary.org/obo/UBERON_0010302">
-    <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">FBbt:00000095</oboInOwl:hasDbXref>
-  </Class>
-  <Class rdf:about="http://purl.obolibrary.org/obo/UBERON_6000096">
-    <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">FBbt:00000096</oboInOwl:hasDbXref>
-  </Class>
-  <Class rdf:about="http://purl.obolibrary.org/obo/UBERON_6000097">
-    <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">FBbt:00000097</oboInOwl:hasDbXref>
-  </Class>
-  <Class rdf:about="http://purl.obolibrary.org/obo/UBERON_6000104">
-    <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">FBbt:00000104</oboInOwl:hasDbXref>
-  </Class>
-  <Class rdf:about="http://purl.obolibrary.org/obo/UBERON_0000923">
-    <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">FBbt:00000110</oboInOwl:hasDbXref>
-  </Class>
-  <Class rdf:about="http://purl.obolibrary.org/obo/UBERON_0000924">
-    <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">FBbt:00000111</oboInOwl:hasDbXref>
-  </Class>
-  <Class rdf:about="http://purl.obolibrary.org/obo/UBERON_6000112">
-    <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">FBbt:00000112</oboInOwl:hasDbXref>
-  </Class>
-  <Class rdf:about="http://purl.obolibrary.org/obo/UBERON_6000119">
-    <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">FBbt:00000119</oboInOwl:hasDbXref>
-  </Class>
-  <Class rdf:about="http://purl.obolibrary.org/obo/UBERON_0000931">
-    <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">FBbt:00000123</oboInOwl:hasDbXref>
-  </Class>
-  <Class rdf:about="http://purl.obolibrary.org/obo/UBERON_0000925">
-    <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">FBbt:00000125</oboInOwl:hasDbXref>
-  </Class>
-  <Class rdf:about="http://purl.obolibrary.org/obo/UBERON_0000926">
-    <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">FBbt:00000126</oboInOwl:hasDbXref>
-  </Class>
-  <Class rdf:about="http://purl.obolibrary.org/obo/UBERON_6000128">
-    <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">FBbt:00000128</oboInOwl:hasDbXref>
-  </Class>
-  <Class rdf:about="http://purl.obolibrary.org/obo/UBERON_6000130">
-    <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">FBbt:00000130</oboInOwl:hasDbXref>
-  </Class>
-  <Class rdf:about="http://purl.obolibrary.org/obo/UBERON_0000927">
-    <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">FBbt:00000136</oboInOwl:hasDbXref>
-  </Class>
-  <Class rdf:about="http://purl.obolibrary.org/obo/UBERON_6000137">
-    <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">FBbt:00000137</oboInOwl:hasDbXref>
-  </Class>
-  <Class rdf:about="http://purl.obolibrary.org/obo/UBERON_6000154">
-    <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">FBbt:00000154</oboInOwl:hasDbXref>
-  </Class>
-  <Class rdf:about="http://purl.obolibrary.org/obo/UBERON_0008816">
-    <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">FBbt:00000155</oboInOwl:hasDbXref>
-  </Class>
-  <Class rdf:about="http://purl.obolibrary.org/obo/UBERON_6000157">
-    <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">FBbt:00000157</oboInOwl:hasDbXref>
-  </Class>
-  <Class rdf:about="http://purl.obolibrary.org/obo/UBERON_6000158">
-    <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">FBbt:00000158</oboInOwl:hasDbXref>
-  </Class>
-  <Class rdf:about="http://purl.obolibrary.org/obo/UBERON_6000160">
-    <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">FBbt:00000160</oboInOwl:hasDbXref>
-  </Class>
-  <Class rdf:about="http://purl.obolibrary.org/obo/UBERON_6000162">
-    <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">FBbt:00000162</oboInOwl:hasDbXref>
-  </Class>
-  <Class rdf:about="http://purl.obolibrary.org/obo/UBERON_6000165">
-    <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">FBbt:00000165</oboInOwl:hasDbXref>
-  </Class>
-  <Class rdf:about="http://purl.obolibrary.org/obo/UBERON_6000166">
-    <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">FBbt:00000166</oboInOwl:hasDbXref>
-  </Class>
-  <Class rdf:about="http://purl.obolibrary.org/obo/UBERON_6000167">
-    <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">FBbt:00000167</oboInOwl:hasDbXref>
-  </Class>
-  <Class rdf:about="http://purl.obolibrary.org/obo/UBERON_6000168">
-    <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">FBbt:00000168</oboInOwl:hasDbXref>
-  </Class>
-  <Class rdf:about="http://purl.obolibrary.org/obo/UBERON_6000169">
-    <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">FBbt:00000169</oboInOwl:hasDbXref>
-  </Class>
-  <Class rdf:about="http://purl.obolibrary.org/obo/UBERON_6000170">
-    <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">FBbt:00000170</oboInOwl:hasDbXref>
-  </Class>
-  <Class rdf:about="http://purl.obolibrary.org/obo/UBERON_6000171">
-    <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">FBbt:00000171</oboInOwl:hasDbXref>
-  </Class>
-  <Class rdf:about="http://purl.obolibrary.org/obo/UBERON_6000172">
-    <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">FBbt:00000172</oboInOwl:hasDbXref>
-  </Class>
-  <Class rdf:about="http://purl.obolibrary.org/obo/UBERON_6000180">
-    <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">FBbt:00000180</oboInOwl:hasDbXref>
-  </Class>
-  <Class rdf:about="http://purl.obolibrary.org/obo/UBERON_6000181">
-    <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">FBbt:00000181</oboInOwl:hasDbXref>
-  </Class>
-  <Class rdf:about="http://purl.obolibrary.org/obo/UBERON_6000186">
-    <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">FBbt:00000186</oboInOwl:hasDbXref>
-  </Class>
-  <Class rdf:about="http://purl.obolibrary.org/obo/UBERON_0000930">
-    <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">FBbt:00000439</oboInOwl:hasDbXref>
-  </Class>
-  <Class rdf:about="http://purl.obolibrary.org/obo/UBERON_6001055">
-    <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">FBbt:00001055</oboInOwl:hasDbXref>
-  </Class>
-  <Class rdf:about="http://purl.obolibrary.org/obo/UBERON_6001056">
-    <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">FBbt:00001056</oboInOwl:hasDbXref>
-  </Class>
-  <Class rdf:about="http://purl.obolibrary.org/obo/UBERON_0002346">
-    <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">FBbt:00001057</oboInOwl:hasDbXref>
-  </Class>
-  <Class rdf:about="http://purl.obolibrary.org/obo/UBERON_6001059">
-    <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">FBbt:00001059</oboInOwl:hasDbXref>
-  </Class>
-  <Class rdf:about="http://purl.obolibrary.org/obo/UBERON_6001060">
-    <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">FBbt:00001060</oboInOwl:hasDbXref>
-  </Class>
-  <Class rdf:about="http://purl.obolibrary.org/obo/UBERON_6001135">
-    <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">FBbt:00001135</oboInOwl:hasDbXref>
-  </Class>
-  <Class rdf:about="http://purl.obolibrary.org/obo/UBERON_6001648">
-    <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">FBbt:00001648</oboInOwl:hasDbXref>
-  </Class>
-  <Class rdf:about="http://purl.obolibrary.org/obo/UBERON_6001649">
-    <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">FBbt:00001649</oboInOwl:hasDbXref>
-  </Class>
-  <Class rdf:about="http://purl.obolibrary.org/obo/UBERON_6001650">
-    <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">FBbt:00001650</oboInOwl:hasDbXref>
-  </Class>
-  <Class rdf:about="http://purl.obolibrary.org/obo/UBERON_6001652">
-    <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">FBbt:00001652</oboInOwl:hasDbXref>
-  </Class>
-  <Class rdf:about="http://purl.obolibrary.org/obo/UBERON_6001653">
-    <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">FBbt:00001653</oboInOwl:hasDbXref>
-  </Class>
-  <Class rdf:about="http://purl.obolibrary.org/obo/UBERON_6001655">
-    <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">FBbt:00001655</oboInOwl:hasDbXref>
-  </Class>
-  <Class rdf:about="http://purl.obolibrary.org/obo/UBERON_6001656">
-    <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">FBbt:00001656</oboInOwl:hasDbXref>
-  </Class>
-  <Class rdf:about="http://purl.obolibrary.org/obo/UBERON_6001657">
-    <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">FBbt:00001657</oboInOwl:hasDbXref>
-  </Class>
-  <Class rdf:about="http://purl.obolibrary.org/obo/UBERON_6001658">
-    <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">FBbt:00001658</oboInOwl:hasDbXref>
-  </Class>
-  <Class rdf:about="http://purl.obolibrary.org/obo/UBERON_6001661">
-    <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">FBbt:00001661</oboInOwl:hasDbXref>
-  </Class>
-  <Class rdf:about="http://purl.obolibrary.org/obo/UBERON_6001662">
-    <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">FBbt:00001662</oboInOwl:hasDbXref>
-  </Class>
-  <Class rdf:about="http://purl.obolibrary.org/obo/UBERON_6001663">
-    <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">FBbt:00001663</oboInOwl:hasDbXref>
-  </Class>
-  <Class rdf:about="http://purl.obolibrary.org/obo/UBERON_6001664">
-    <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">FBbt:00001664</oboInOwl:hasDbXref>
-  </Class>
-  <Class rdf:about="http://purl.obolibrary.org/obo/UBERON_6001668">
-    <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">FBbt:00001668</oboInOwl:hasDbXref>
-  </Class>
-  <Class rdf:about="http://purl.obolibrary.org/obo/UBERON_0012325">
-    <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">FBbt:00001718</oboInOwl:hasDbXref>
-  </Class>
-  <Class rdf:about="http://purl.obolibrary.org/obo/UBERON_6001722">
-    <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">FBbt:00001722</oboInOwl:hasDbXref>
-  </Class>
-  <Class rdf:about="http://purl.obolibrary.org/obo/UBERON_0002548">
-    <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">FBbt:00001727</oboInOwl:hasDbXref>
-  </Class>
-  <Class rdf:about="http://purl.obolibrary.org/obo/UBERON_6001728">
-    <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">FBbt:00001728</oboInOwl:hasDbXref>
-  </Class>
-  <Class rdf:about="http://purl.obolibrary.org/obo/UBERON_6001729">
-    <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">FBbt:00001729</oboInOwl:hasDbXref>
-  </Class>
-  <Class rdf:about="http://purl.obolibrary.org/obo/UBERON_6001730">
-    <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">FBbt:00001730</oboInOwl:hasDbXref>
-  </Class>
-  <Class rdf:about="http://purl.obolibrary.org/obo/UBERON_6001731">
-    <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">FBbt:00001731</oboInOwl:hasDbXref>
-  </Class>
-  <Class rdf:about="http://purl.obolibrary.org/obo/UBERON_6001732">
-    <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">FBbt:00001732</oboInOwl:hasDbXref>
-  </Class>
-  <Class rdf:about="http://purl.obolibrary.org/obo/UBERON_6001733">
-    <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">FBbt:00001733</oboInOwl:hasDbXref>
-  </Class>
-  <Class rdf:about="http://purl.obolibrary.org/obo/UBERON_6001734">
-    <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">FBbt:00001734</oboInOwl:hasDbXref>
-  </Class>
-  <Class rdf:about="http://purl.obolibrary.org/obo/UBERON_6001735">
-    <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">FBbt:00001735</oboInOwl:hasDbXref>
-  </Class>
-  <Class rdf:about="http://purl.obolibrary.org/obo/UBERON_6001737">
-    <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">FBbt:00001737</oboInOwl:hasDbXref>
-  </Class>
-  <Class rdf:about="http://purl.obolibrary.org/obo/UBERON_6001740">
-    <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">FBbt:00001740</oboInOwl:hasDbXref>
-  </Class>
-  <Class rdf:about="http://purl.obolibrary.org/obo/UBERON_6001741">
-    <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">FBbt:00001741</oboInOwl:hasDbXref>
-  </Class>
-  <Class rdf:about="http://purl.obolibrary.org/obo/UBERON_6001742">
-    <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">FBbt:00001742</oboInOwl:hasDbXref>
-  </Class>
-  <Class rdf:about="http://purl.obolibrary.org/obo/UBERON_6001743">
-    <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">FBbt:00001743</oboInOwl:hasDbXref>
-  </Class>
-  <Class rdf:about="http://purl.obolibrary.org/obo/UBERON_6001744">
-    <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">FBbt:00001744</oboInOwl:hasDbXref>
-  </Class>
-  <Class rdf:about="http://purl.obolibrary.org/obo/UBERON_6001745">
-    <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">FBbt:00001745</oboInOwl:hasDbXref>
-  </Class>
-  <Class rdf:about="http://purl.obolibrary.org/obo/UBERON_6001746">
-    <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">FBbt:00001746</oboInOwl:hasDbXref>
-  </Class>
-  <Class rdf:about="http://purl.obolibrary.org/obo/UBERON_6001747">
-    <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">FBbt:00001747</oboInOwl:hasDbXref>
-  </Class>
-  <Class rdf:about="http://purl.obolibrary.org/obo/UBERON_6001755">
-    <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">FBbt:00001755</oboInOwl:hasDbXref>
-  </Class>
-  <Class rdf:about="http://purl.obolibrary.org/obo/UBERON_6001756">
-    <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">FBbt:00001756</oboInOwl:hasDbXref>
-  </Class>
-  <Class rdf:about="http://purl.obolibrary.org/obo/UBERON_6001760">
-    <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">FBbt:00001760</oboInOwl:hasDbXref>
-  </Class>
-  <Class rdf:about="http://purl.obolibrary.org/obo/UBERON_0000939">
-    <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">FBbt:00001761</oboInOwl:hasDbXref>
-  </Class>
-  <Class rdf:about="http://purl.obolibrary.org/obo/UBERON_6001764">
-    <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">FBbt:00001764</oboInOwl:hasDbXref>
-  </Class>
-  <Class rdf:about="http://purl.obolibrary.org/obo/UBERON_6001765">
-    <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">FBbt:00001765</oboInOwl:hasDbXref>
-  </Class>
-  <Class rdf:about="http://purl.obolibrary.org/obo/UBERON_6001766">
-    <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">FBbt:00001766</oboInOwl:hasDbXref>
-  </Class>
-  <Class rdf:about="http://purl.obolibrary.org/obo/UBERON_6001767">
-    <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">FBbt:00001767</oboInOwl:hasDbXref>
-  </Class>
-  <Class rdf:about="http://purl.obolibrary.org/obo/UBERON_6001776">
-    <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">FBbt:00001776</oboInOwl:hasDbXref>
-  </Class>
-  <Class rdf:about="http://purl.obolibrary.org/obo/UBERON_6001778">
-    <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">FBbt:00001778</oboInOwl:hasDbXref>
-  </Class>
-  <Class rdf:about="http://purl.obolibrary.org/obo/UBERON_6001779">
-    <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">FBbt:00001779</oboInOwl:hasDbXref>
-  </Class>
-  <Class rdf:about="http://purl.obolibrary.org/obo/UBERON_6001780">
-    <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">FBbt:00001780</oboInOwl:hasDbXref>
-  </Class>
-  <Class rdf:about="http://purl.obolibrary.org/obo/UBERON_6001781">
-    <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">FBbt:00001781</oboInOwl:hasDbXref>
-  </Class>
-  <Class rdf:about="http://purl.obolibrary.org/obo/UBERON_6001784">
-    <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">FBbt:00001784</oboInOwl:hasDbXref>
-  </Class>
-  <Class rdf:about="http://purl.obolibrary.org/obo/UBERON_6001785">
-    <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">FBbt:00001785</oboInOwl:hasDbXref>
-  </Class>
-  <Class rdf:about="http://purl.obolibrary.org/obo/UBERON_6001787">
-    <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">FBbt:00001787</oboInOwl:hasDbXref>
-  </Class>
-  <Class rdf:about="http://purl.obolibrary.org/obo/UBERON_6001790">
-    <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">FBbt:00001790</oboInOwl:hasDbXref>
-  </Class>
-  <Class rdf:about="http://purl.obolibrary.org/obo/UBERON_6001842">
-    <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">FBbt:00001842</oboInOwl:hasDbXref>
-  </Class>
-  <Class rdf:about="http://purl.obolibrary.org/obo/UBERON_6001845">
-    <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">FBbt:00001845</oboInOwl:hasDbXref>
-  </Class>
-  <Class rdf:about="http://purl.obolibrary.org/obo/UBERON_6001848">
-    <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">FBbt:00001848</oboInOwl:hasDbXref>
-  </Class>
-  <Class rdf:about="http://purl.obolibrary.org/obo/UBERON_6001911">
-    <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">FBbt:00001911</oboInOwl:hasDbXref>
-  </Class>
-  <Class rdf:about="http://purl.obolibrary.org/obo/UBERON_6001919">
-    <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">FBbt:00001919</oboInOwl:hasDbXref>
-  </Class>
-  <Class rdf:about="http://purl.obolibrary.org/obo/UBERON_6001920">
-    <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">FBbt:00001920</oboInOwl:hasDbXref>
-  </Class>
-  <Class rdf:about="http://purl.obolibrary.org/obo/UBERON_6001925">
-    <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">FBbt:00001925</oboInOwl:hasDbXref>
-  </Class>
-  <Class rdf:about="http://purl.obolibrary.org/obo/UBERON_0004904">
-    <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">FBbt:00001956</oboInOwl:hasDbXref>
-  </Class>
-  <Class rdf:about="http://purl.obolibrary.org/obo/UBERON_6002639">
-    <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">FBbt:00002639</oboInOwl:hasDbXref>
-  </Class>
-  <Class rdf:about="http://purl.obolibrary.org/obo/UBERON_6002642">
-    <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">FBbt:00002642</oboInOwl:hasDbXref>
-  </Class>
-  <Class rdf:about="http://purl.obolibrary.org/obo/UBERON_0003142">
-    <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">FBbt:00002952</oboInOwl:hasDbXref>
-  </Class>
-  <Class rdf:about="http://purl.obolibrary.org/obo/UBERON_0003143">
-    <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">FBbt:00002953</oboInOwl:hasDbXref>
-  </Class>
-  <Class rdf:about="http://purl.obolibrary.org/obo/UBERON_0007023">
-    <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">FBbt:00003004</oboInOwl:hasDbXref>
-  </Class>
-  <Class rdf:about="http://purl.obolibrary.org/obo/UBERON_6003005">
-    <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">FBbt:00003005</oboInOwl:hasDbXref>
-  </Class>
-  <Class rdf:about="http://purl.obolibrary.org/obo/UBERON_6003006">
-    <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">FBbt:00003006</oboInOwl:hasDbXref>
-  </Class>
-  <Class rdf:about="http://purl.obolibrary.org/obo/UBERON_6003007">
-    <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">FBbt:00003007</oboInOwl:hasDbXref>
-  </Class>
-  <Class rdf:about="http://purl.obolibrary.org/obo/UBERON_6003009">
-    <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">FBbt:00003009</oboInOwl:hasDbXref>
-  </Class>
-  <Class rdf:about="http://purl.obolibrary.org/obo/UBERON_6003010">
-    <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">FBbt:00003010</oboInOwl:hasDbXref>
-  </Class>
-  <Class rdf:about="http://purl.obolibrary.org/obo/UBERON_6003011">
-    <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">FBbt:00003011</oboInOwl:hasDbXref>
-  </Class>
-  <Class rdf:about="http://purl.obolibrary.org/obo/UBERON_6003012">
-    <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">FBbt:00003012</oboInOwl:hasDbXref>
-  </Class>
-  <Class rdf:about="http://purl.obolibrary.org/obo/UBERON_6003018">
-    <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">FBbt:00003018</oboInOwl:hasDbXref>
-  </Class>
-  <Class rdf:about="http://purl.obolibrary.org/obo/UBERON_6003019">
-    <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">FBbt:00003019</oboInOwl:hasDbXref>
-  </Class>
-  <Class rdf:about="http://purl.obolibrary.org/obo/UBERON_6003020">
-    <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">FBbt:00003020</oboInOwl:hasDbXref>
-  </Class>
-  <Class rdf:about="http://purl.obolibrary.org/obo/UBERON_6003021">
-    <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">FBbt:00003021</oboInOwl:hasDbXref>
-  </Class>
-  <Class rdf:about="http://purl.obolibrary.org/obo/UBERON_6003023">
-    <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">FBbt:00003023</oboInOwl:hasDbXref>
-  </Class>
-  <Class rdf:about="http://purl.obolibrary.org/obo/UBERON_6003024">
-    <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">FBbt:00003024</oboInOwl:hasDbXref>
-  </Class>
-  <Class rdf:about="http://purl.obolibrary.org/obo/UBERON_6003039">
-    <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">FBbt:00003039</oboInOwl:hasDbXref>
-  </Class>
-  <Class rdf:about="http://purl.obolibrary.org/obo/UBERON_0001555">
-    <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">FBbt:00003125</oboInOwl:hasDbXref>
-  </Class>
-  <Class rdf:about="http://purl.obolibrary.org/obo/UBERON_0000165">
-    <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">FBbt:00003126</oboInOwl:hasDbXref>
-  </Class>
-  <Class rdf:about="http://purl.obolibrary.org/obo/UBERON_0015230">
-    <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">FBbt:00003154</oboInOwl:hasDbXref>
-  </Class>
-  <Class rdf:about="http://purl.obolibrary.org/obo/UBERON_6003259">
-    <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">FBbt:00003259</oboInOwl:hasDbXref>
-  </Class>
-  <Class rdf:about="http://purl.obolibrary.org/obo/UBERON_6003559">
-    <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">FBbt:00003559</oboInOwl:hasDbXref>
-  </Class>
-  <Class rdf:about="http://purl.obolibrary.org/obo/UBERON_6003623">
-    <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">FBbt:00003623</oboInOwl:hasDbXref>
-  </Class>
-  <Class rdf:about="http://purl.obolibrary.org/obo/UBERON_6003624">
-    <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">FBbt:00003624</oboInOwl:hasDbXref>
-  </Class>
-  <Class rdf:about="http://purl.obolibrary.org/obo/UBERON_6003626">
-    <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">FBbt:00003626</oboInOwl:hasDbXref>
-  </Class>
-  <Class rdf:about="http://purl.obolibrary.org/obo/UBERON_6003627">
-    <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">FBbt:00003627</oboInOwl:hasDbXref>
-  </Class>
-  <Class rdf:about="http://purl.obolibrary.org/obo/UBERON_6003632">
-    <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">FBbt:00003632</oboInOwl:hasDbXref>
-  </Class>
-  <Class rdf:about="http://purl.obolibrary.org/obo/UBERON_0006795">
-    <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">FBbt:00003701</oboInOwl:hasDbXref>
-  </Class>
-  <Class rdf:about="http://purl.obolibrary.org/obo/UBERON_0000963">
-    <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">FBbt:00004114</oboInOwl:hasDbXref>
-  </Class>
-  <Class rdf:about="http://purl.obolibrary.org/obo/UBERON_0000207">
-    <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">FBbt:00004199</oboInOwl:hasDbXref>
-  </Class>
-  <Class rdf:about="http://purl.obolibrary.org/obo/UBERON_0005388">
-    <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">FBbt:00004200</oboInOwl:hasDbXref>
-  </Class>
-  <Class rdf:about="http://purl.obolibrary.org/obo/UBERON_0002050">
-    <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">FBbt:00004208</oboInOwl:hasDbXref>
-  </Class>
-  <Class rdf:about="http://purl.obolibrary.org/obo/UBERON_6004296">
-    <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">FBbt:00004296</oboInOwl:hasDbXref>
-  </Class>
-  <Class rdf:about="http://purl.obolibrary.org/obo/UBERON_6004340">
-    <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">FBbt:00004340</oboInOwl:hasDbXref>
-  </Class>
-  <Class rdf:about="http://purl.obolibrary.org/obo/UBERON_6004475">
-    <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">FBbt:00004475</oboInOwl:hasDbXref>
-  </Class>
-  <Class rdf:about="http://purl.obolibrary.org/obo/UBERON_6004476">
-    <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">FBbt:00004476</oboInOwl:hasDbXref>
-  </Class>
-  <Class rdf:about="http://purl.obolibrary.org/obo/UBERON_6004477">
-    <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">FBbt:00004477</oboInOwl:hasDbXref>
-  </Class>
-  <Class rdf:about="http://purl.obolibrary.org/obo/UBERON_6004481">
-    <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">FBbt:00004481</oboInOwl:hasDbXref>
-  </Class>
-  <Class rdf:about="http://purl.obolibrary.org/obo/UBERON_0003153">
-    <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">FBbt:00004482</oboInOwl:hasDbXref>
-  </Class>
-  <Class rdf:about="http://purl.obolibrary.org/obo/UBERON_0003155">
-    <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">FBbt:00004492</oboInOwl:hasDbXref>
-  </Class>
-  <Class rdf:about="http://purl.obolibrary.org/obo/UBERON_0003161">
-    <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">FBbt:00004505</oboInOwl:hasDbXref>
-  </Class>
-  <Class rdf:about="http://purl.obolibrary.org/obo/UBERON_0003162">
-    <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">FBbt:00004506</oboInOwl:hasDbXref>
-  </Class>
-  <Class rdf:about="http://purl.obolibrary.org/obo/UBERON_0003211">
-    <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">FBbt:00004507</oboInOwl:hasDbXref>
-  </Class>
-  <Class rdf:about="http://purl.obolibrary.org/obo/UBERON_0000018">
-    <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">FBbt:00004508</oboInOwl:hasDbXref>
-  </Class>
-  <Class rdf:about="http://purl.obolibrary.org/obo/UBERON_0000971">
-    <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">FBbt:00004510</oboInOwl:hasDbXref>
-  </Class>
-  <Class rdf:about="http://purl.obolibrary.org/obo/UBERON_0000972">
-    <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">FBbt:00004511</oboInOwl:hasDbXref>
-  </Class>
-  <Class rdf:about="http://purl.obolibrary.org/obo/UBERON_6004519">
-    <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">FBbt:00004519</oboInOwl:hasDbXref>
-  </Class>
-  <Class rdf:about="http://purl.obolibrary.org/obo/UBERON_6004520">
-    <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">FBbt:00004520</oboInOwl:hasDbXref>
-  </Class>
-  <Class rdf:about="http://purl.obolibrary.org/obo/UBERON_6004521">
-    <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">FBbt:00004521</oboInOwl:hasDbXref>
-  </Class>
-  <Class rdf:about="http://purl.obolibrary.org/obo/UBERON_0005905">
-    <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">FBbt:00004522</oboInOwl:hasDbXref>
-  </Class>
-  <Class rdf:about="http://purl.obolibrary.org/obo/UBERON_6004535">
-    <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">FBbt:00004535</oboInOwl:hasDbXref>
-  </Class>
-  <Class rdf:about="http://purl.obolibrary.org/obo/UBERON_6004540">
-    <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">FBbt:00004540</oboInOwl:hasDbXref>
-  </Class>
-  <Class rdf:about="http://purl.obolibrary.org/obo/UBERON_6004551">
-    <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">FBbt:00004551</oboInOwl:hasDbXref>
-  </Class>
-  <Class rdf:about="http://purl.obolibrary.org/obo/UBERON_6004552">
-    <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">FBbt:00004552</oboInOwl:hasDbXref>
-  </Class>
-  <Class rdf:about="http://purl.obolibrary.org/obo/UBERON_0003130">
-    <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">FBbt:00004557</oboInOwl:hasDbXref>
-  </Class>
-  <Class rdf:about="http://purl.obolibrary.org/obo/UBERON_6004578">
-    <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">FBbt:00004578</oboInOwl:hasDbXref>
-  </Class>
-  <Class rdf:about="http://purl.obolibrary.org/obo/UBERON_6004579">
-    <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">FBbt:00004579</oboInOwl:hasDbXref>
-  </Class>
-  <Class rdf:about="http://purl.obolibrary.org/obo/UBERON_6004580">
-    <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">FBbt:00004580</oboInOwl:hasDbXref>
-  </Class>
-  <Class rdf:about="http://purl.obolibrary.org/obo/UBERON_0005895">
-    <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">FBbt:00004640</oboInOwl:hasDbXref>
-  </Class>
-  <Class rdf:about="http://purl.obolibrary.org/obo/UBERON_0003131">
-    <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">FBbt:00004642</oboInOwl:hasDbXref>
-  </Class>
-  <Class rdf:about="http://purl.obolibrary.org/obo/UBERON_6004646">
-    <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">FBbt:00004646</oboInOwl:hasDbXref>
-  </Class>
-  <Class rdf:about="http://purl.obolibrary.org/obo/UBERON_6004648">
-    <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">FBbt:00004648</oboInOwl:hasDbXref>
-  </Class>
-  <Class rdf:about="http://purl.obolibrary.org/obo/UBERON_6004663">
-    <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">FBbt:00004663</oboInOwl:hasDbXref>
-  </Class>
-  <Class rdf:about="http://purl.obolibrary.org/obo/UBERON_6004668">
-    <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">FBbt:00004668</oboInOwl:hasDbXref>
-  </Class>
-  <Class rdf:about="http://purl.obolibrary.org/obo/UBERON_6004670">
-    <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">FBbt:00004670</oboInOwl:hasDbXref>
-  </Class>
-  <Class rdf:about="http://purl.obolibrary.org/obo/UBERON_0000984">
-    <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">FBbt:00004729</oboInOwl:hasDbXref>
-  </Class>
-  <Class rdf:about="http://purl.obolibrary.org/obo/UBERON_0003194">
-    <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">FBbt:00004751</oboInOwl:hasDbXref>
-  </Class>
-  <Class rdf:about="http://purl.obolibrary.org/obo/UBERON_0000987">
-    <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">FBbt:00004783</oboInOwl:hasDbXref>
-  </Class>
-  <Class rdf:about="http://purl.obolibrary.org/obo/UBERON_6004788">
-    <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">FBbt:00004788</oboInOwl:hasDbXref>
-  </Class>
-  <Class rdf:about="http://purl.obolibrary.org/obo/UBERON_6004823">
-    <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">FBbt:00004823</oboInOwl:hasDbXref>
-  </Class>
-  <Class rdf:about="http://purl.obolibrary.org/obo/UBERON_6004824">
-    <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">FBbt:00004824</oboInOwl:hasDbXref>
-  </Class>
-  <Class rdf:about="http://purl.obolibrary.org/obo/UBERON_6004825">
-    <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">FBbt:00004825</oboInOwl:hasDbXref>
-  </Class>
-  <Class rdf:about="http://purl.obolibrary.org/obo/UBERON_0008811">
-    <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">FBbt:00004850</oboInOwl:hasDbXref>
-  </Class>
-  <Class rdf:about="http://purl.obolibrary.org/obo/UBERON_0000467">
-    <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">FBbt:00004856</oboInOwl:hasDbXref>
-  </Class>
-  <Class rdf:about="http://purl.obolibrary.org/obo/UBERON_0000990">
-    <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">FBbt:00004857</oboInOwl:hasDbXref>
-  </Class>
-  <Class rdf:about="http://purl.obolibrary.org/obo/UBERON_0000991">
-    <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">FBbt:00004858</oboInOwl:hasDbXref>
-  </Class>
-  <Class rdf:about="http://purl.obolibrary.org/obo/UBERON_0000474">
-    <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">FBbt:00004864</oboInOwl:hasDbXref>
-  </Class>
-  <Class rdf:about="http://purl.obolibrary.org/obo/UBERON_0000992">
-    <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">FBbt:00004865</oboInOwl:hasDbXref>
-  </Class>
-  <Class rdf:about="http://purl.obolibrary.org/obo/UBERON_0003199">
-    <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">FBbt:00004894</oboInOwl:hasDbXref>
-  </Class>
-  <Class rdf:about="http://purl.obolibrary.org/obo/UBERON_0000994">
-    <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">FBbt:00004921</oboInOwl:hasDbXref>
-  </Class>
-  <Class rdf:about="http://purl.obolibrary.org/obo/UBERON_0000079">
-    <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">FBbt:00004927</oboInOwl:hasDbXref>
-  </Class>
-  <Class rdf:about="http://purl.obolibrary.org/obo/UBERON_0000473">
-    <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">FBbt:00004928</oboInOwl:hasDbXref>
-  </Class>
-  <Class rdf:about="http://purl.obolibrary.org/obo/UBERON_0006868">
-    <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">FBbt:00004958</oboInOwl:hasDbXref>
-  </Class>
-  <Class rdf:about="http://purl.obolibrary.org/obo/UBERON_0002416">
-    <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">FBbt:00004969</oboInOwl:hasDbXref>
-  </Class>
-  <Class rdf:about="http://purl.obolibrary.org/obo/UBERON_0001001">
-    <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">FBbt:00004970</oboInOwl:hasDbXref>
-  </Class>
-  <Class rdf:about="http://purl.obolibrary.org/obo/UBERON_0003201">
-    <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">FBbt:00004973</oboInOwl:hasDbXref>
-  </Class>
-  <Class rdf:about="http://purl.obolibrary.org/obo/UBERON_0003202">
-    <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">FBbt:00004974</oboInOwl:hasDbXref>
-  </Class>
-  <Class rdf:about="http://purl.obolibrary.org/obo/UBERON_6004979">
-    <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">FBbt:00004979</oboInOwl:hasDbXref>
-  </Class>
-  <Class rdf:about="http://purl.obolibrary.org/obo/UBERON_6004983">
-    <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">FBbt:00004983</oboInOwl:hasDbXref>
-  </Class>
-  <Class rdf:about="http://purl.obolibrary.org/obo/UBERON_6004986">
-    <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">FBbt:00004986</oboInOwl:hasDbXref>
-  </Class>
-  <Class rdf:about="http://purl.obolibrary.org/obo/UBERON_0018656">
-    <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">FBbt:00004987</oboInOwl:hasDbXref>
-  </Class>
-  <Class rdf:about="http://purl.obolibrary.org/obo/UBERON_0007376">
-    <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">FBbt:00004993</oboInOwl:hasDbXref>
-  </Class>
-  <Class rdf:about="http://purl.obolibrary.org/obo/UBERON_6005023">
-    <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">FBbt:00005023</oboInOwl:hasDbXref>
-  </Class>
-  <Class rdf:about="http://purl.obolibrary.org/obo/UBERON_0005155">
-    <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">FBbt:00005024</oboInOwl:hasDbXref>
-  </Class>
-  <Class rdf:about="http://purl.obolibrary.org/obo/UBERON_6005036">
-    <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">FBbt:00005036</oboInOwl:hasDbXref>
-  </Class>
-  <Class rdf:about="http://purl.obolibrary.org/obo/UBERON_6005037">
-    <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">FBbt:00005037</oboInOwl:hasDbXref>
-  </Class>
-  <Class rdf:about="http://purl.obolibrary.org/obo/UBERON_6005043">
-    <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">FBbt:00005043</oboInOwl:hasDbXref>
-  </Class>
-  <Class rdf:about="http://purl.obolibrary.org/obo/UBERON_6005054">
-    <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">FBbt:00005054</oboInOwl:hasDbXref>
-  </Class>
-  <Class rdf:about="http://purl.obolibrary.org/obo/UBERON_0001007">
-    <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">FBbt:00005055</oboInOwl:hasDbXref>
-  </Class>
-  <Class rdf:about="http://purl.obolibrary.org/obo/UBERON_0001008">
-    <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">FBbt:00005056</oboInOwl:hasDbXref>
-  </Class>
-  <Class rdf:about="http://purl.obolibrary.org/obo/UBERON_0009054">
-    <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">FBbt:00005057</oboInOwl:hasDbXref>
-  </Class>
-  <Class rdf:about="http://purl.obolibrary.org/obo/UBERON_0002323">
-    <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">FBbt:00005060</oboInOwl:hasDbXref>
-  </Class>
-  <Class rdf:about="http://purl.obolibrary.org/obo/UBERON_0001011">
-    <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">FBbt:00005061</oboInOwl:hasDbXref>
-  </Class>
-  <Class rdf:about="http://purl.obolibrary.org/obo/UBERON_0003917">
-    <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">FBbt:00005066</oboInOwl:hasDbXref>
-  </Class>
-  <Class rdf:about="http://purl.obolibrary.org/obo/UBERON_0000949">
-    <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">FBbt:00005068</oboInOwl:hasDbXref>
-  </Class>
-  <Class rdf:about="http://purl.obolibrary.org/obo/UBERON_0001016">
-    <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">FBbt:00005093</oboInOwl:hasDbXref>
-  </Class>
-  <Class rdf:about="http://purl.obolibrary.org/obo/UBERON_0001017">
-    <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">FBbt:00005094</oboInOwl:hasDbXref>
-  </Class>
-  <Class rdf:about="http://purl.obolibrary.org/obo/UBERON_0000955">
-    <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">FBbt:00005095</oboInOwl:hasDbXref>
-  </Class>
-  <Class rdf:about="http://purl.obolibrary.org/obo/UBERON_6005096">
-    <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">FBbt:00005096</oboInOwl:hasDbXref>
-  </Class>
-  <Class rdf:about="http://purl.obolibrary.org/obo/UBERON_0000934">
-    <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">FBbt:00005097</oboInOwl:hasDbXref>
-  </Class>
-  <Class rdf:about="http://purl.obolibrary.org/obo/UBERON_0000010">
-    <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">FBbt:00005098</oboInOwl:hasDbXref>
-  </Class>
-  <Class rdf:about="http://purl.obolibrary.org/obo/UBERON_0000122">
-    <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">FBbt:00005099</oboInOwl:hasDbXref>
-  </Class>
-  <Class rdf:about="http://purl.obolibrary.org/obo/UBERON_0001018">
-    <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">FBbt:00005100</oboInOwl:hasDbXref>
-  </Class>
-  <Class rdf:about="http://purl.obolibrary.org/obo/UBERON_0001021">
-    <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">FBbt:00005105</oboInOwl:hasDbXref>
-  </Class>
-  <Class rdf:about="http://purl.obolibrary.org/obo/UBERON_0001027">
-    <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">FBbt:00005136</oboInOwl:hasDbXref>
-  </Class>
-  <Class rdf:about="http://purl.obolibrary.org/obo/UBERON_0002606">
-    <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">FBbt:00005139</oboInOwl:hasDbXref>
-  </Class>
-  <Class rdf:about="http://purl.obolibrary.org/obo/UBERON_0000020">
-    <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">FBbt:00005155</oboInOwl:hasDbXref>
-  </Class>
-  <Class rdf:about="http://purl.obolibrary.org/obo/UBERON_0000005">
-    <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">FBbt:00005157</oboInOwl:hasDbXref>
-  </Class>
-  <Class rdf:about="http://purl.obolibrary.org/obo/UBERON_0002268">
-    <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">FBbt:00005158</oboInOwl:hasDbXref>
-  </Class>
-  <Class rdf:about="http://purl.obolibrary.org/obo/UBERON_0003212">
-    <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">FBbt:00005159</oboInOwl:hasDbXref>
-  </Class>
-  <Class rdf:about="http://purl.obolibrary.org/obo/UBERON_0000970">
-    <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">FBbt:00005162</oboInOwl:hasDbXref>
-  </Class>
-  <Class rdf:about="http://purl.obolibrary.org/obo/UBERON_6005168">
-    <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">FBbt:00005168</oboInOwl:hasDbXref>
-  </Class>
-  <Class rdf:about="http://purl.obolibrary.org/obo/UBERON_6005177">
-    <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">FBbt:00005177</oboInOwl:hasDbXref>
-  </Class>
-  <Class rdf:about="http://purl.obolibrary.org/obo/UBERON_0001038">
-    <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">FBbt:00005215</oboInOwl:hasDbXref>
-  </Class>
-  <Class rdf:about="http://purl.obolibrary.org/obo/UBERON_0004734">
-    <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">FBbt:00005317</oboInOwl:hasDbXref>
-  </Class>
-  <Class rdf:about="http://purl.obolibrary.org/obo/UBERON_0000323">
-    <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">FBbt:00005333</oboInOwl:hasDbXref>
-  </Class>
-  <Class rdf:about="http://purl.obolibrary.org/obo/UBERON_0018382">
-    <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">FBbt:00005338</oboInOwl:hasDbXref>
-  </Class>
-  <Class rdf:about="http://purl.obolibrary.org/obo/UBERON_6005378">
-    <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">FBbt:00005378</oboInOwl:hasDbXref>
-  </Class>
-  <Class rdf:about="http://purl.obolibrary.org/obo/UBERON_0001041">
-    <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">FBbt:00005379</oboInOwl:hasDbXref>
-  </Class>
-  <Class rdf:about="http://purl.obolibrary.org/obo/UBERON_6005380">
-    <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">FBbt:00005380</oboInOwl:hasDbXref>
-  </Class>
-  <Class rdf:about="http://purl.obolibrary.org/obo/UBERON_0001044">
-    <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">FBbt:00005382</oboInOwl:hasDbXref>
-  </Class>
-  <Class rdf:about="http://purl.obolibrary.org/obo/UBERON_0001045">
-    <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">FBbt:00005383</oboInOwl:hasDbXref>
-  </Class>
-  <Class rdf:about="http://purl.obolibrary.org/obo/UBERON_0001046">
-    <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">FBbt:00005384</oboInOwl:hasDbXref>
-  </Class>
-  <Class rdf:about="http://purl.obolibrary.org/obo/UBERON_0001047">
-    <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">FBbt:00005386</oboInOwl:hasDbXref>
-  </Class>
-  <Class rdf:about="http://purl.obolibrary.org/obo/UBERON_6005393">
-    <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">FBbt:00005393</oboInOwl:hasDbXref>
-  </Class>
-  <Class rdf:about="http://purl.obolibrary.org/obo/UBERON_6005396">
-    <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">FBbt:00005396</oboInOwl:hasDbXref>
-  </Class>
-  <Class rdf:about="http://purl.obolibrary.org/obo/UBERON_0007688">
-    <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">FBbt:00005426</oboInOwl:hasDbXref>
-  </Class>
-  <Class rdf:about="http://purl.obolibrary.org/obo/UBERON_6005427">
-    <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">FBbt:00005427</oboInOwl:hasDbXref>
-  </Class>
-  <Class rdf:about="http://purl.obolibrary.org/obo/UBERON_6005461">
-    <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">FBbt:00005461</oboInOwl:hasDbXref>
-  </Class>
-  <Class rdf:about="http://purl.obolibrary.org/obo/UBERON_6005467">
-    <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">FBbt:00005467</oboInOwl:hasDbXref>
-  </Class>
-  <Class rdf:about="http://purl.obolibrary.org/obo/UBERON_0001048">
-    <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">FBbt:00005495</oboInOwl:hasDbXref>
-  </Class>
-  <Class rdf:about="http://purl.obolibrary.org/obo/UBERON_6005514">
-    <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">FBbt:00005514</oboInOwl:hasDbXref>
-  </Class>
-  <Class rdf:about="http://purl.obolibrary.org/obo/UBERON_6005526">
-    <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">FBbt:00005526</oboInOwl:hasDbXref>
-  </Class>
-  <Class rdf:about="http://purl.obolibrary.org/obo/UBERON_6005533">
-    <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">FBbt:00005533</oboInOwl:hasDbXref>
-  </Class>
-  <Class rdf:about="http://purl.obolibrary.org/obo/UBERON_6005538">
-    <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">FBbt:00005538</oboInOwl:hasDbXref>
-  </Class>
-  <Class rdf:about="http://purl.obolibrary.org/obo/UBERON_6005558">
-    <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">FBbt:00005558</oboInOwl:hasDbXref>
-  </Class>
-  <Class rdf:about="http://purl.obolibrary.org/obo/UBERON_6005569">
-    <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">FBbt:00005569</oboInOwl:hasDbXref>
-  </Class>
-  <Class rdf:about="http://purl.obolibrary.org/obo/UBERON_0006866">
-    <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">FBbt:00005756</oboInOwl:hasDbXref>
-  </Class>
-  <Class rdf:about="http://purl.obolibrary.org/obo/UBERON_0001053">
-    <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">FBbt:00005757</oboInOwl:hasDbXref>
-  </Class>
-  <Class rdf:about="http://purl.obolibrary.org/obo/UBERON_0001054">
-    <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">FBbt:00005786</oboInOwl:hasDbXref>
-  </Class>
-  <Class rdf:about="http://purl.obolibrary.org/obo/UBERON_0001056">
-    <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">FBbt:00005799</oboInOwl:hasDbXref>
-  </Class>
-  <Class rdf:about="http://purl.obolibrary.org/obo/UBERON_0001057">
-    <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">FBbt:00005800</oboInOwl:hasDbXref>
-  </Class>
-  <Class rdf:about="http://purl.obolibrary.org/obo/UBERON_0001058">
-    <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">FBbt:00005801</oboInOwl:hasDbXref>
-  </Class>
-  <Class rdf:about="http://purl.obolibrary.org/obo/UBERON_0001059">
-    <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">FBbt:00005802</oboInOwl:hasDbXref>
-  </Class>
-  <Class rdf:about="http://purl.obolibrary.org/obo/UBERON_6005805">
-    <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">FBbt:00005805</oboInOwl:hasDbXref>
-  </Class>
-  <Class rdf:about="http://purl.obolibrary.org/obo/UBERON_0004905">
-    <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">FBbt:00005811</oboInOwl:hasDbXref>
-  </Class>
-  <Class rdf:about="http://purl.obolibrary.org/obo/UBERON_6005830">
-    <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">FBbt:00005830</oboInOwl:hasDbXref>
-  </Class>
-  <Class rdf:about="http://purl.obolibrary.org/obo/UBERON_6005831">
-    <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">FBbt:00005831</oboInOwl:hasDbXref>
-  </Class>
-  <Class rdf:about="http://purl.obolibrary.org/obo/UBERON_0000478">
-    <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">FBbt:00005835</oboInOwl:hasDbXref>
-  </Class>
-  <Class rdf:about="http://purl.obolibrary.org/obo/UBERON_6005913">
-    <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">FBbt:00005913</oboInOwl:hasDbXref>
-  </Class>
-  <Class rdf:about="http://purl.obolibrary.org/obo/UBERON_6006011">
-    <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">FBbt:00006011</oboInOwl:hasDbXref>
-  </Class>
-  <Class rdf:about="http://purl.obolibrary.org/obo/UBERON_6006032">
-    <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">FBbt:00006032</oboInOwl:hasDbXref>
-  </Class>
-  <Class rdf:about="http://purl.obolibrary.org/obo/UBERON_0000026">
-    <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">FBbt:00007000</oboInOwl:hasDbXref>
-  </Class>
-  <Class rdf:about="http://purl.obolibrary.org/obo/UBERON_0000061">
-    <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">FBbt:00007001</oboInOwl:hasDbXref>
-  </Class>
-  <Class rdf:about="http://purl.obolibrary.org/obo/UBERON_0000479">
-    <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">FBbt:00007003</oboInOwl:hasDbXref>
-  </Class>
-  <Class rdf:about="http://purl.obolibrary.org/obo/UBERON_0003101">
-    <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">FBbt:00007004</oboInOwl:hasDbXref>
-  </Class>
-  <Class rdf:about="http://purl.obolibrary.org/obo/UBERON_0000483">
-    <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">FBbt:00007005</oboInOwl:hasDbXref>
-  </Class>
-  <Class rdf:about="http://purl.obolibrary.org/obo/UBERON_0005423">
-    <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">FBbt:00007006</oboInOwl:hasDbXref>
-  </Class>
-  <Class rdf:about="http://purl.obolibrary.org/obo/UBERON_0000475">
-    <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">FBbt:00007009</oboInOwl:hasDbXref>
-  </Class>
-  <Class rdf:about="http://purl.obolibrary.org/obo/UBERON_0000481">
-    <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">FBbt:00007010</oboInOwl:hasDbXref>
-  </Class>
-  <Class rdf:about="http://purl.obolibrary.org/obo/UBERON_0003100">
-    <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">FBbt:00007011</oboInOwl:hasDbXref>
-  </Class>
-  <Class rdf:about="http://purl.obolibrary.org/obo/UBERON_0000476">
-    <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">FBbt:00007013</oboInOwl:hasDbXref>
-  </Class>
-  <Class rdf:about="http://purl.obolibrary.org/obo/UBERON_0000466">
-    <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">FBbt:00007015</oboInOwl:hasDbXref>
-  </Class>
-  <Class rdf:about="http://purl.obolibrary.org/obo/UBERON_0000465">
-    <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">FBbt:00007016</oboInOwl:hasDbXref>
-  </Class>
-  <Class rdf:about="http://purl.obolibrary.org/obo/UBERON_0000464">
-    <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">FBbt:00007017</oboInOwl:hasDbXref>
-  </Class>
-  <Class rdf:about="http://purl.obolibrary.org/obo/UBERON_0010758">
-    <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">FBbt:00007018</oboInOwl:hasDbXref>
-  </Class>
-  <Class rdf:about="http://purl.obolibrary.org/obo/UBERON_0000463">
-    <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">FBbt:00007019</oboInOwl:hasDbXref>
-  </Class>
-  <Class rdf:about="http://purl.obolibrary.org/obo/UBERON_6007020">
-    <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">FBbt:00007020</oboInOwl:hasDbXref>
-  </Class>
-  <Class rdf:about="http://purl.obolibrary.org/obo/UBERON_0000485">
-    <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">FBbt:00007027</oboInOwl:hasDbXref>
-  </Class>
-  <Class rdf:about="http://purl.obolibrary.org/obo/UBERON_6007045">
-    <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">FBbt:00007045</oboInOwl:hasDbXref>
-  </Class>
-  <Class rdf:about="http://purl.obolibrary.org/obo/UBERON_6007046">
-    <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">FBbt:00007046</oboInOwl:hasDbXref>
-  </Class>
-  <Class rdf:about="http://purl.obolibrary.org/obo/UBERON_0005162">
-    <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">FBbt:00007060</oboInOwl:hasDbXref>
-  </Class>
-  <Class rdf:about="http://purl.obolibrary.org/obo/UBERON_6007070">
-    <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">FBbt:00007070</oboInOwl:hasDbXref>
-  </Class>
-  <Class rdf:about="http://purl.obolibrary.org/obo/UBERON_6007116">
-    <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">FBbt:00007116</oboInOwl:hasDbXref>
-  </Class>
-  <Class rdf:about="http://purl.obolibrary.org/obo/UBERON_6007145">
-    <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">FBbt:00007145</oboInOwl:hasDbXref>
-  </Class>
-  <Class rdf:about="http://purl.obolibrary.org/obo/UBERON_6007149">
-    <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">FBbt:00007149</oboInOwl:hasDbXref>
-  </Class>
-  <Class rdf:about="http://purl.obolibrary.org/obo/UBERON_6007150">
-    <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">FBbt:00007150</oboInOwl:hasDbXref>
-  </Class>
-  <Class rdf:about="http://purl.obolibrary.org/obo/UBERON_0002536">
-    <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">FBbt:00007152</oboInOwl:hasDbXref>
-  </Class>
-  <Class rdf:about="http://purl.obolibrary.org/obo/UBERON_0010001">
-    <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">FBbt:00007229</oboInOwl:hasDbXref>
-  </Class>
-  <Class rdf:about="http://purl.obolibrary.org/obo/UBERON_0014732">
-    <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">FBbt:00007230</oboInOwl:hasDbXref>
-  </Class>
-  <Class rdf:about="http://purl.obolibrary.org/obo/UBERON_6007231">
-    <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">FBbt:00007231</oboInOwl:hasDbXref>
-  </Class>
-  <Class rdf:about="http://purl.obolibrary.org/obo/UBERON_6007232">
-    <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">FBbt:00007232</oboInOwl:hasDbXref>
-  </Class>
-  <Class rdf:about="http://purl.obolibrary.org/obo/UBERON_6007233">
-    <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">FBbt:00007233</oboInOwl:hasDbXref>
-  </Class>
-  <Class rdf:about="http://purl.obolibrary.org/obo/UBERON_6007240">
-    <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">FBbt:00007240</oboInOwl:hasDbXref>
-  </Class>
-  <Class rdf:about="http://purl.obolibrary.org/obo/UBERON_6007242">
-    <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">FBbt:00007242</oboInOwl:hasDbXref>
-  </Class>
-  <Class rdf:about="http://purl.obolibrary.org/obo/UBERON_6007245">
-    <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">FBbt:00007245</oboInOwl:hasDbXref>
-  </Class>
-  <Class rdf:about="http://purl.obolibrary.org/obo/UBERON_6007248">
-    <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">FBbt:00007248</oboInOwl:hasDbXref>
-  </Class>
-  <Class rdf:about="http://purl.obolibrary.org/obo/UBERON_0034923">
-    <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">FBbt:00007276</oboInOwl:hasDbXref>
-  </Class>
-  <Class rdf:about="http://purl.obolibrary.org/obo/UBERON_0000477">
-    <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">FBbt:00007277</oboInOwl:hasDbXref>
-  </Class>
-  <Class rdf:about="http://purl.obolibrary.org/obo/UBERON_0015203">
-    <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">FBbt:00007278</oboInOwl:hasDbXref>
-  </Class>
-  <Class rdf:about="http://purl.obolibrary.org/obo/UBERON_6007280">
-    <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">FBbt:00007280</oboInOwl:hasDbXref>
-  </Class>
-  <Class rdf:about="http://purl.obolibrary.org/obo/UBERON_6007284">
-    <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">FBbt:00007284</oboInOwl:hasDbXref>
-  </Class>
-  <Class rdf:about="http://purl.obolibrary.org/obo/UBERON_6007285">
-    <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">FBbt:00007285</oboInOwl:hasDbXref>
-  </Class>
-  <Class rdf:about="http://purl.obolibrary.org/obo/UBERON_6007288">
-    <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">FBbt:00007288</oboInOwl:hasDbXref>
-  </Class>
-  <Class rdf:about="http://purl.obolibrary.org/obo/UBERON_6007289">
-    <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">FBbt:00007289</oboInOwl:hasDbXref>
-  </Class>
-  <Class rdf:about="http://purl.obolibrary.org/obo/UBERON_0011216">
-    <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">FBbt:00007330</oboInOwl:hasDbXref>
-  </Class>
-  <Class rdf:about="http://purl.obolibrary.org/obo/UBERON_6007331">
-    <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">FBbt:00007331</oboInOwl:hasDbXref>
-  </Class>
-  <Class rdf:about="http://purl.obolibrary.org/obo/UBERON_6007373">
-    <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">FBbt:00007373</oboInOwl:hasDbXref>
-  </Class>
-  <Class rdf:about="http://purl.obolibrary.org/obo/UBERON_0006832">
-    <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">FBbt:00007410</oboInOwl:hasDbXref>
-  </Class>
-  <Class rdf:about="http://purl.obolibrary.org/obo/UBERON_6007424">
-    <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">FBbt:00007424</oboInOwl:hasDbXref>
-  </Class>
-  <Class rdf:about="http://purl.obolibrary.org/obo/UBERON_0003914">
-    <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">FBbt:00007474</oboInOwl:hasDbXref>
-  </Class>
-  <Class rdf:about="http://purl.obolibrary.org/obo/UBERON_0001032">
-    <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">FBbt:00007692</oboInOwl:hasDbXref>
-  </Class>
-  <Class rdf:about="http://purl.obolibrary.org/obo/UBERON_6016022">
-    <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">FBbt:00016022</oboInOwl:hasDbXref>
-  </Class>
-  <Class rdf:about="http://purl.obolibrary.org/obo/UBERON_6040003">
-    <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">FBbt:00040003</oboInOwl:hasDbXref>
-  </Class>
-  <Class rdf:about="http://purl.obolibrary.org/obo/UBERON_6040005">
-    <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">FBbt:00040005</oboInOwl:hasDbXref>
-  </Class>
-  <Class rdf:about="http://purl.obolibrary.org/obo/UBERON_6040007">
-    <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">FBbt:00040007</oboInOwl:hasDbXref>
-  </Class>
-  <Class rdf:about="http://purl.obolibrary.org/obo/UBERON_6041000">
-    <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">FBbt:00041000</oboInOwl:hasDbXref>
-  </Class>
-  <Class rdf:about="http://purl.obolibrary.org/obo/UBERON_0001245">
-    <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">FBbt:00047153</oboInOwl:hasDbXref>
-  </Class>
-  <Class rdf:about="http://purl.obolibrary.org/obo/UBERON_0003929">
-    <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">FBbt:00047166</oboInOwl:hasDbXref>
-  </Class>
-  <Class rdf:about="http://purl.obolibrary.org/obo/UBERON_6057001">
-    <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">FBbt:00057001</oboInOwl:hasDbXref>
-  </Class>
-  <Class rdf:about="http://purl.obolibrary.org/obo/UBERON_0015231">
-    <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">FBbt:00058291</oboInOwl:hasDbXref>
-  </Class>
-  <Class rdf:about="http://purl.obolibrary.org/obo/UBERON_0034926">
-    <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">FBbt:00100152</oboInOwl:hasDbXref>
-  </Class>
-  <Class rdf:about="http://purl.obolibrary.org/obo/UBERON_6100153">
-    <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">FBbt:00100153</oboInOwl:hasDbXref>
-  </Class>
-  <Class rdf:about="http://purl.obolibrary.org/obo/UBERON_0010000">
-    <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">FBbt:00100313</oboInOwl:hasDbXref>
-  </Class>
-  <Class rdf:about="http://purl.obolibrary.org/obo/UBERON_0000058">
-    <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">FBbt:00100314</oboInOwl:hasDbXref>
-  </Class>
-  <Class rdf:about="http://purl.obolibrary.org/obo/UBERON_0004921">
-    <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">FBbt:00100315</oboInOwl:hasDbXref>
-  </Class>
-  <Class rdf:about="http://purl.obolibrary.org/obo/UBERON_0009854">
-    <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">FBbt:00100316</oboInOwl:hasDbXref>
-  </Class>
-  <Class rdf:about="http://purl.obolibrary.org/obo/UBERON_0002530">
-    <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">FBbt:00100317</oboInOwl:hasDbXref>
-  </Class>
-  <Class rdf:about="http://purl.obolibrary.org/obo/UBERON_6110636">
-    <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">FBbt:00110636</oboInOwl:hasDbXref>
-  </Class>
-  <Class rdf:about="http://purl.obolibrary.org/obo/UBERON_6110746">
-    <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">FBbt:00110746</oboInOwl:hasDbXref>
-  </Class>
-  <Class rdf:about="http://purl.obolibrary.org/obo/UBERON_6110811">
-    <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">FBbt:00110811</oboInOwl:hasDbXref>
-  </Class>
-  <Class rdf:about="http://purl.obolibrary.org/obo/UBERON_0001062">
-    <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">FBbt:10000000</oboInOwl:hasDbXref>
-  </Class>
+<rdf:RDF xmlns="http://purl.obolibrary.org/obo/uberon/components/mappings.owl#"
+     xml:base="http://purl.obolibrary.org/obo/uberon/components/mappings.owl"
+     xmlns:owl="http://www.w3.org/2002/07/owl#"
+     xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+     xmlns:xml="http://www.w3.org/XML/1998/namespace"
+     xmlns:xsd="http://www.w3.org/2001/XMLSchema#"
+     xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
+     xmlns:sssom="https://w3id.org/sssom/"
+     xmlns:oboInOwl="http://www.geneontology.org/formats/oboInOwl#">
+    <owl:Ontology rdf:about="http://purl.obolibrary.org/obo/uberon/components/mappings.owl"/>
+    
+
+
+    <!-- 
+    ///////////////////////////////////////////////////////////////////////////////////////
+    //
+    // Annotation properties
+    //
+    ///////////////////////////////////////////////////////////////////////////////////////
+     -->
+
+    
+
+
+    <!-- http://www.geneontology.org/formats/oboInOwl#hasDbXref -->
+
+    <owl:AnnotationProperty rdf:about="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+    
+
+
+    <!-- https://w3id.org/sssom/author_id -->
+
+    <owl:AnnotationProperty rdf:about="https://w3id.org/sssom/author_id"/>
+    
+
+
+    <!-- https://w3id.org/sssom/mapping_justification -->
+
+    <owl:AnnotationProperty rdf:about="https://w3id.org/sssom/mapping_justification"/>
+    
+
+
+    <!-- https://w3id.org/sssom/mapping_provider -->
+
+    <owl:AnnotationProperty rdf:about="https://w3id.org/sssom/mapping_provider"/>
+    
+
+
+    <!-- 
+    ///////////////////////////////////////////////////////////////////////////////////////
+    //
+    // Annotations
+    //
+    ///////////////////////////////////////////////////////////////////////////////////////
+     -->
+
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_0000005">
+        <oboInOwl:hasDbXref>FBbt:00005157</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_0000005"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>FBbt:00005157</owl:annotatedTarget>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_0000010">
+        <oboInOwl:hasDbXref>FBbt:00005098</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_0000010"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>FBbt:00005098</owl:annotatedTarget>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_0000016">
+        <oboInOwl:hasDbXref>https://meshb.nlm.nih.gov/record/ui?ui=D007515</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_0000016"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>https://meshb.nlm.nih.gov/record/ui?ui=D007515</owl:annotatedTarget>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/LexicalMatching"/>
+        <sssom:mapping_provider>https://github.com/biopragmatics/biomappings</sssom:mapping_provider>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_0000017">
+        <oboInOwl:hasDbXref>https://meshb.nlm.nih.gov/record/ui?ui=D046790</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_0000017"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>https://meshb.nlm.nih.gov/record/ui?ui=D046790</owl:annotatedTarget>
+        <sssom:author_id rdf:resource="https://orcid.org/0000-0001-9439-5346"/>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+        <sssom:mapping_provider>https://github.com/biopragmatics/biomappings</sssom:mapping_provider>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_0000018">
+        <oboInOwl:hasDbXref>FBbt:00004508</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>IDOMAL:0002421</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_0000018"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>FBbt:00004508</owl:annotatedTarget>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+    </owl:Axiom>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_0000018"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>IDOMAL:0002421</owl:annotatedTarget>
+        <sssom:author_id rdf:resource="https://orcid.org/0000-0003-4423-4370"/>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+        <sssom:mapping_provider>https://github.com/biopragmatics/biomappings</sssom:mapping_provider>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_0000020">
+        <oboInOwl:hasDbXref>FBbt:00005155</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_0000020"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>FBbt:00005155</owl:annotatedTarget>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_0000026">
+        <oboInOwl:hasDbXref>FBbt:00007000</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_0000026"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>FBbt:00007000</owl:annotatedTarget>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_0000044">
+        <oboInOwl:hasDbXref>https://meshb.nlm.nih.gov/record/ui?ui=D005727</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_0000044"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>https://meshb.nlm.nih.gov/record/ui?ui=D005727</owl:annotatedTarget>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/LexicalMatching"/>
+        <sssom:mapping_provider>https://github.com/biopragmatics/biomappings</sssom:mapping_provider>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_0000058">
+        <oboInOwl:hasDbXref>FBbt:00100314</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_0000058"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>FBbt:00100314</owl:annotatedTarget>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_0000061">
+        <oboInOwl:hasDbXref>FBbt:00007001</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_0000061"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>FBbt:00007001</owl:annotatedTarget>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_0000076">
+        <oboInOwl:hasDbXref>BTO:0006242</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_0000076"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>BTO:0006242</owl:annotatedTarget>
+        <sssom:author_id rdf:resource="https://orcid.org/0000-0003-4423-4370"/>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+        <sssom:mapping_provider>https://github.com/biopragmatics/biomappings</sssom:mapping_provider>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_0000079">
+        <oboInOwl:hasDbXref>FBbt:00004927</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_0000079"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>FBbt:00004927</owl:annotatedTarget>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_0000106">
+        <oboInOwl:hasDbXref>IDOMAL:0000302</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_0000106"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>IDOMAL:0000302</owl:annotatedTarget>
+        <sssom:author_id rdf:resource="https://orcid.org/0000-0003-4423-4370"/>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+        <sssom:mapping_provider>https://github.com/biopragmatics/biomappings</sssom:mapping_provider>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_0000120">
+        <oboInOwl:hasDbXref>https://meshb.nlm.nih.gov/record/ui?ui=D001812</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_0000120"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>https://meshb.nlm.nih.gov/record/ui?ui=D001812</owl:annotatedTarget>
+        <sssom:author_id rdf:resource="https://orcid.org/0000-0001-9439-5346"/>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+        <sssom:mapping_provider>https://github.com/biopragmatics/biomappings</sssom:mapping_provider>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_0000122">
+        <oboInOwl:hasDbXref>FBbt:00005099</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_0000122"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>FBbt:00005099</owl:annotatedTarget>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_0000159">
+        <oboInOwl:hasDbXref>https://meshb.nlm.nih.gov/record/ui?ui=D001003</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_0000159"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>https://meshb.nlm.nih.gov/record/ui?ui=D001003</owl:annotatedTarget>
+        <sssom:author_id rdf:resource="https://orcid.org/0000-0001-9439-5346"/>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+        <sssom:mapping_provider>https://github.com/biopragmatics/biomappings</sssom:mapping_provider>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_0000165">
+        <oboInOwl:hasDbXref>FBbt:00003126</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_0000165"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>FBbt:00003126</owl:annotatedTarget>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_0000167">
+        <oboInOwl:hasDbXref>https://meshb.nlm.nih.gov/record/ui?ui=D009055</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_0000167"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>https://meshb.nlm.nih.gov/record/ui?ui=D009055</owl:annotatedTarget>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/LexicalMatching"/>
+        <sssom:mapping_provider>https://github.com/biopragmatics/biomappings</sssom:mapping_provider>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_0000175">
+        <oboInOwl:hasDbXref>https://meshb.nlm.nih.gov/record/ui?ui=D010996</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_0000175"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>https://meshb.nlm.nih.gov/record/ui?ui=D010996</owl:annotatedTarget>
+        <sssom:author_id rdf:resource="https://orcid.org/0000-0001-9439-5346"/>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+        <sssom:mapping_provider>https://github.com/biopragmatics/biomappings</sssom:mapping_provider>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_0000202">
+        <oboInOwl:hasDbXref>FBbt:00007091</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_0000202"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>FBbt:00007091</owl:annotatedTarget>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_0000207">
+        <oboInOwl:hasDbXref>FBbt:00004199</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_0000207"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>FBbt:00004199</owl:annotatedTarget>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_0000220">
+        <oboInOwl:hasDbXref>https://meshb.nlm.nih.gov/record/ui?ui=D001269</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_0000220"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>https://meshb.nlm.nih.gov/record/ui?ui=D001269</owl:annotatedTarget>
+        <sssom:author_id rdf:resource="https://orcid.org/0000-0001-9439-5346"/>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+        <sssom:mapping_provider>https://github.com/biopragmatics/biomappings</sssom:mapping_provider>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_0000323">
+        <oboInOwl:hasDbXref>FBbt:00005333</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_0000323"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>FBbt:00005333</owl:annotatedTarget>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_0000353">
+        <oboInOwl:hasDbXref>BTO:0000999</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>BTO:0001539</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_0000353"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>BTO:0000999</owl:annotatedTarget>
+        <sssom:author_id rdf:resource="https://orcid.org/0000-0003-4423-4370"/>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+        <sssom:mapping_provider>https://github.com/biopragmatics/biomappings</sssom:mapping_provider>
+    </owl:Axiom>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_0000353"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>BTO:0001539</owl:annotatedTarget>
+        <sssom:author_id rdf:resource="https://orcid.org/0000-0003-4423-4370"/>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+        <sssom:mapping_provider>https://github.com/biopragmatics/biomappings</sssom:mapping_provider>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_0000387">
+        <oboInOwl:hasDbXref>https://meshb.nlm.nih.gov/record/ui?ui=D000072600</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_0000387"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>https://meshb.nlm.nih.gov/record/ui?ui=D000072600</owl:annotatedTarget>
+        <sssom:author_id rdf:resource="https://orcid.org/0000-0001-9439-5346"/>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+        <sssom:mapping_provider>https://github.com/biopragmatics/biomappings</sssom:mapping_provider>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_0000463">
+        <oboInOwl:hasDbXref>FBbt:00007019</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_0000463"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>FBbt:00007019</owl:annotatedTarget>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_0000464">
+        <oboInOwl:hasDbXref>FBbt:00007017</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_0000464"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>FBbt:00007017</owl:annotatedTarget>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_0000465">
+        <oboInOwl:hasDbXref>FBbt:00007016</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_0000465"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>FBbt:00007016</owl:annotatedTarget>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_0000466">
+        <oboInOwl:hasDbXref>FBbt:00007015</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_0000466"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>FBbt:00007015</owl:annotatedTarget>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_0000467">
+        <oboInOwl:hasDbXref>FBbt:00004856</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>IDOMAL:0002460</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_0000467"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>FBbt:00004856</owl:annotatedTarget>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+    </owl:Axiom>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_0000467"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>IDOMAL:0002460</owl:annotatedTarget>
+        <sssom:author_id rdf:resource="https://orcid.org/0000-0003-4423-4370"/>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+        <sssom:mapping_provider>https://github.com/biopragmatics/biomappings</sssom:mapping_provider>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_0000468">
+        <oboInOwl:hasDbXref>FBbt:00000001</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_0000468"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>FBbt:00000001</owl:annotatedTarget>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_0000473">
+        <oboInOwl:hasDbXref>FBbt:00004928</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_0000473"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>FBbt:00004928</owl:annotatedTarget>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_0000474">
+        <oboInOwl:hasDbXref>FBbt:00004864</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_0000474"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>FBbt:00004864</owl:annotatedTarget>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_0000475">
+        <oboInOwl:hasDbXref>FBbt:00007009</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_0000475"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>FBbt:00007009</owl:annotatedTarget>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_0000476">
+        <oboInOwl:hasDbXref>FBbt:00007013</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_0000476"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>FBbt:00007013</owl:annotatedTarget>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_0000477">
+        <oboInOwl:hasDbXref>FBbt:00007277</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_0000477"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>FBbt:00007277</owl:annotatedTarget>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_0000478">
+        <oboInOwl:hasDbXref>FBbt:00005835</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_0000478"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>FBbt:00005835</owl:annotatedTarget>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_0000479">
+        <oboInOwl:hasDbXref>FBbt:00007003</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_0000479"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>FBbt:00007003</owl:annotatedTarget>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_0000480">
+        <oboInOwl:hasDbXref>IDOMAL:0002459</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_0000480"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>IDOMAL:0002459</owl:annotatedTarget>
+        <sssom:author_id rdf:resource="https://orcid.org/0000-0003-4423-4370"/>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+        <sssom:mapping_provider>https://github.com/biopragmatics/biomappings</sssom:mapping_provider>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_0000481">
+        <oboInOwl:hasDbXref>FBbt:00007010</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_0000481"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>FBbt:00007010</owl:annotatedTarget>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_0000483">
+        <oboInOwl:hasDbXref>FBbt:00007005</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_0000483"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>FBbt:00007005</owl:annotatedTarget>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_0000485">
+        <oboInOwl:hasDbXref>FBbt:00007027</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_0000485"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>FBbt:00007027</owl:annotatedTarget>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_0000569">
+        <oboInOwl:hasDbXref>https://meshb.nlm.nih.gov/record/ui?ui=D007080</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_0000569"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>https://meshb.nlm.nih.gov/record/ui?ui=D007080</owl:annotatedTarget>
+        <sssom:author_id rdf:resource="https://orcid.org/0000-0001-9439-5346"/>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+        <sssom:mapping_provider>https://github.com/biopragmatics/biomappings</sssom:mapping_provider>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_0000914">
+        <oboInOwl:hasDbXref>FBbt:00000003</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_0000914"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>FBbt:00000003</owl:annotatedTarget>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_0000920">
+        <oboInOwl:hasDbXref>FBbt:00000038</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_0000920"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>FBbt:00000038</owl:annotatedTarget>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_0000922">
+        <oboInOwl:hasDbXref>FBbt:00000052</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>IDOMAL:0000646</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_0000922"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>FBbt:00000052</owl:annotatedTarget>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+    </owl:Axiom>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_0000922"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>IDOMAL:0000646</owl:annotatedTarget>
+        <sssom:author_id rdf:resource="https://orcid.org/0000-0003-4423-4370"/>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+        <sssom:mapping_provider>https://github.com/biopragmatics/biomappings</sssom:mapping_provider>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_0000923">
+        <oboInOwl:hasDbXref>FBbt:00000110</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_0000923"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>FBbt:00000110</owl:annotatedTarget>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_0000924">
+        <oboInOwl:hasDbXref>FBbt:00000111</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_0000924"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>FBbt:00000111</owl:annotatedTarget>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_0000925">
+        <oboInOwl:hasDbXref>FBbt:00000125</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_0000925"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>FBbt:00000125</owl:annotatedTarget>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_0000926">
+        <oboInOwl:hasDbXref>FBbt:00000126</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_0000926"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>FBbt:00000126</owl:annotatedTarget>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_0000927">
+        <oboInOwl:hasDbXref>FBbt:00000136</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_0000927"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>FBbt:00000136</owl:annotatedTarget>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_0000930">
+        <oboInOwl:hasDbXref>FBbt:00000439</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_0000930"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>FBbt:00000439</owl:annotatedTarget>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_0000931">
+        <oboInOwl:hasDbXref>FBbt:00000123</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_0000931"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>FBbt:00000123</owl:annotatedTarget>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_0000934">
+        <oboInOwl:hasDbXref>FBbt:00005097</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_0000934"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>FBbt:00005097</owl:annotatedTarget>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_0000939">
+        <oboInOwl:hasDbXref>FBbt:00001761</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>https://meshb.nlm.nih.gov/record/ui?ui=D060227</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_0000939"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>FBbt:00001761</owl:annotatedTarget>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+    </owl:Axiom>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_0000939"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>https://meshb.nlm.nih.gov/record/ui?ui=D060227</owl:annotatedTarget>
+        <sssom:author_id rdf:resource="https://orcid.org/0000-0001-9439-5346"/>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+        <sssom:mapping_provider>https://github.com/biopragmatics/biomappings</sssom:mapping_provider>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_0000949">
+        <oboInOwl:hasDbXref>FBbt:00005068</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_0000949"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>FBbt:00005068</owl:annotatedTarget>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_0000955">
+        <oboInOwl:hasDbXref>FBbt:00005095</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_0000955"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>FBbt:00005095</owl:annotatedTarget>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_0000963">
+        <oboInOwl:hasDbXref>FBbt:00004114</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_0000963"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>FBbt:00004114</owl:annotatedTarget>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_0000970">
+        <oboInOwl:hasDbXref>FBbt:00005162</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_0000970"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>FBbt:00005162</owl:annotatedTarget>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_0000971">
+        <oboInOwl:hasDbXref>FBbt:00004510</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_0000971"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>FBbt:00004510</owl:annotatedTarget>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_0000972">
+        <oboInOwl:hasDbXref>FBbt:00004511</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_0000972"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>FBbt:00004511</owl:annotatedTarget>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_0000984">
+        <oboInOwl:hasDbXref>FBbt:00004729</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_0000984"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>FBbt:00004729</owl:annotatedTarget>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_0000987">
+        <oboInOwl:hasDbXref>FBbt:00004783</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_0000987"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>FBbt:00004783</owl:annotatedTarget>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_0000990">
+        <oboInOwl:hasDbXref>FBbt:00004857</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>https://meshb.nlm.nih.gov/record/ui?ui=D005835</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_0000990"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>FBbt:00004857</owl:annotatedTarget>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+    </owl:Axiom>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_0000990"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>https://meshb.nlm.nih.gov/record/ui?ui=D005835</owl:annotatedTarget>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/LexicalMatching"/>
+        <sssom:mapping_provider>https://github.com/biopragmatics/biomappings</sssom:mapping_provider>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_0000991">
+        <oboInOwl:hasDbXref>FBbt:00004858</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_0000991"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>FBbt:00004858</owl:annotatedTarget>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_0000992">
+        <oboInOwl:hasDbXref>FBbt:00004865</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_0000992"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>FBbt:00004865</owl:annotatedTarget>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_0000994">
+        <oboInOwl:hasDbXref>FBbt:00004921</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_0000994"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>FBbt:00004921</owl:annotatedTarget>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_0001001">
+        <oboInOwl:hasDbXref>FBbt:00004970</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_0001001"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>FBbt:00004970</owl:annotatedTarget>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_0001007">
+        <oboInOwl:hasDbXref>FBbt:00005055</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_0001007"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>FBbt:00005055</owl:annotatedTarget>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_0001008">
+        <oboInOwl:hasDbXref>FBbt:00005056</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_0001008"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>FBbt:00005056</owl:annotatedTarget>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_0001009">
+        <oboInOwl:hasDbXref>https://meshb.nlm.nih.gov/record/ui?ui=D002319</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_0001009"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>https://meshb.nlm.nih.gov/record/ui?ui=D002319</owl:annotatedTarget>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/LexicalMatching"/>
+        <sssom:mapping_provider>https://github.com/biopragmatics/biomappings</sssom:mapping_provider>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_0001011">
+        <oboInOwl:hasDbXref>FBbt:00005061</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_0001011"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>FBbt:00005061</owl:annotatedTarget>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_0001016">
+        <oboInOwl:hasDbXref>FBbt:00005093</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_0001016"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>FBbt:00005093</owl:annotatedTarget>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_0001017">
+        <oboInOwl:hasDbXref>FBbt:00005094</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_0001017"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>FBbt:00005094</owl:annotatedTarget>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_0001018">
+        <oboInOwl:hasDbXref>FBbt:00005100</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_0001018"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>FBbt:00005100</owl:annotatedTarget>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_0001021">
+        <oboInOwl:hasDbXref>FBbt:00005105</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_0001021"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>FBbt:00005105</owl:annotatedTarget>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_0001027">
+        <oboInOwl:hasDbXref>FBbt:00005136</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_0001027"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>FBbt:00005136</owl:annotatedTarget>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_0001032">
+        <oboInOwl:hasDbXref>FBbt:00007692</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_0001032"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>FBbt:00007692</owl:annotatedTarget>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_0001038">
+        <oboInOwl:hasDbXref>FBbt:00005215</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_0001038"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>FBbt:00005215</owl:annotatedTarget>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_0001041">
+        <oboInOwl:hasDbXref>FBbt:00005379</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_0001041"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>FBbt:00005379</owl:annotatedTarget>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_0001044">
+        <oboInOwl:hasDbXref>FBbt:00005382</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_0001044"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>FBbt:00005382</owl:annotatedTarget>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_0001045">
+        <oboInOwl:hasDbXref>FBbt:00005383</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_0001045"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>FBbt:00005383</owl:annotatedTarget>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_0001046">
+        <oboInOwl:hasDbXref>FBbt:00005384</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_0001046"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>FBbt:00005384</owl:annotatedTarget>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_0001047">
+        <oboInOwl:hasDbXref>FBbt:00005386</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_0001047"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>FBbt:00005386</owl:annotatedTarget>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_0001048">
+        <oboInOwl:hasDbXref>FBbt:00005495</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_0001048"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>FBbt:00005495</owl:annotatedTarget>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_0001049">
+        <oboInOwl:hasDbXref>https://meshb.nlm.nih.gov/record/ui?ui=D054259</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_0001049"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>https://meshb.nlm.nih.gov/record/ui?ui=D054259</owl:annotatedTarget>
+        <sssom:author_id rdf:resource="https://orcid.org/0000-0001-9439-5346"/>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+        <sssom:mapping_provider>https://github.com/biopragmatics/biomappings</sssom:mapping_provider>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_0001053">
+        <oboInOwl:hasDbXref>FBbt:00005757</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_0001053"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>FBbt:00005757</owl:annotatedTarget>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_0001054">
+        <oboInOwl:hasDbXref>FBbt:00005786</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_0001054"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>FBbt:00005786</owl:annotatedTarget>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_0001056">
+        <oboInOwl:hasDbXref>FBbt:00005799</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_0001056"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>FBbt:00005799</owl:annotatedTarget>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_0001057">
+        <oboInOwl:hasDbXref>FBbt:00005800</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_0001057"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>FBbt:00005800</owl:annotatedTarget>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_0001058">
+        <oboInOwl:hasDbXref>FBbt:00005801</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_0001058"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>FBbt:00005801</owl:annotatedTarget>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_0001059">
+        <oboInOwl:hasDbXref>FBbt:00005802</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_0001059"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>FBbt:00005802</owl:annotatedTarget>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_0001062">
+        <oboInOwl:hasDbXref>FBbt:10000000</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_0001062"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>FBbt:10000000</owl:annotatedTarget>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_0001156">
+        <oboInOwl:hasDbXref>https://meshb.nlm.nih.gov/record/ui?ui=D044682</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_0001156"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>https://meshb.nlm.nih.gov/record/ui?ui=D044682</owl:annotatedTarget>
+        <sssom:author_id rdf:resource="https://orcid.org/0000-0001-9439-5346"/>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+        <sssom:mapping_provider>https://github.com/biopragmatics/biomappings</sssom:mapping_provider>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_0001157">
+        <oboInOwl:hasDbXref>https://meshb.nlm.nih.gov/record/ui?ui=D044684</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_0001157"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>https://meshb.nlm.nih.gov/record/ui?ui=D044684</owl:annotatedTarget>
+        <sssom:author_id rdf:resource="https://orcid.org/0000-0001-9439-5346"/>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+        <sssom:mapping_provider>https://github.com/biopragmatics/biomappings</sssom:mapping_provider>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_0001158">
+        <oboInOwl:hasDbXref>https://meshb.nlm.nih.gov/record/ui?ui=D044683</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_0001158"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>https://meshb.nlm.nih.gov/record/ui?ui=D044683</owl:annotatedTarget>
+        <sssom:author_id rdf:resource="https://orcid.org/0000-0001-9439-5346"/>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+        <sssom:mapping_provider>https://github.com/biopragmatics/biomappings</sssom:mapping_provider>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_0001173">
+        <oboInOwl:hasDbXref>https://meshb.nlm.nih.gov/record/ui?ui=D001659</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_0001173"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>https://meshb.nlm.nih.gov/record/ui?ui=D001659</owl:annotatedTarget>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/LexicalMatching"/>
+        <sssom:mapping_provider>https://github.com/biopragmatics/biomappings</sssom:mapping_provider>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_0001245">
+        <oboInOwl:hasDbXref>FBbt:00047153</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_0001245"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>FBbt:00047153</owl:annotatedTarget>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_0001263">
+        <oboInOwl:hasDbXref>BTO:0000028</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_0001263"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>BTO:0000028</owl:annotatedTarget>
+        <sssom:author_id rdf:resource="https://orcid.org/0000-0003-4423-4370"/>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+        <sssom:mapping_provider>https://github.com/biopragmatics/biomappings</sssom:mapping_provider>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_0001268">
+        <oboInOwl:hasDbXref>https://meshb.nlm.nih.gov/record/ui?ui=D001202</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_0001268"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>https://meshb.nlm.nih.gov/record/ui?ui=D001202</owl:annotatedTarget>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/LexicalMatching"/>
+        <sssom:mapping_provider>https://github.com/biopragmatics/biomappings</sssom:mapping_provider>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_0001347">
+        <oboInOwl:hasDbXref>https://meshb.nlm.nih.gov/record/ui?ui=D052436</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_0001347"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>https://meshb.nlm.nih.gov/record/ui?ui=D052436</owl:annotatedTarget>
+        <sssom:author_id rdf:resource="https://orcid.org/0000-0001-9439-5346"/>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+        <sssom:mapping_provider>https://github.com/biopragmatics/biomappings</sssom:mapping_provider>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_0001377">
+        <oboInOwl:hasDbXref>https://meshb.nlm.nih.gov/record/ui?ui=D052097</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_0001377"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>https://meshb.nlm.nih.gov/record/ui?ui=D052097</owl:annotatedTarget>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/LexicalMatching"/>
+        <sssom:mapping_provider>https://github.com/biopragmatics/biomappings</sssom:mapping_provider>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_0001439">
+        <oboInOwl:hasDbXref>https://meshb.nlm.nih.gov/record/ui?ui=D000071538</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_0001439"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>https://meshb.nlm.nih.gov/record/ui?ui=D000071538</owl:annotatedTarget>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/LexicalMatching"/>
+        <sssom:mapping_provider>https://github.com/biopragmatics/biomappings</sssom:mapping_provider>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_0001473">
+        <oboInOwl:hasDbXref>https://meshb.nlm.nih.gov/record/ui?ui=D042601</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_0001473"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>https://meshb.nlm.nih.gov/record/ui?ui=D042601</owl:annotatedTarget>
+        <sssom:author_id rdf:resource="https://orcid.org/0000-0001-9439-5346"/>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+        <sssom:mapping_provider>https://github.com/biopragmatics/biomappings</sssom:mapping_provider>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_0001555">
+        <oboInOwl:hasDbXref>FBbt:00003125</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>https://meshb.nlm.nih.gov/record/ui?ui=D041981</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_0001555"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>FBbt:00003125</owl:annotatedTarget>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+    </owl:Axiom>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_0001555"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>https://meshb.nlm.nih.gov/record/ui?ui=D041981</owl:annotatedTarget>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/LexicalMatching"/>
+        <sssom:mapping_provider>https://github.com/biopragmatics/biomappings</sssom:mapping_provider>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_0001601">
+        <oboInOwl:hasDbXref>https://meshb.nlm.nih.gov/record/ui?ui=D009801</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_0001601"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>https://meshb.nlm.nih.gov/record/ui?ui=D009801</owl:annotatedTarget>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/LexicalMatching"/>
+        <sssom:mapping_provider>https://github.com/biopragmatics/biomappings</sssom:mapping_provider>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_0001642">
+        <oboInOwl:hasDbXref>https://meshb.nlm.nih.gov/record/ui?ui=D054063</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_0001642"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>https://meshb.nlm.nih.gov/record/ui?ui=D054063</owl:annotatedTarget>
+        <sssom:author_id rdf:resource="https://orcid.org/0000-0001-9439-5346"/>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+        <sssom:mapping_provider>https://github.com/biopragmatics/biomappings</sssom:mapping_provider>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_0001683">
+        <oboInOwl:hasDbXref>https://meshb.nlm.nih.gov/record/ui?ui=D015050</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_0001683"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>https://meshb.nlm.nih.gov/record/ui?ui=D015050</owl:annotatedTarget>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/LexicalMatching"/>
+        <sssom:mapping_provider>https://github.com/biopragmatics/biomappings</sssom:mapping_provider>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_0001715">
+        <oboInOwl:hasDbXref>https://meshb.nlm.nih.gov/record/ui?ui=D065838</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_0001715"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>https://meshb.nlm.nih.gov/record/ui?ui=D065838</owl:annotatedTarget>
+        <sssom:author_id rdf:resource="https://orcid.org/0000-0001-9439-5346"/>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+        <sssom:mapping_provider>https://github.com/biopragmatics/biomappings</sssom:mapping_provider>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_0001742">
+        <oboInOwl:hasDbXref>https://meshb.nlm.nih.gov/record/ui?ui=D004825</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_0001742"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>https://meshb.nlm.nih.gov/record/ui?ui=D004825</owl:annotatedTarget>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/LexicalMatching"/>
+        <sssom:mapping_provider>https://github.com/biopragmatics/biomappings</sssom:mapping_provider>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_0001797">
+        <oboInOwl:hasDbXref>https://meshb.nlm.nih.gov/record/ui?ui=D014822</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_0001797"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>https://meshb.nlm.nih.gov/record/ui?ui=D014822</owl:annotatedTarget>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/LexicalMatching"/>
+        <sssom:mapping_provider>https://github.com/biopragmatics/biomappings</sssom:mapping_provider>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_0001806">
+        <oboInOwl:hasDbXref>https://meshb.nlm.nih.gov/record/ui?ui=D005728</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_0001806"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>https://meshb.nlm.nih.gov/record/ui?ui=D005728</owl:annotatedTarget>
+        <sssom:author_id rdf:resource="https://orcid.org/0000-0001-9439-5346"/>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+        <sssom:mapping_provider>https://github.com/biopragmatics/biomappings</sssom:mapping_provider>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_0001808">
+        <oboInOwl:hasDbXref>https://meshb.nlm.nih.gov/record/ui?ui=D005726</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_0001808"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>https://meshb.nlm.nih.gov/record/ui?ui=D005726</owl:annotatedTarget>
+        <sssom:author_id rdf:resource="https://orcid.org/0000-0001-9439-5346"/>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+        <sssom:mapping_provider>https://github.com/biopragmatics/biomappings</sssom:mapping_provider>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_0001823">
+        <oboInOwl:hasDbXref>https://meshb.nlm.nih.gov/record/ui?ui=D055171</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_0001823"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>https://meshb.nlm.nih.gov/record/ui?ui=D055171</owl:annotatedTarget>
+        <sssom:author_id rdf:resource="https://orcid.org/0000-0001-9439-5346"/>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+        <sssom:mapping_provider>https://github.com/biopragmatics/biomappings</sssom:mapping_provider>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_0001856">
+        <oboInOwl:hasDbXref>https://meshb.nlm.nih.gov/record/ui?ui=D054776</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_0001856"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>https://meshb.nlm.nih.gov/record/ui?ui=D054776</owl:annotatedTarget>
+        <sssom:author_id rdf:resource="https://orcid.org/0000-0001-9439-5346"/>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+        <sssom:mapping_provider>https://github.com/biopragmatics/biomappings</sssom:mapping_provider>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_0001862">
+        <oboInOwl:hasDbXref>https://meshb.nlm.nih.gov/record/ui?ui=D014722</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_0001862"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>https://meshb.nlm.nih.gov/record/ui?ui=D014722</owl:annotatedTarget>
+        <sssom:author_id rdf:resource="https://orcid.org/0000-0001-9439-5346"/>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+        <sssom:mapping_provider>https://github.com/biopragmatics/biomappings</sssom:mapping_provider>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_0001863">
+        <oboInOwl:hasDbXref>https://meshb.nlm.nih.gov/record/ui?ui=D054738</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_0001863"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>https://meshb.nlm.nih.gov/record/ui?ui=D054738</owl:annotatedTarget>
+        <sssom:author_id rdf:resource="https://orcid.org/0000-0001-9439-5346"/>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+        <sssom:mapping_provider>https://github.com/biopragmatics/biomappings</sssom:mapping_provider>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_0001870">
+        <oboInOwl:hasDbXref>https://meshb.nlm.nih.gov/record/ui?ui=D005625</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_0001870"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>https://meshb.nlm.nih.gov/record/ui?ui=D005625</owl:annotatedTarget>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/LexicalMatching"/>
+        <sssom:mapping_provider>https://github.com/biopragmatics/biomappings</sssom:mapping_provider>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_0001907">
+        <oboInOwl:hasDbXref>https://meshb.nlm.nih.gov/record/ui?ui=D065820</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_0001907"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>https://meshb.nlm.nih.gov/record/ui?ui=D065820</owl:annotatedTarget>
+        <sssom:author_id rdf:resource="https://orcid.org/0000-0001-9439-5346"/>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+        <sssom:mapping_provider>https://github.com/biopragmatics/biomappings</sssom:mapping_provider>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_0001931">
+        <oboInOwl:hasDbXref>BTO:0006166</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_0001931"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>BTO:0006166</owl:annotatedTarget>
+        <sssom:author_id rdf:resource="https://orcid.org/0000-0003-4423-4370"/>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+        <sssom:mapping_provider>https://github.com/biopragmatics/biomappings</sssom:mapping_provider>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_0001943">
+        <oboInOwl:hasDbXref>https://meshb.nlm.nih.gov/record/ui?ui=D013681</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_0001943"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>https://meshb.nlm.nih.gov/record/ui?ui=D013681</owl:annotatedTarget>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/LexicalMatching"/>
+        <sssom:mapping_provider>https://github.com/biopragmatics/biomappings</sssom:mapping_provider>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_0001944">
+        <oboInOwl:hasDbXref>https://meshb.nlm.nih.gov/record/ui?ui=D066250</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_0001944"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>https://meshb.nlm.nih.gov/record/ui?ui=D066250</owl:annotatedTarget>
+        <sssom:author_id rdf:resource="https://orcid.org/0000-0001-9439-5346"/>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+        <sssom:mapping_provider>https://github.com/biopragmatics/biomappings</sssom:mapping_provider>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_0001947">
+        <oboInOwl:hasDbXref>BTO:0006329</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_0001947"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>BTO:0006329</owl:annotatedTarget>
+        <sssom:author_id rdf:resource="https://orcid.org/0000-0003-4423-4370"/>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+        <sssom:mapping_provider>https://github.com/biopragmatics/biomappings</sssom:mapping_provider>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_0001965">
+        <oboInOwl:hasDbXref>https://meshb.nlm.nih.gov/record/ui?ui=D065842</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_0001965"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>https://meshb.nlm.nih.gov/record/ui?ui=D065842</owl:annotatedTarget>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/LexicalMatching"/>
+        <sssom:mapping_provider>https://github.com/biopragmatics/biomappings</sssom:mapping_provider>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_0001966">
+        <oboInOwl:hasDbXref>https://meshb.nlm.nih.gov/record/ui?ui=D065841</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_0001966"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>https://meshb.nlm.nih.gov/record/ui?ui=D065841</owl:annotatedTarget>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/LexicalMatching"/>
+        <sssom:mapping_provider>https://github.com/biopragmatics/biomappings</sssom:mapping_provider>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_0001977">
+        <oboInOwl:hasDbXref>https://meshb.nlm.nih.gov/record/ui?ui=D044967</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_0001977"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>https://meshb.nlm.nih.gov/record/ui?ui=D044967</owl:annotatedTarget>
+        <sssom:author_id rdf:resource="https://orcid.org/0000-0001-9439-5346"/>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+        <sssom:mapping_provider>https://github.com/biopragmatics/biomappings</sssom:mapping_provider>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_0001995">
+        <oboInOwl:hasDbXref>https://meshb.nlm.nih.gov/record/ui?ui=D051445</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_0001995"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>https://meshb.nlm.nih.gov/record/ui?ui=D051445</owl:annotatedTarget>
+        <sssom:author_id rdf:resource="https://orcid.org/0000-0001-9439-5346"/>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+        <sssom:mapping_provider>https://github.com/biopragmatics/biomappings</sssom:mapping_provider>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_0002020">
+        <oboInOwl:hasDbXref>https://meshb.nlm.nih.gov/record/ui?ui=D066128</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_0002020"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>https://meshb.nlm.nih.gov/record/ui?ui=D066128</owl:annotatedTarget>
+        <sssom:author_id rdf:resource="https://orcid.org/0000-0001-9439-5346"/>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+        <sssom:mapping_provider>https://github.com/biopragmatics/biomappings</sssom:mapping_provider>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_0002035">
+        <oboInOwl:hasDbXref>BTO:0006167</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_0002035"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>BTO:0006167</owl:annotatedTarget>
+        <sssom:author_id rdf:resource="https://orcid.org/0000-0003-4423-4370"/>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+        <sssom:mapping_provider>https://github.com/biopragmatics/biomappings</sssom:mapping_provider>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_0002043">
+        <oboInOwl:hasDbXref>https://meshb.nlm.nih.gov/record/ui?ui=D065847</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_0002043"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>https://meshb.nlm.nih.gov/record/ui?ui=D065847</owl:annotatedTarget>
+        <sssom:author_id rdf:resource="https://orcid.org/0000-0001-9439-5346"/>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+        <sssom:mapping_provider>https://github.com/biopragmatics/biomappings</sssom:mapping_provider>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_0002050">
+        <oboInOwl:hasDbXref>FBbt:00004208</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_0002050"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>FBbt:00004208</owl:annotatedTarget>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_0002062">
+        <oboInOwl:hasDbXref>https://meshb.nlm.nih.gov/record/ui?ui=D054089</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_0002062"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>https://meshb.nlm.nih.gov/record/ui?ui=D054089</owl:annotatedTarget>
+        <sssom:author_id rdf:resource="https://orcid.org/0000-0001-9439-5346"/>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+        <sssom:mapping_provider>https://github.com/biopragmatics/biomappings</sssom:mapping_provider>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_0002072">
+        <oboInOwl:hasDbXref>https://meshb.nlm.nih.gov/record/ui?ui=D040521</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_0002072"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>https://meshb.nlm.nih.gov/record/ui?ui=D040521</owl:annotatedTarget>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/LexicalMatching"/>
+        <sssom:mapping_provider>https://github.com/biopragmatics/biomappings</sssom:mapping_provider>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_0002090">
+        <oboInOwl:hasDbXref>https://meshb.nlm.nih.gov/record/ui?ui=D013131</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_0002090"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>https://meshb.nlm.nih.gov/record/ui?ui=D013131</owl:annotatedTarget>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/LexicalMatching"/>
+        <sssom:mapping_provider>https://github.com/biopragmatics/biomappings</sssom:mapping_provider>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_0002101">
+        <oboInOwl:hasDbXref>https://meshb.nlm.nih.gov/record/ui?ui=D005121</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_0002101"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>https://meshb.nlm.nih.gov/record/ui?ui=D005121</owl:annotatedTarget>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/LexicalMatching"/>
+        <sssom:mapping_provider>https://github.com/biopragmatics/biomappings</sssom:mapping_provider>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_0002120">
+        <oboInOwl:hasDbXref>https://meshb.nlm.nih.gov/record/ui?ui=D060910</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_0002120"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>https://meshb.nlm.nih.gov/record/ui?ui=D060910</owl:annotatedTarget>
+        <sssom:author_id rdf:resource="https://orcid.org/0000-0001-9439-5346"/>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+        <sssom:mapping_provider>https://github.com/biopragmatics/biomappings</sssom:mapping_provider>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_0002128">
+        <oboInOwl:hasDbXref>https://meshb.nlm.nih.gov/record/ui?ui=D065832</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_0002128"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>https://meshb.nlm.nih.gov/record/ui?ui=D065832</owl:annotatedTarget>
+        <sssom:author_id rdf:resource="https://orcid.org/0000-0001-9439-5346"/>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+        <sssom:mapping_provider>https://github.com/biopragmatics/biomappings</sssom:mapping_provider>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_0002141">
+        <oboInOwl:hasDbXref>https://meshb.nlm.nih.gov/record/ui?ui=D065839</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_0002141"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>https://meshb.nlm.nih.gov/record/ui?ui=D065839</owl:annotatedTarget>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/LexicalMatching"/>
+        <sssom:mapping_provider>https://github.com/biopragmatics/biomappings</sssom:mapping_provider>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_0002142">
+        <oboInOwl:hasDbXref>https://meshb.nlm.nih.gov/record/ui?ui=D045042</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_0002142"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>https://meshb.nlm.nih.gov/record/ui?ui=D045042</owl:annotatedTarget>
+        <sssom:author_id rdf:resource="https://orcid.org/0000-0003-4423-4370"/>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+        <sssom:mapping_provider>https://github.com/biopragmatics/biomappings</sssom:mapping_provider>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_0002145">
+        <oboInOwl:hasDbXref>https://meshb.nlm.nih.gov/record/ui?ui=D066268</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_0002145"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>https://meshb.nlm.nih.gov/record/ui?ui=D066268</owl:annotatedTarget>
+        <sssom:author_id rdf:resource="https://orcid.org/0000-0001-9439-5346"/>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+        <sssom:mapping_provider>https://github.com/biopragmatics/biomappings</sssom:mapping_provider>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_0002152">
+        <oboInOwl:hasDbXref>https://meshb.nlm.nih.gov/record/ui?ui=D065837</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_0002152"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>https://meshb.nlm.nih.gov/record/ui?ui=D065837</owl:annotatedTarget>
+        <sssom:author_id rdf:resource="https://orcid.org/0000-0001-9439-5346"/>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+        <sssom:mapping_provider>https://github.com/biopragmatics/biomappings</sssom:mapping_provider>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_0002156">
+        <oboInOwl:hasDbXref>https://meshb.nlm.nih.gov/record/ui?ui=D065846</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_0002156"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>https://meshb.nlm.nih.gov/record/ui?ui=D065846</owl:annotatedTarget>
+        <sssom:author_id rdf:resource="https://orcid.org/0000-0001-9439-5346"/>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+        <sssom:mapping_provider>https://github.com/biopragmatics/biomappings</sssom:mapping_provider>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_0002157">
+        <oboInOwl:hasDbXref>https://meshb.nlm.nih.gov/record/ui?ui=D065848</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_0002157"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>https://meshb.nlm.nih.gov/record/ui?ui=D065848</owl:annotatedTarget>
+        <sssom:author_id rdf:resource="https://orcid.org/0000-0001-9439-5346"/>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+        <sssom:mapping_provider>https://github.com/biopragmatics/biomappings</sssom:mapping_provider>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_0002186">
+        <oboInOwl:hasDbXref>https://meshb.nlm.nih.gov/record/ui?ui=D055745</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_0002186"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>https://meshb.nlm.nih.gov/record/ui?ui=D055745</owl:annotatedTarget>
+        <sssom:author_id rdf:resource="https://orcid.org/0000-0001-9439-5346"/>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+        <sssom:mapping_provider>https://github.com/biopragmatics/biomappings</sssom:mapping_provider>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_0002190">
+        <oboInOwl:hasDbXref>https://meshb.nlm.nih.gov/record/ui?ui=D015434</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_0002190"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>https://meshb.nlm.nih.gov/record/ui?ui=D015434</owl:annotatedTarget>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/LexicalMatching"/>
+        <sssom:mapping_provider>https://github.com/biopragmatics/biomappings</sssom:mapping_provider>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_0002207">
+        <oboInOwl:hasDbXref>https://meshb.nlm.nih.gov/record/ui?ui=D014989</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_0002207"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>https://meshb.nlm.nih.gov/record/ui?ui=D014989</owl:annotatedTarget>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/LexicalMatching"/>
+        <sssom:mapping_provider>https://github.com/biopragmatics/biomappings</sssom:mapping_provider>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_0002219">
+        <oboInOwl:hasDbXref>BTO:0006266</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_0002219"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>BTO:0006266</owl:annotatedTarget>
+        <sssom:author_id rdf:resource="https://orcid.org/0000-0003-4423-4370"/>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+        <sssom:mapping_provider>https://github.com/biopragmatics/biomappings</sssom:mapping_provider>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_0002228">
+        <oboInOwl:hasDbXref>VO:0012403</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_0002228"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>VO:0012403</owl:annotatedTarget>
+        <sssom:author_id rdf:resource="https://orcid.org/0000-0003-4423-4370"/>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+        <sssom:mapping_provider>https://github.com/biopragmatics/biomappings</sssom:mapping_provider>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_0002236">
+        <oboInOwl:hasDbXref>https://meshb.nlm.nih.gov/record/ui?ui=D066186</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_0002236"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>https://meshb.nlm.nih.gov/record/ui?ui=D066186</owl:annotatedTarget>
+        <sssom:author_id rdf:resource="https://orcid.org/0000-0001-9439-5346"/>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+        <sssom:mapping_provider>https://github.com/biopragmatics/biomappings</sssom:mapping_provider>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_0002242">
+        <oboInOwl:hasDbXref>https://meshb.nlm.nih.gov/record/ui?ui=D000070614</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_0002242"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>https://meshb.nlm.nih.gov/record/ui?ui=D000070614</owl:annotatedTarget>
+        <sssom:author_id rdf:resource="https://orcid.org/0000-0001-9439-5346"/>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+        <sssom:mapping_provider>https://github.com/biopragmatics/biomappings</sssom:mapping_provider>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_0002262">
+        <oboInOwl:hasDbXref>BTO:0006296</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_0002262"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>BTO:0006296</owl:annotatedTarget>
+        <sssom:author_id rdf:resource="https://orcid.org/0000-0003-4423-4370"/>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+        <sssom:mapping_provider>https://github.com/biopragmatics/biomappings</sssom:mapping_provider>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_0002268">
+        <oboInOwl:hasDbXref>FBbt:00005158</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_0002268"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>FBbt:00005158</owl:annotatedTarget>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_0002295">
+        <oboInOwl:hasDbXref>https://meshb.nlm.nih.gov/record/ui?ui=D003053</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_0002295"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>https://meshb.nlm.nih.gov/record/ui?ui=D003053</owl:annotatedTarget>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/LexicalMatching"/>
+        <sssom:mapping_provider>https://github.com/biopragmatics/biomappings</sssom:mapping_provider>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_0002316">
+        <oboInOwl:hasDbXref>https://meshb.nlm.nih.gov/record/ui?ui=D066127</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_0002316"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>https://meshb.nlm.nih.gov/record/ui?ui=D066127</owl:annotatedTarget>
+        <sssom:author_id rdf:resource="https://orcid.org/0000-0001-9439-5346"/>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+        <sssom:mapping_provider>https://github.com/biopragmatics/biomappings</sssom:mapping_provider>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_0002323">
+        <oboInOwl:hasDbXref>FBbt:00005060</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_0002323"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>FBbt:00005060</owl:annotatedTarget>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_0002346">
+        <oboInOwl:hasDbXref>FBbt:00001057</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_0002346"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>FBbt:00001057</owl:annotatedTarget>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_0002373">
+        <oboInOwl:hasDbXref>https://meshb.nlm.nih.gov/record/ui?ui=D014066</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_0002373"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>https://meshb.nlm.nih.gov/record/ui?ui=D014066</owl:annotatedTarget>
+        <sssom:author_id rdf:resource="https://orcid.org/0000-0001-9439-5346"/>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+        <sssom:mapping_provider>https://github.com/biopragmatics/biomappings</sssom:mapping_provider>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_0002393">
+        <oboInOwl:hasDbXref>https://meshb.nlm.nih.gov/record/ui?ui=D005064</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_0002393"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>https://meshb.nlm.nih.gov/record/ui?ui=D005064</owl:annotatedTarget>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/LexicalMatching"/>
+        <sssom:mapping_provider>https://github.com/biopragmatics/biomappings</sssom:mapping_provider>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_0002396">
+        <oboInOwl:hasDbXref>https://meshb.nlm.nih.gov/record/ui?ui=D055172</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_0002396"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>https://meshb.nlm.nih.gov/record/ui?ui=D055172</owl:annotatedTarget>
+        <sssom:author_id rdf:resource="https://orcid.org/0000-0001-9439-5346"/>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+        <sssom:mapping_provider>https://github.com/biopragmatics/biomappings</sssom:mapping_provider>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_0002409">
+        <oboInOwl:hasDbXref>https://meshb.nlm.nih.gov/record/ui?ui=D000069236</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_0002409"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>https://meshb.nlm.nih.gov/record/ui?ui=D000069236</owl:annotatedTarget>
+        <sssom:author_id rdf:resource="https://orcid.org/0000-0001-9439-5346"/>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+        <sssom:mapping_provider>https://github.com/biopragmatics/biomappings</sssom:mapping_provider>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_0002410">
+        <oboInOwl:hasDbXref>IDOMAL:0002126</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_0002410"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>IDOMAL:0002126</owl:annotatedTarget>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/LexicalMatching"/>
+        <sssom:mapping_provider>https://github.com/biopragmatics/biomappings</sssom:mapping_provider>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_0002412">
+        <oboInOwl:hasDbXref>BTO:0006196</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_0002412"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>BTO:0006196</owl:annotatedTarget>
+        <sssom:author_id rdf:resource="https://orcid.org/0000-0003-4423-4370"/>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+        <sssom:mapping_provider>https://github.com/biopragmatics/biomappings</sssom:mapping_provider>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_0002416">
+        <oboInOwl:hasDbXref>FBbt:00004969</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_0002416"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>FBbt:00004969</owl:annotatedTarget>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_0002430">
+        <oboInOwl:hasDbXref>BTO:0006481</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_0002430"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>BTO:0006481</owl:annotatedTarget>
+        <sssom:author_id rdf:resource="https://orcid.org/0000-0003-4423-4370"/>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+        <sssom:mapping_provider>https://github.com/biopragmatics/biomappings</sssom:mapping_provider>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_0002469">
+        <oboInOwl:hasDbXref>https://meshb.nlm.nih.gov/record/ui?ui=D000071041</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_0002469"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>https://meshb.nlm.nih.gov/record/ui?ui=D000071041</owl:annotatedTarget>
+        <sssom:author_id rdf:resource="https://orcid.org/0000-0001-9439-5346"/>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+        <sssom:mapping_provider>https://github.com/biopragmatics/biomappings</sssom:mapping_provider>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_0002493">
+        <oboInOwl:hasDbXref>https://meshb.nlm.nih.gov/record/ui?ui=D055988</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_0002493"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>https://meshb.nlm.nih.gov/record/ui?ui=D055988</owl:annotatedTarget>
+        <sssom:author_id rdf:resource="https://orcid.org/0000-0001-9439-5346"/>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+        <sssom:mapping_provider>https://github.com/biopragmatics/biomappings</sssom:mapping_provider>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_0002530">
+        <oboInOwl:hasDbXref>FBbt:00100317</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_0002530"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>FBbt:00100317</owl:annotatedTarget>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_0002536">
+        <oboInOwl:hasDbXref>FBbt:00007152</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_0002536"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>FBbt:00007152</owl:annotatedTarget>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_0002540">
+        <oboInOwl:hasDbXref>https://meshb.nlm.nih.gov/record/ui?ui=D053403</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_0002540"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>https://meshb.nlm.nih.gov/record/ui?ui=D053403</owl:annotatedTarget>
+        <sssom:author_id rdf:resource="https://orcid.org/0000-0001-9439-5346"/>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+        <sssom:mapping_provider>https://github.com/biopragmatics/biomappings</sssom:mapping_provider>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_0002548">
+        <oboInOwl:hasDbXref>FBbt:00001727</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>https://meshb.nlm.nih.gov/record/ui?ui=D007814</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_0002548"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>FBbt:00001727</owl:annotatedTarget>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+    </owl:Axiom>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_0002548"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>https://meshb.nlm.nih.gov/record/ui?ui=D007814</owl:annotatedTarget>
+        <sssom:author_id rdf:resource="https://orcid.org/0000-0001-9439-5346"/>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+        <sssom:mapping_provider>https://github.com/biopragmatics/biomappings</sssom:mapping_provider>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_0002600">
+        <oboInOwl:hasDbXref>https://meshb.nlm.nih.gov/record/ui?ui=D065726</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_0002600"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>https://meshb.nlm.nih.gov/record/ui?ui=D065726</owl:annotatedTarget>
+        <sssom:author_id rdf:resource="https://orcid.org/0000-0001-9439-5346"/>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+        <sssom:mapping_provider>https://github.com/biopragmatics/biomappings</sssom:mapping_provider>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_0002606">
+        <oboInOwl:hasDbXref>FBbt:00005139</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_0002606"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>FBbt:00005139</owl:annotatedTarget>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_0002623">
+        <oboInOwl:hasDbXref>https://meshb.nlm.nih.gov/record/ui?ui=D065850</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_0002623"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>https://meshb.nlm.nih.gov/record/ui?ui=D065850</owl:annotatedTarget>
+        <sssom:author_id rdf:resource="https://orcid.org/0000-0001-9439-5346"/>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+        <sssom:mapping_provider>https://github.com/biopragmatics/biomappings</sssom:mapping_provider>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_0002625">
+        <oboInOwl:hasDbXref>BTO:0006168</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_0002625"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>BTO:0006168</owl:annotatedTarget>
+        <sssom:author_id rdf:resource="https://orcid.org/0000-0003-4423-4370"/>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+        <sssom:mapping_provider>https://github.com/biopragmatics/biomappings</sssom:mapping_provider>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_0002631">
+        <oboInOwl:hasDbXref>https://meshb.nlm.nih.gov/record/ui?ui=D065843</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_0002631"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>https://meshb.nlm.nih.gov/record/ui?ui=D065843</owl:annotatedTarget>
+        <sssom:author_id rdf:resource="https://orcid.org/0000-0001-9439-5346"/>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+        <sssom:mapping_provider>https://github.com/biopragmatics/biomappings</sssom:mapping_provider>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_0002633">
+        <oboInOwl:hasDbXref>https://meshb.nlm.nih.gov/record/ui?ui=D066266</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_0002633"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>https://meshb.nlm.nih.gov/record/ui?ui=D066266</owl:annotatedTarget>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/LexicalMatching"/>
+        <sssom:mapping_provider>https://github.com/biopragmatics/biomappings</sssom:mapping_provider>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_0002639">
+        <oboInOwl:hasDbXref>https://meshb.nlm.nih.gov/record/ui?ui=D066265</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_0002639"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>https://meshb.nlm.nih.gov/record/ui?ui=D066265</owl:annotatedTarget>
+        <sssom:author_id rdf:resource="https://orcid.org/0000-0001-9439-5346"/>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+        <sssom:mapping_provider>https://github.com/biopragmatics/biomappings</sssom:mapping_provider>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_0002682">
+        <oboInOwl:hasDbXref>https://meshb.nlm.nih.gov/record/ui?ui=D065827</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_0002682"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>https://meshb.nlm.nih.gov/record/ui?ui=D065827</owl:annotatedTarget>
+        <sssom:author_id rdf:resource="https://orcid.org/0000-0001-9439-5346"/>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+        <sssom:mapping_provider>https://github.com/biopragmatics/biomappings</sssom:mapping_provider>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_0002684">
+        <oboInOwl:hasDbXref>https://meshb.nlm.nih.gov/record/ui?ui=D065849</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_0002684"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>https://meshb.nlm.nih.gov/record/ui?ui=D065849</owl:annotatedTarget>
+        <sssom:author_id rdf:resource="https://orcid.org/0000-0001-9439-5346"/>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+        <sssom:mapping_provider>https://github.com/biopragmatics/biomappings</sssom:mapping_provider>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_0002689">
+        <oboInOwl:hasDbXref>BTO:0006268</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>https://meshb.nlm.nih.gov/record/ui?ui=D066278</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_0002689"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>BTO:0006268</owl:annotatedTarget>
+        <sssom:author_id rdf:resource="https://orcid.org/0000-0003-4423-4370"/>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+        <sssom:mapping_provider>https://github.com/biopragmatics/biomappings</sssom:mapping_provider>
+    </owl:Axiom>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_0002689"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>https://meshb.nlm.nih.gov/record/ui?ui=D066278</owl:annotatedTarget>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/LexicalMatching"/>
+        <sssom:mapping_provider>https://github.com/biopragmatics/biomappings</sssom:mapping_provider>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_0002704">
+        <oboInOwl:hasDbXref>https://meshb.nlm.nih.gov/record/ui?ui=D005829</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_0002704"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>https://meshb.nlm.nih.gov/record/ui?ui=D005829</owl:annotatedTarget>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/LexicalMatching"/>
+        <sssom:mapping_provider>https://github.com/biopragmatics/biomappings</sssom:mapping_provider>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_0002705">
+        <oboInOwl:hasDbXref>https://meshb.nlm.nih.gov/record/ui?ui=D020644</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_0002705"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>https://meshb.nlm.nih.gov/record/ui?ui=D020644</owl:annotatedTarget>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/LexicalMatching"/>
+        <sssom:mapping_provider>https://github.com/biopragmatics/biomappings</sssom:mapping_provider>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_0002707">
+        <oboInOwl:hasDbXref>BTO:0006132</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_0002707"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>BTO:0006132</owl:annotatedTarget>
+        <sssom:author_id rdf:resource="https://orcid.org/0000-0003-4423-4370"/>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+        <sssom:mapping_provider>https://github.com/biopragmatics/biomappings</sssom:mapping_provider>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_0002714">
+        <oboInOwl:hasDbXref>BTO:0006159</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_0002714"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>BTO:0006159</owl:annotatedTarget>
+        <sssom:author_id rdf:resource="https://orcid.org/0000-0003-4423-4370"/>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+        <sssom:mapping_provider>https://github.com/biopragmatics/biomappings</sssom:mapping_provider>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_0002726">
+        <oboInOwl:hasDbXref>https://meshb.nlm.nih.gov/record/ui?ui=D066193</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_0002726"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>https://meshb.nlm.nih.gov/record/ui?ui=D066193</owl:annotatedTarget>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/LexicalMatching"/>
+        <sssom:mapping_provider>https://github.com/biopragmatics/biomappings</sssom:mapping_provider>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_0002743">
+        <oboInOwl:hasDbXref>https://meshb.nlm.nih.gov/record/ui?ui=D066187</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_0002743"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>https://meshb.nlm.nih.gov/record/ui?ui=D066187</owl:annotatedTarget>
+        <sssom:author_id rdf:resource="https://orcid.org/0000-0001-9439-5346"/>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+        <sssom:mapping_provider>https://github.com/biopragmatics/biomappings</sssom:mapping_provider>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_0002751">
+        <oboInOwl:hasDbXref>BTO:0006175</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_0002751"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>BTO:0006175</owl:annotatedTarget>
+        <sssom:author_id rdf:resource="https://orcid.org/0000-0003-4423-4370"/>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+        <sssom:mapping_provider>https://github.com/biopragmatics/biomappings</sssom:mapping_provider>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_0002752">
+        <oboInOwl:hasDbXref>BTO:0006157</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_0002752"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>BTO:0006157</owl:annotatedTarget>
+        <sssom:author_id rdf:resource="https://orcid.org/0000-0003-4423-4370"/>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+        <sssom:mapping_provider>https://github.com/biopragmatics/biomappings</sssom:mapping_provider>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_0002754">
+        <oboInOwl:hasDbXref>https://meshb.nlm.nih.gov/record/ui?ui=D065844</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_0002754"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>https://meshb.nlm.nih.gov/record/ui?ui=D065844</owl:annotatedTarget>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/LexicalMatching"/>
+        <sssom:mapping_provider>https://github.com/biopragmatics/biomappings</sssom:mapping_provider>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_0002769">
+        <oboInOwl:hasDbXref>BTO:0006177</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_0002769"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>BTO:0006177</owl:annotatedTarget>
+        <sssom:author_id rdf:resource="https://orcid.org/0000-0003-4423-4370"/>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+        <sssom:mapping_provider>https://github.com/biopragmatics/biomappings</sssom:mapping_provider>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_0002771">
+        <oboInOwl:hasDbXref>BTO:0006176</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_0002771"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>BTO:0006176</owl:annotatedTarget>
+        <sssom:author_id rdf:resource="https://orcid.org/0000-0003-4423-4370"/>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+        <sssom:mapping_provider>https://github.com/biopragmatics/biomappings</sssom:mapping_provider>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_0002776">
+        <oboInOwl:hasDbXref>https://meshb.nlm.nih.gov/record/ui?ui=D020651</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_0002776"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>https://meshb.nlm.nih.gov/record/ui?ui=D020651</owl:annotatedTarget>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/LexicalMatching"/>
+        <sssom:mapping_provider>https://github.com/biopragmatics/biomappings</sssom:mapping_provider>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_0002883">
+        <oboInOwl:hasDbXref>https://meshb.nlm.nih.gov/record/ui?ui=D066274</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_0002883"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>https://meshb.nlm.nih.gov/record/ui?ui=D066274</owl:annotatedTarget>
+        <sssom:author_id rdf:resource="https://orcid.org/0000-0001-9439-5346"/>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+        <sssom:mapping_provider>https://github.com/biopragmatics/biomappings</sssom:mapping_provider>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_0002895">
+        <oboInOwl:hasDbXref>https://meshb.nlm.nih.gov/record/ui?ui=D018728</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_0002895"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>https://meshb.nlm.nih.gov/record/ui?ui=D018728</owl:annotatedTarget>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/LexicalMatching"/>
+        <sssom:mapping_provider>https://github.com/biopragmatics/biomappings</sssom:mapping_provider>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_0002932">
+        <oboInOwl:hasDbXref>https://meshb.nlm.nih.gov/record/ui?ui=D065833</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_0002932"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>https://meshb.nlm.nih.gov/record/ui?ui=D065833</owl:annotatedTarget>
+        <sssom:author_id rdf:resource="https://orcid.org/0000-0001-9439-5346"/>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+        <sssom:mapping_provider>https://github.com/biopragmatics/biomappings</sssom:mapping_provider>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_0002967">
+        <oboInOwl:hasDbXref>https://meshb.nlm.nih.gov/record/ui?ui=D006179</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_0002967"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>https://meshb.nlm.nih.gov/record/ui?ui=D006179</owl:annotatedTarget>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/LexicalMatching"/>
+        <sssom:mapping_provider>https://github.com/biopragmatics/biomappings</sssom:mapping_provider>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_0003023">
+        <oboInOwl:hasDbXref>https://meshb.nlm.nih.gov/record/ui?ui=D065821</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_0003023"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>https://meshb.nlm.nih.gov/record/ui?ui=D065821</owl:annotatedTarget>
+        <sssom:author_id rdf:resource="https://orcid.org/0000-0001-9439-5346"/>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+        <sssom:mapping_provider>https://github.com/biopragmatics/biomappings</sssom:mapping_provider>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_0003044">
+        <oboInOwl:hasDbXref>https://meshb.nlm.nih.gov/record/ui?ui=D000083382</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_0003044"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>https://meshb.nlm.nih.gov/record/ui?ui=D000083382</owl:annotatedTarget>
+        <sssom:author_id rdf:resource="https://orcid.org/0000-0001-9439-5346"/>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+        <sssom:mapping_provider>https://github.com/biopragmatics/biomappings</sssom:mapping_provider>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_0003050">
+        <oboInOwl:hasDbXref>BTO:0006222</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_0003050"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>BTO:0006222</owl:annotatedTarget>
+        <sssom:author_id rdf:resource="https://orcid.org/0000-0003-4423-4370"/>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+        <sssom:mapping_provider>https://github.com/biopragmatics/biomappings</sssom:mapping_provider>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_0003055">
+        <oboInOwl:hasDbXref>BTO:0003377</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_0003055"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>BTO:0003377</owl:annotatedTarget>
+        <sssom:author_id rdf:resource="https://orcid.org/0000-0003-4423-4370"/>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+        <sssom:mapping_provider>https://github.com/biopragmatics/biomappings</sssom:mapping_provider>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_0003060">
+        <oboInOwl:hasDbXref>BTO:0005991</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_0003060"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>BTO:0005991</owl:annotatedTarget>
+        <sssom:author_id rdf:resource="https://orcid.org/0000-0003-4423-4370"/>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+        <sssom:mapping_provider>https://github.com/biopragmatics/biomappings</sssom:mapping_provider>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_0003074">
+        <oboInOwl:hasDbXref>BTO:0005990</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_0003074"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>BTO:0005990</owl:annotatedTarget>
+        <sssom:author_id rdf:resource="https://orcid.org/0000-0003-4423-4370"/>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+        <sssom:mapping_provider>https://github.com/biopragmatics/biomappings</sssom:mapping_provider>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_0003075">
+        <oboInOwl:hasDbXref>https://meshb.nlm.nih.gov/record/ui?ui=D054258</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_0003075"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>https://meshb.nlm.nih.gov/record/ui?ui=D054258</owl:annotatedTarget>
+        <sssom:author_id rdf:resource="https://orcid.org/0000-0001-9439-5346"/>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+        <sssom:mapping_provider>https://github.com/biopragmatics/biomappings</sssom:mapping_provider>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_0003089">
+        <oboInOwl:hasDbXref>BTO:0006255</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_0003089"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>BTO:0006255</owl:annotatedTarget>
+        <sssom:author_id rdf:resource="https://orcid.org/0000-0003-4423-4370"/>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+        <sssom:mapping_provider>https://github.com/biopragmatics/biomappings</sssom:mapping_provider>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_0003100">
+        <oboInOwl:hasDbXref>FBbt:00007011</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_0003100"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>FBbt:00007011</owl:annotatedTarget>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_0003101">
+        <oboInOwl:hasDbXref>FBbt:00007004</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_0003101"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>FBbt:00007004</owl:annotatedTarget>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_0003125">
+        <oboInOwl:hasDbXref>FBbt:00000042</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_0003125"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>FBbt:00000042</owl:annotatedTarget>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_0003128">
+        <oboInOwl:hasDbXref>https://meshb.nlm.nih.gov/record/ui?ui=D012886</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_0003128"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>https://meshb.nlm.nih.gov/record/ui?ui=D012886</owl:annotatedTarget>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/LexicalMatching"/>
+        <sssom:mapping_provider>https://github.com/biopragmatics/biomappings</sssom:mapping_provider>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_0003130">
+        <oboInOwl:hasDbXref>FBbt:00004557</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_0003130"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>FBbt:00004557</owl:annotatedTarget>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_0003131">
+        <oboInOwl:hasDbXref>FBbt:00004642</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_0003131"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>FBbt:00004642</owl:annotatedTarget>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_0003142">
+        <oboInOwl:hasDbXref>FBbt:00002952</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_0003142"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>FBbt:00002952</owl:annotatedTarget>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_0003143">
+        <oboInOwl:hasDbXref>FBbt:00002953</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>https://meshb.nlm.nih.gov/record/ui?ui=D011679</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_0003143"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>FBbt:00002953</owl:annotatedTarget>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+    </owl:Axiom>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_0003143"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>https://meshb.nlm.nih.gov/record/ui?ui=D011679</owl:annotatedTarget>
+        <sssom:author_id rdf:resource="https://orcid.org/0000-0001-9439-5346"/>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+        <sssom:mapping_provider>https://github.com/biopragmatics/biomappings</sssom:mapping_provider>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_0003153">
+        <oboInOwl:hasDbXref>FBbt:00004482</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_0003153"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>FBbt:00004482</owl:annotatedTarget>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_0003155">
+        <oboInOwl:hasDbXref>FBbt:00004492</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_0003155"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>FBbt:00004492</owl:annotatedTarget>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_0003161">
+        <oboInOwl:hasDbXref>FBbt:00004505</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_0003161"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>FBbt:00004505</owl:annotatedTarget>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_0003162">
+        <oboInOwl:hasDbXref>FBbt:00004506</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_0003162"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>FBbt:00004506</owl:annotatedTarget>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_0003194">
+        <oboInOwl:hasDbXref>FBbt:00004751</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_0003194"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>FBbt:00004751</owl:annotatedTarget>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_0003199">
+        <oboInOwl:hasDbXref>FBbt:00004894</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_0003199"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>FBbt:00004894</owl:annotatedTarget>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_0003201">
+        <oboInOwl:hasDbXref>FBbt:00004973</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_0003201"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>FBbt:00004973</owl:annotatedTarget>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_0003202">
+        <oboInOwl:hasDbXref>FBbt:00004974</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_0003202"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>FBbt:00004974</owl:annotatedTarget>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_0003209">
+        <oboInOwl:hasDbXref>https://meshb.nlm.nih.gov/record/ui?ui=D049428</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_0003209"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>https://meshb.nlm.nih.gov/record/ui?ui=D049428</owl:annotatedTarget>
+        <sssom:author_id rdf:resource="https://orcid.org/0000-0001-9439-5346"/>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+        <sssom:mapping_provider>https://github.com/biopragmatics/biomappings</sssom:mapping_provider>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_0003211">
+        <oboInOwl:hasDbXref>FBbt:00004507</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_0003211"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>FBbt:00004507</owl:annotatedTarget>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_0003212">
+        <oboInOwl:hasDbXref>FBbt:00005159</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_0003212"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>FBbt:00005159</owl:annotatedTarget>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_0003460">
+        <oboInOwl:hasDbXref>https://meshb.nlm.nih.gov/record/ui?ui=D050280</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_0003460"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>https://meshb.nlm.nih.gov/record/ui?ui=D050280</owl:annotatedTarget>
+        <sssom:author_id rdf:resource="https://orcid.org/0000-0001-9439-5346"/>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+        <sssom:mapping_provider>https://github.com/biopragmatics/biomappings</sssom:mapping_provider>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_0003462">
+        <oboInOwl:hasDbXref>https://meshb.nlm.nih.gov/record/ui?ui=D005147</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_0003462"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>https://meshb.nlm.nih.gov/record/ui?ui=D005147</owl:annotatedTarget>
+        <sssom:author_id rdf:resource="https://orcid.org/0000-0001-9439-5346"/>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+        <sssom:mapping_provider>https://github.com/biopragmatics/biomappings</sssom:mapping_provider>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_0003679">
+        <oboInOwl:hasDbXref>BTO:0006184</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_0003679"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>BTO:0006184</owl:annotatedTarget>
+        <sssom:author_id rdf:resource="https://orcid.org/0000-0003-4423-4370"/>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+        <sssom:mapping_provider>https://github.com/biopragmatics/biomappings</sssom:mapping_provider>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_0003687">
+        <oboInOwl:hasDbXref>BTO:0006035</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_0003687"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>BTO:0006035</owl:annotatedTarget>
+        <sssom:author_id rdf:resource="https://orcid.org/0000-0003-4423-4370"/>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+        <sssom:mapping_provider>https://github.com/biopragmatics/biomappings</sssom:mapping_provider>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_0003823">
+        <oboInOwl:hasDbXref>VO:0010971</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_0003823"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>VO:0010971</owl:annotatedTarget>
+        <sssom:author_id rdf:resource="https://orcid.org/0000-0003-4423-4370"/>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+        <sssom:mapping_provider>https://github.com/biopragmatics/biomappings</sssom:mapping_provider>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_0003881">
+        <oboInOwl:hasDbXref>https://meshb.nlm.nih.gov/record/ui?ui=D056547</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_0003881"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>https://meshb.nlm.nih.gov/record/ui?ui=D056547</owl:annotatedTarget>
+        <sssom:author_id rdf:resource="https://orcid.org/0000-0001-9439-5346"/>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+        <sssom:mapping_provider>https://github.com/biopragmatics/biomappings</sssom:mapping_provider>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_0003882">
+        <oboInOwl:hasDbXref>https://meshb.nlm.nih.gov/record/ui?ui=D056651</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_0003882"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>https://meshb.nlm.nih.gov/record/ui?ui=D056651</owl:annotatedTarget>
+        <sssom:author_id rdf:resource="https://orcid.org/0000-0001-9439-5346"/>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+        <sssom:mapping_provider>https://github.com/biopragmatics/biomappings</sssom:mapping_provider>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_0003883">
+        <oboInOwl:hasDbXref>https://meshb.nlm.nih.gov/record/ui?ui=D056654</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_0003883"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>https://meshb.nlm.nih.gov/record/ui?ui=D056654</owl:annotatedTarget>
+        <sssom:author_id rdf:resource="https://orcid.org/0000-0001-9439-5346"/>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+        <sssom:mapping_provider>https://github.com/biopragmatics/biomappings</sssom:mapping_provider>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_0003911">
+        <oboInOwl:hasDbXref>BTO:0006008</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_0003911"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>BTO:0006008</owl:annotatedTarget>
+        <sssom:author_id rdf:resource="https://orcid.org/0000-0003-4423-4370"/>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+        <sssom:mapping_provider>https://github.com/biopragmatics/biomappings</sssom:mapping_provider>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_0003914">
+        <oboInOwl:hasDbXref>FBbt:00007474</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_0003914"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>FBbt:00007474</owl:annotatedTarget>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_0003917">
+        <oboInOwl:hasDbXref>FBbt:00005066</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_0003917"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>FBbt:00005066</owl:annotatedTarget>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_0003929">
+        <oboInOwl:hasDbXref>FBbt:00047166</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_0003929"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>FBbt:00047166</owl:annotatedTarget>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_0003937">
+        <oboInOwl:hasDbXref>BTO:0006162</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_0003937"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>BTO:0006162</owl:annotatedTarget>
+        <sssom:author_id rdf:resource="https://orcid.org/0000-0003-4423-4370"/>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+        <sssom:mapping_provider>https://github.com/biopragmatics/biomappings</sssom:mapping_provider>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_0004016">
+        <oboInOwl:hasDbXref>BTO:0006248</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_0004016"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>BTO:0006248</owl:annotatedTarget>
+        <sssom:author_id rdf:resource="https://orcid.org/0000-0003-4423-4370"/>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+        <sssom:mapping_provider>https://github.com/biopragmatics/biomappings</sssom:mapping_provider>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_0004035">
+        <oboInOwl:hasDbXref>VO:0011276</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_0004035"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>VO:0011276</owl:annotatedTarget>
+        <sssom:author_id rdf:resource="https://orcid.org/0000-0003-4423-4370"/>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+        <sssom:mapping_provider>https://github.com/biopragmatics/biomappings</sssom:mapping_provider>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_0004199">
+        <oboInOwl:hasDbXref>VO:0010896</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_0004199"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>VO:0010896</owl:annotatedTarget>
+        <sssom:author_id rdf:resource="https://orcid.org/0000-0003-4423-4370"/>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+        <sssom:mapping_provider>https://github.com/biopragmatics/biomappings</sssom:mapping_provider>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_0004341">
+        <oboInOwl:hasDbXref>https://meshb.nlm.nih.gov/record/ui?ui=D054240</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_0004341"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>https://meshb.nlm.nih.gov/record/ui?ui=D054240</owl:annotatedTarget>
+        <sssom:author_id rdf:resource="https://orcid.org/0000-0001-9439-5346"/>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+        <sssom:mapping_provider>https://github.com/biopragmatics/biomappings</sssom:mapping_provider>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_0004550">
+        <oboInOwl:hasDbXref>https://meshb.nlm.nih.gov/record/ui?ui=D049630</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_0004550"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>https://meshb.nlm.nih.gov/record/ui?ui=D049630</owl:annotatedTarget>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/LexicalMatching"/>
+        <sssom:mapping_provider>https://github.com/biopragmatics/biomappings</sssom:mapping_provider>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_0004637">
+        <oboInOwl:hasDbXref>BTO:0005981</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_0004637"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>BTO:0005981</owl:annotatedTarget>
+        <sssom:author_id rdf:resource="https://orcid.org/0000-0003-4423-4370"/>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+        <sssom:mapping_provider>https://github.com/biopragmatics/biomappings</sssom:mapping_provider>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_0004676">
+        <oboInOwl:hasDbXref>https://meshb.nlm.nih.gov/record/ui?ui=D066152</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_0004676"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>https://meshb.nlm.nih.gov/record/ui?ui=D066152</owl:annotatedTarget>
+        <sssom:author_id rdf:resource="https://orcid.org/0000-0001-9439-5346"/>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+        <sssom:mapping_provider>https://github.com/biopragmatics/biomappings</sssom:mapping_provider>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_0004720">
+        <oboInOwl:hasDbXref>https://meshb.nlm.nih.gov/record/ui?ui=D065814</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_0004720"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>https://meshb.nlm.nih.gov/record/ui?ui=D065814</owl:annotatedTarget>
+        <sssom:author_id rdf:resource="https://orcid.org/0000-0001-9439-5346"/>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+        <sssom:mapping_provider>https://github.com/biopragmatics/biomappings</sssom:mapping_provider>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_0004734">
+        <oboInOwl:hasDbXref>FBbt:00005317</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_0004734"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>FBbt:00005317</owl:annotatedTarget>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_0004749">
+        <oboInOwl:hasDbXref>https://meshb.nlm.nih.gov/record/ui?ui=D054239</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_0004749"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>https://meshb.nlm.nih.gov/record/ui?ui=D054239</owl:annotatedTarget>
+        <sssom:author_id rdf:resource="https://orcid.org/0000-0001-9439-5346"/>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+        <sssom:mapping_provider>https://github.com/biopragmatics/biomappings</sssom:mapping_provider>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_0004904">
+        <oboInOwl:hasDbXref>FBbt:00001956</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_0004904"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>FBbt:00001956</owl:annotatedTarget>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_0004905">
+        <oboInOwl:hasDbXref>FBbt:00005811</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_0004905"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>FBbt:00005811</owl:annotatedTarget>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_0004921">
+        <oboInOwl:hasDbXref>FBbt:00100315</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_0004921"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>FBbt:00100315</owl:annotatedTarget>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_0005155">
+        <oboInOwl:hasDbXref>FBbt:00005024</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_0005155"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>FBbt:00005024</owl:annotatedTarget>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_0005162">
+        <oboInOwl:hasDbXref>FBbt:00007060</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_0005162"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>FBbt:00007060</owl:annotatedTarget>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_0005290">
+        <oboInOwl:hasDbXref>https://meshb.nlm.nih.gov/record/ui?ui=D054024</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_0005290"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>https://meshb.nlm.nih.gov/record/ui?ui=D054024</owl:annotatedTarget>
+        <sssom:author_id rdf:resource="https://orcid.org/0000-0001-9439-5346"/>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+        <sssom:mapping_provider>https://github.com/biopragmatics/biomappings</sssom:mapping_provider>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_0005335">
+        <oboInOwl:hasDbXref>https://meshb.nlm.nih.gov/record/ui?ui=D049033</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_0005335"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>https://meshb.nlm.nih.gov/record/ui?ui=D049033</owl:annotatedTarget>
+        <sssom:author_id rdf:resource="https://orcid.org/0000-0001-9439-5346"/>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+        <sssom:mapping_provider>https://github.com/biopragmatics/biomappings</sssom:mapping_provider>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_0005343">
+        <oboInOwl:hasDbXref>https://meshb.nlm.nih.gov/record/ui?ui=D002540</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_0005343"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>https://meshb.nlm.nih.gov/record/ui?ui=D002540</owl:annotatedTarget>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/LexicalMatching"/>
+        <sssom:mapping_provider>https://github.com/biopragmatics/biomappings</sssom:mapping_provider>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_0005388">
+        <oboInOwl:hasDbXref>FBbt:00004200</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_0005388"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>FBbt:00004200</owl:annotatedTarget>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_0005403">
+        <oboInOwl:hasDbXref>https://meshb.nlm.nih.gov/record/ui?ui=D066328</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_0005403"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>https://meshb.nlm.nih.gov/record/ui?ui=D066328</owl:annotatedTarget>
+        <sssom:author_id rdf:resource="https://orcid.org/0000-0001-9439-5346"/>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+        <sssom:mapping_provider>https://github.com/biopragmatics/biomappings</sssom:mapping_provider>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_0005408">
+        <oboInOwl:hasDbXref>BTO:0006267</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>https://meshb.nlm.nih.gov/record/ui?ui=D066280</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_0005408"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>BTO:0006267</owl:annotatedTarget>
+        <sssom:author_id rdf:resource="https://orcid.org/0000-0003-4423-4370"/>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+        <sssom:mapping_provider>https://github.com/biopragmatics/biomappings</sssom:mapping_provider>
+    </owl:Axiom>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_0005408"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>https://meshb.nlm.nih.gov/record/ui?ui=D066280</owl:annotatedTarget>
+        <sssom:author_id rdf:resource="https://orcid.org/0000-0001-9439-5346"/>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+        <sssom:mapping_provider>https://github.com/biopragmatics/biomappings</sssom:mapping_provider>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_0005423">
+        <oboInOwl:hasDbXref>FBbt:00007006</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_0005423"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>FBbt:00007006</owl:annotatedTarget>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_0005438">
+        <oboInOwl:hasDbXref>https://meshb.nlm.nih.gov/record/ui?ui=D054326</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_0005438"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>https://meshb.nlm.nih.gov/record/ui?ui=D054326</owl:annotatedTarget>
+        <sssom:author_id rdf:resource="https://orcid.org/0000-0001-9439-5346"/>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+        <sssom:mapping_provider>https://github.com/biopragmatics/biomappings</sssom:mapping_provider>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_0005456">
+        <oboInOwl:hasDbXref>https://meshb.nlm.nih.gov/record/ui?ui=D000080869</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_0005456"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>https://meshb.nlm.nih.gov/record/ui?ui=D000080869</owl:annotatedTarget>
+        <sssom:author_id rdf:resource="https://orcid.org/0000-0001-9439-5346"/>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+        <sssom:mapping_provider>https://github.com/biopragmatics/biomappings</sssom:mapping_provider>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_0005498">
+        <oboInOwl:hasDbXref>BTO:0006179</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_0005498"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>BTO:0006179</owl:annotatedTarget>
+        <sssom:author_id rdf:resource="https://orcid.org/0000-0003-4423-4370"/>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+        <sssom:mapping_provider>https://github.com/biopragmatics/biomappings</sssom:mapping_provider>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_0005631">
+        <oboInOwl:hasDbXref>https://meshb.nlm.nih.gov/record/ui?ui=D005321</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_0005631"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>https://meshb.nlm.nih.gov/record/ui?ui=D005321</owl:annotatedTarget>
+        <sssom:author_id rdf:resource="https://orcid.org/0000-0001-9439-5346"/>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+        <sssom:mapping_provider>https://github.com/biopragmatics/biomappings</sssom:mapping_provider>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_0005742">
+        <oboInOwl:hasDbXref>https://meshb.nlm.nih.gov/record/ui?ui=D063194</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_0005742"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>https://meshb.nlm.nih.gov/record/ui?ui=D063194</owl:annotatedTarget>
+        <sssom:author_id rdf:resource="https://orcid.org/0000-0001-9439-5346"/>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+        <sssom:mapping_provider>https://github.com/biopragmatics/biomappings</sssom:mapping_provider>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_0005777">
+        <oboInOwl:hasDbXref>https://meshb.nlm.nih.gov/record/ui?ui=D050533</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_0005777"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>https://meshb.nlm.nih.gov/record/ui?ui=D050533</owl:annotatedTarget>
+        <sssom:author_id rdf:resource="https://orcid.org/0000-0001-9439-5346"/>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+        <sssom:mapping_provider>https://github.com/biopragmatics/biomappings</sssom:mapping_provider>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_0005895">
+        <oboInOwl:hasDbXref>FBbt:00004640</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_0005895"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>FBbt:00004640</owl:annotatedTarget>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_0005902">
+        <oboInOwl:hasDbXref>https://meshb.nlm.nih.gov/record/ui?ui=D009778</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_0005902"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>https://meshb.nlm.nih.gov/record/ui?ui=D009778</owl:annotatedTarget>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/LexicalMatching"/>
+        <sssom:mapping_provider>https://github.com/biopragmatics/biomappings</sssom:mapping_provider>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_0005905">
+        <oboInOwl:hasDbXref>FBbt:00004522</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_0005905"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>FBbt:00004522</owl:annotatedTarget>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_0006083">
+        <oboInOwl:hasDbXref>https://meshb.nlm.nih.gov/record/ui?ui=D000071039</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_0006083"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>https://meshb.nlm.nih.gov/record/ui?ui=D000071039</owl:annotatedTarget>
+        <sssom:author_id rdf:resource="https://orcid.org/0000-0001-9439-5346"/>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+        <sssom:mapping_provider>https://github.com/biopragmatics/biomappings</sssom:mapping_provider>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_0006098">
+        <oboInOwl:hasDbXref>https://meshb.nlm.nih.gov/record/ui?ui=D001479</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_0006098"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>https://meshb.nlm.nih.gov/record/ui?ui=D001479</owl:annotatedTarget>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/LexicalMatching"/>
+        <sssom:mapping_provider>https://github.com/biopragmatics/biomappings</sssom:mapping_provider>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_0006108">
+        <oboInOwl:hasDbXref>https://meshb.nlm.nih.gov/record/ui?ui=D066276</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_0006108"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>https://meshb.nlm.nih.gov/record/ui?ui=D066276</owl:annotatedTarget>
+        <sssom:author_id rdf:resource="https://orcid.org/0000-0001-9439-5346"/>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+        <sssom:mapping_provider>https://github.com/biopragmatics/biomappings</sssom:mapping_provider>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_0006444">
+        <oboInOwl:hasDbXref>https://meshb.nlm.nih.gov/record/ui?ui=D000070616</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_0006444"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>https://meshb.nlm.nih.gov/record/ui?ui=D000070616</owl:annotatedTarget>
+        <sssom:author_id rdf:resource="https://orcid.org/0000-0001-9439-5346"/>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+        <sssom:mapping_provider>https://github.com/biopragmatics/biomappings</sssom:mapping_provider>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_0006514">
+        <oboInOwl:hasDbXref>https://meshb.nlm.nih.gov/record/ui?ui=D005917</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_0006514"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>https://meshb.nlm.nih.gov/record/ui?ui=D005917</owl:annotatedTarget>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/LexicalMatching"/>
+        <sssom:mapping_provider>https://github.com/biopragmatics/biomappings</sssom:mapping_provider>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_0006588">
+        <oboInOwl:hasDbXref>https://meshb.nlm.nih.gov/record/ui?ui=D000069592</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_0006588"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>https://meshb.nlm.nih.gov/record/ui?ui=D000069592</owl:annotatedTarget>
+        <sssom:author_id rdf:resource="https://orcid.org/0000-0001-9439-5346"/>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+        <sssom:mapping_provider>https://github.com/biopragmatics/biomappings</sssom:mapping_provider>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_0006589">
+        <oboInOwl:hasDbXref>https://meshb.nlm.nih.gov/record/ui?ui=D012404</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_0006589"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>https://meshb.nlm.nih.gov/record/ui?ui=D012404</owl:annotatedTarget>
+        <sssom:author_id rdf:resource="https://orcid.org/0000-0001-9439-5346"/>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+        <sssom:mapping_provider>https://github.com/biopragmatics/biomappings</sssom:mapping_provider>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_0006614">
+        <oboInOwl:hasDbXref>https://meshb.nlm.nih.gov/record/ui?ui=D000070606</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_0006614"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>https://meshb.nlm.nih.gov/record/ui?ui=D000070606</owl:annotatedTarget>
+        <sssom:author_id rdf:resource="https://orcid.org/0000-0001-9439-5346"/>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+        <sssom:mapping_provider>https://github.com/biopragmatics/biomappings</sssom:mapping_provider>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_0006657">
+        <oboInOwl:hasDbXref>https://meshb.nlm.nih.gov/record/ui?ui=D061165</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_0006657"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>https://meshb.nlm.nih.gov/record/ui?ui=D061165</owl:annotatedTarget>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/LexicalMatching"/>
+        <sssom:mapping_provider>https://github.com/biopragmatics/biomappings</sssom:mapping_provider>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_0006675">
+        <oboInOwl:hasDbXref>https://meshb.nlm.nih.gov/record/ui?ui=D055422</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_0006675"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>https://meshb.nlm.nih.gov/record/ui?ui=D055422</owl:annotatedTarget>
+        <sssom:author_id rdf:resource="https://orcid.org/0000-0001-9439-5346"/>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+        <sssom:mapping_provider>https://github.com/biopragmatics/biomappings</sssom:mapping_provider>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_0006692">
+        <oboInOwl:hasDbXref>https://meshb.nlm.nih.gov/record/ui?ui=D013115</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_0006692"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>https://meshb.nlm.nih.gov/record/ui?ui=D013115</owl:annotatedTarget>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/LexicalMatching"/>
+        <sssom:mapping_provider>https://github.com/biopragmatics/biomappings</sssom:mapping_provider>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_0006795">
+        <oboInOwl:hasDbXref>FBbt:00003701</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_0006795"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>FBbt:00003701</owl:annotatedTarget>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_0006810">
+        <oboInOwl:hasDbXref>https://meshb.nlm.nih.gov/record/ui?ui=D056740</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_0006810"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>https://meshb.nlm.nih.gov/record/ui?ui=D056740</owl:annotatedTarget>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/LexicalMatching"/>
+        <sssom:mapping_provider>https://github.com/biopragmatics/biomappings</sssom:mapping_provider>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_0006812">
+        <oboInOwl:hasDbXref>https://meshb.nlm.nih.gov/record/ui?ui=D000080383</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_0006812"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>https://meshb.nlm.nih.gov/record/ui?ui=D000080383</owl:annotatedTarget>
+        <sssom:author_id rdf:resource="https://orcid.org/0000-0001-9439-5346"/>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+        <sssom:mapping_provider>https://github.com/biopragmatics/biomappings</sssom:mapping_provider>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_0006832">
+        <oboInOwl:hasDbXref>FBbt:00007410</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_0006832"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>FBbt:00007410</owl:annotatedTarget>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_0006834">
+        <oboInOwl:hasDbXref>FBbt:00004924</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_0006834"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>FBbt:00004924</owl:annotatedTarget>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_0006866">
+        <oboInOwl:hasDbXref>FBbt:00005756</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_0006866"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>FBbt:00005756</owl:annotatedTarget>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_0006868">
+        <oboInOwl:hasDbXref>FBbt:00004958</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_0006868"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>FBbt:00004958</owl:annotatedTarget>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_0007023">
+        <oboInOwl:hasDbXref>FBbt:00003004</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_0007023"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>FBbt:00003004</owl:annotatedTarget>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_0007109">
+        <oboInOwl:hasDbXref>https://meshb.nlm.nih.gov/record/ui?ui=D008470</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_0007109"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>https://meshb.nlm.nih.gov/record/ui?ui=D008470</owl:annotatedTarget>
+        <sssom:author_id rdf:resource="https://orcid.org/0000-0001-9439-5346"/>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+        <sssom:mapping_provider>https://github.com/biopragmatics/biomappings</sssom:mapping_provider>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_0007132">
+        <oboInOwl:hasDbXref>https://meshb.nlm.nih.gov/record/ui?ui=D060226</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_0007132"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>https://meshb.nlm.nih.gov/record/ui?ui=D060226</owl:annotatedTarget>
+        <sssom:author_id rdf:resource="https://orcid.org/0000-0001-9439-5346"/>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+        <sssom:mapping_provider>https://github.com/biopragmatics/biomappings</sssom:mapping_provider>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_0007251">
+        <oboInOwl:hasDbXref>https://meshb.nlm.nih.gov/record/ui?ui=D011301</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_0007251"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>https://meshb.nlm.nih.gov/record/ui?ui=D011301</owl:annotatedTarget>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/LexicalMatching"/>
+        <sssom:mapping_provider>https://github.com/biopragmatics/biomappings</sssom:mapping_provider>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_0007268">
+        <oboInOwl:hasDbXref>https://meshb.nlm.nih.gov/record/ui?ui=D049631</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_0007268"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>https://meshb.nlm.nih.gov/record/ui?ui=D049631</owl:annotatedTarget>
+        <sssom:author_id rdf:resource="https://orcid.org/0000-0001-9439-5346"/>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+        <sssom:mapping_provider>https://github.com/biopragmatics/biomappings</sssom:mapping_provider>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_0007329">
+        <oboInOwl:hasDbXref>https://meshb.nlm.nih.gov/record/ui?ui=D010183</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_0007329"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>https://meshb.nlm.nih.gov/record/ui?ui=D010183</owl:annotatedTarget>
+        <sssom:author_id rdf:resource="https://orcid.org/0000-0001-9439-5346"/>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+        <sssom:mapping_provider>https://github.com/biopragmatics/biomappings</sssom:mapping_provider>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_0007376">
+        <oboInOwl:hasDbXref>FBbt:00004993</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_0007376"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>FBbt:00004993</owl:annotatedTarget>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_0007412">
+        <oboInOwl:hasDbXref>https://meshb.nlm.nih.gov/record/ui?ui=D066267</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_0007412"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>https://meshb.nlm.nih.gov/record/ui?ui=D066267</owl:annotatedTarget>
+        <sssom:author_id rdf:resource="https://orcid.org/0000-0001-9439-5346"/>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+        <sssom:mapping_provider>https://github.com/biopragmatics/biomappings</sssom:mapping_provider>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_0007632">
+        <oboInOwl:hasDbXref>https://meshb.nlm.nih.gov/record/ui?ui=D065835</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_0007632"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>https://meshb.nlm.nih.gov/record/ui?ui=D065835</owl:annotatedTarget>
+        <sssom:author_id rdf:resource="https://orcid.org/0000-0001-9439-5346"/>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+        <sssom:mapping_provider>https://github.com/biopragmatics/biomappings</sssom:mapping_provider>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_0007634">
+        <oboInOwl:hasDbXref>https://meshb.nlm.nih.gov/record/ui?ui=D065823</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_0007634"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>https://meshb.nlm.nih.gov/record/ui?ui=D065823</owl:annotatedTarget>
+        <sssom:author_id rdf:resource="https://orcid.org/0000-0001-9439-5346"/>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+        <sssom:mapping_provider>https://github.com/biopragmatics/biomappings</sssom:mapping_provider>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_0007641">
+        <oboInOwl:hasDbXref>https://meshb.nlm.nih.gov/record/ui?ui=D014278</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_0007641"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>https://meshb.nlm.nih.gov/record/ui?ui=D014278</owl:annotatedTarget>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/LexicalMatching"/>
+        <sssom:mapping_provider>https://github.com/biopragmatics/biomappings</sssom:mapping_provider>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_0007688">
+        <oboInOwl:hasDbXref>FBbt:00005426</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_0007688"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>FBbt:00005426</owl:annotatedTarget>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_0007703">
+        <oboInOwl:hasDbXref>BTO:0006128</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>https://meshb.nlm.nih.gov/record/ui?ui=D013133</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_0007703"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>BTO:0006128</owl:annotatedTarget>
+        <sssom:author_id rdf:resource="https://orcid.org/0000-0003-4423-4370"/>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+        <sssom:mapping_provider>https://github.com/biopragmatics/biomappings</sssom:mapping_provider>
+    </owl:Axiom>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_0007703"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>https://meshb.nlm.nih.gov/record/ui?ui=D013133</owl:annotatedTarget>
+        <sssom:author_id rdf:resource="https://orcid.org/0000-0001-9439-5346"/>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+        <sssom:mapping_provider>https://github.com/biopragmatics/biomappings</sssom:mapping_provider>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_0008266">
+        <oboInOwl:hasDbXref>https://meshb.nlm.nih.gov/record/ui?ui=D010513</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_0008266"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>https://meshb.nlm.nih.gov/record/ui?ui=D010513</owl:annotatedTarget>
+        <sssom:author_id rdf:resource="https://orcid.org/0000-0001-9439-5346"/>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+        <sssom:mapping_provider>https://github.com/biopragmatics/biomappings</sssom:mapping_provider>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_0008269">
+        <oboInOwl:hasDbXref>https://meshb.nlm.nih.gov/record/ui?ui=D060734</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_0008269"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>https://meshb.nlm.nih.gov/record/ui?ui=D060734</owl:annotatedTarget>
+        <sssom:author_id rdf:resource="https://orcid.org/0000-0001-9439-5346"/>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+        <sssom:mapping_provider>https://github.com/biopragmatics/biomappings</sssom:mapping_provider>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_0008275">
+        <oboInOwl:hasDbXref>https://meshb.nlm.nih.gov/record/ui?ui=D060105</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_0008275"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>https://meshb.nlm.nih.gov/record/ui?ui=D060105</owl:annotatedTarget>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/LexicalMatching"/>
+        <sssom:mapping_provider>https://github.com/biopragmatics/biomappings</sssom:mapping_provider>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_0008811">
+        <oboInOwl:hasDbXref>FBbt:00004850</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_0008811"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>FBbt:00004850</owl:annotatedTarget>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_0008816">
+        <oboInOwl:hasDbXref>FBbt:00000155</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_0008816"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>FBbt:00000155</owl:annotatedTarget>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_0008826">
+        <oboInOwl:hasDbXref>https://meshb.nlm.nih.gov/record/ui?ui=D011663</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_0008826"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>https://meshb.nlm.nih.gov/record/ui?ui=D011663</owl:annotatedTarget>
+        <sssom:author_id rdf:resource="https://orcid.org/0000-0001-9439-5346"/>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+        <sssom:mapping_provider>https://github.com/biopragmatics/biomappings</sssom:mapping_provider>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_0008904">
+        <oboInOwl:hasDbXref>BTO:0006219</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_0008904"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>BTO:0006219</owl:annotatedTarget>
+        <sssom:author_id rdf:resource="https://orcid.org/0000-0003-4423-4370"/>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+        <sssom:mapping_provider>https://github.com/biopragmatics/biomappings</sssom:mapping_provider>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_0008969">
+        <oboInOwl:hasDbXref>https://meshb.nlm.nih.gov/record/ui?ui=D003795</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_0008969"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>https://meshb.nlm.nih.gov/record/ui?ui=D003795</owl:annotatedTarget>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/LexicalMatching"/>
+        <sssom:mapping_provider>https://github.com/biopragmatics/biomappings</sssom:mapping_provider>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_0008974">
+        <oboInOwl:hasDbXref>https://meshb.nlm.nih.gov/record/ui?ui=D001050</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_0008974"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>https://meshb.nlm.nih.gov/record/ui?ui=D001050</owl:annotatedTarget>
+        <sssom:author_id rdf:resource="https://orcid.org/0000-0001-9439-5346"/>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+        <sssom:mapping_provider>https://github.com/biopragmatics/biomappings</sssom:mapping_provider>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_0009040">
+        <oboInOwl:hasDbXref>https://meshb.nlm.nih.gov/record/ui?ui=D007083</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_0009040"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>https://meshb.nlm.nih.gov/record/ui?ui=D007083</owl:annotatedTarget>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/LexicalMatching"/>
+        <sssom:mapping_provider>https://github.com/biopragmatics/biomappings</sssom:mapping_provider>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_0009054">
+        <oboInOwl:hasDbXref>FBbt:00005057</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_0009054"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>FBbt:00005057</owl:annotatedTarget>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_0009097">
+        <oboInOwl:hasDbXref>IDOMAL:0000443</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_0009097"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>IDOMAL:0000443</owl:annotatedTarget>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/LexicalMatching"/>
+        <sssom:mapping_provider>https://github.com/biopragmatics/biomappings</sssom:mapping_provider>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_0009127">
+        <oboInOwl:hasDbXref>BTO:0006250</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_0009127"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>BTO:0006250</owl:annotatedTarget>
+        <sssom:author_id rdf:resource="https://orcid.org/0000-0003-4423-4370"/>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+        <sssom:mapping_provider>https://github.com/biopragmatics/biomappings</sssom:mapping_provider>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_0009571">
+        <oboInOwl:hasDbXref>FBbt:00000093</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_0009571"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>FBbt:00000093</owl:annotatedTarget>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_0009755">
+        <oboInOwl:hasDbXref>https://meshb.nlm.nih.gov/record/ui?ui=C009301</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_0009755"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>https://meshb.nlm.nih.gov/record/ui?ui=C009301</owl:annotatedTarget>
+        <sssom:author_id rdf:resource="https://orcid.org/0000-0001-9439-5346"/>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+        <sssom:mapping_provider>https://github.com/biopragmatics/biomappings</sssom:mapping_provider>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_0009757">
+        <oboInOwl:hasDbXref>https://meshb.nlm.nih.gov/record/ui?ui=D018648</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_0009757"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>https://meshb.nlm.nih.gov/record/ui?ui=D018648</owl:annotatedTarget>
+        <sssom:author_id rdf:resource="https://orcid.org/0000-0001-9439-5346"/>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+        <sssom:mapping_provider>https://github.com/biopragmatics/biomappings</sssom:mapping_provider>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_0009854">
+        <oboInOwl:hasDbXref>FBbt:00100316</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_0009854"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>FBbt:00100316</owl:annotatedTarget>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_0009951">
+        <oboInOwl:hasDbXref>https://meshb.nlm.nih.gov/record/ui?ui=D009830</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_0009951"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>https://meshb.nlm.nih.gov/record/ui?ui=D009830</owl:annotatedTarget>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/LexicalMatching"/>
+        <sssom:mapping_provider>https://github.com/biopragmatics/biomappings</sssom:mapping_provider>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_0010000">
+        <oboInOwl:hasDbXref>FBbt:00100313</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_0010000"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>FBbt:00100313</owl:annotatedTarget>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_0010001">
+        <oboInOwl:hasDbXref>FBbt:00007229</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_0010001"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>FBbt:00007229</owl:annotatedTarget>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_0010264">
+        <oboInOwl:hasDbXref>https://meshb.nlm.nih.gov/record/ui?ui=D043143</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_0010264"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>https://meshb.nlm.nih.gov/record/ui?ui=D043143</owl:annotatedTarget>
+        <sssom:author_id rdf:resource="https://orcid.org/0000-0001-9439-5346"/>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+        <sssom:mapping_provider>https://github.com/biopragmatics/biomappings</sssom:mapping_provider>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_0010302">
+        <oboInOwl:hasDbXref>FBbt:00000095</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_0010302"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>FBbt:00000095</owl:annotatedTarget>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_0010361">
+        <oboInOwl:hasDbXref>https://meshb.nlm.nih.gov/record/ui?ui=D013580</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_0010361"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>https://meshb.nlm.nih.gov/record/ui?ui=D013580</owl:annotatedTarget>
+        <sssom:author_id rdf:resource="https://orcid.org/0000-0001-9439-5346"/>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+        <sssom:mapping_provider>https://github.com/biopragmatics/biomappings</sssom:mapping_provider>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_0010725">
+        <oboInOwl:hasDbXref>https://meshb.nlm.nih.gov/record/ui?ui=C536002</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_0010725"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>https://meshb.nlm.nih.gov/record/ui?ui=C536002</owl:annotatedTarget>
+        <sssom:author_id rdf:resource="https://orcid.org/0000-0001-9439-5346"/>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+        <sssom:mapping_provider>https://github.com/biopragmatics/biomappings</sssom:mapping_provider>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_0010758">
+        <oboInOwl:hasDbXref>FBbt:00007018</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_0010758"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>FBbt:00007018</owl:annotatedTarget>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_0011004">
+        <oboInOwl:hasDbXref>BTO:0006051</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_0011004"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>BTO:0006051</owl:annotatedTarget>
+        <sssom:author_id rdf:resource="https://orcid.org/0000-0003-4423-4370"/>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+        <sssom:mapping_provider>https://github.com/biopragmatics/biomappings</sssom:mapping_provider>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_0011117">
+        <oboInOwl:hasDbXref>https://meshb.nlm.nih.gov/record/ui?ui=D007719</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_0011117"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>https://meshb.nlm.nih.gov/record/ui?ui=D007719</owl:annotatedTarget>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/LexicalMatching"/>
+        <sssom:mapping_provider>https://github.com/biopragmatics/biomappings</sssom:mapping_provider>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_0011119">
+        <oboInOwl:hasDbXref>https://meshb.nlm.nih.gov/record/ui?ui=D052737</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_0011119"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>https://meshb.nlm.nih.gov/record/ui?ui=D052737</owl:annotatedTarget>
+        <sssom:author_id rdf:resource="https://orcid.org/0000-0001-9439-5346"/>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+        <sssom:mapping_provider>https://github.com/biopragmatics/biomappings</sssom:mapping_provider>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_0011132">
+        <oboInOwl:hasDbXref>https://meshb.nlm.nih.gov/record/ui?ui=D050824</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_0011132"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>https://meshb.nlm.nih.gov/record/ui?ui=D050824</owl:annotatedTarget>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/LexicalMatching"/>
+        <sssom:mapping_provider>https://github.com/biopragmatics/biomappings</sssom:mapping_provider>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_0011166">
+        <oboInOwl:hasDbXref>https://meshb.nlm.nih.gov/record/ui?ui=D057071</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_0011166"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>https://meshb.nlm.nih.gov/record/ui?ui=D057071</owl:annotatedTarget>
+        <sssom:author_id rdf:resource="https://orcid.org/0000-0001-9439-5346"/>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+        <sssom:mapping_provider>https://github.com/biopragmatics/biomappings</sssom:mapping_provider>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_0011216">
+        <oboInOwl:hasDbXref>FBbt:00007330</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_0011216"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>FBbt:00007330</owl:annotatedTarget>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_0011390">
+        <oboInOwl:hasDbXref>https://meshb.nlm.nih.gov/record/ui?ui=D060525</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_0011390"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>https://meshb.nlm.nih.gov/record/ui?ui=D060525</owl:annotatedTarget>
+        <sssom:author_id rdf:resource="https://orcid.org/0000-0001-9439-5346"/>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+        <sssom:mapping_provider>https://github.com/biopragmatics/biomappings</sssom:mapping_provider>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_0011895">
+        <oboInOwl:hasDbXref>BTO:0006241</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_0011895"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>BTO:0006241</owl:annotatedTarget>
+        <sssom:author_id rdf:resource="https://orcid.org/0000-0003-4423-4370"/>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+        <sssom:mapping_provider>https://github.com/biopragmatics/biomappings</sssom:mapping_provider>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_0011905">
+        <oboInOwl:hasDbXref>BTO:0006312</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_0011905"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>BTO:0006312</owl:annotatedTarget>
+        <sssom:author_id rdf:resource="https://orcid.org/0000-0003-4423-4370"/>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+        <sssom:mapping_provider>https://github.com/biopragmatics/biomappings</sssom:mapping_provider>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_0012245">
+        <oboInOwl:hasDbXref>BTO:0002854</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>https://meshb.nlm.nih.gov/record/ui?ui=D047011</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_0012245"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>BTO:0002854</owl:annotatedTarget>
+        <sssom:author_id rdf:resource="https://orcid.org/0000-0003-4423-4370"/>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+        <sssom:mapping_provider>https://github.com/biopragmatics/biomappings</sssom:mapping_provider>
+    </owl:Axiom>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_0012245"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>https://meshb.nlm.nih.gov/record/ui?ui=D047011</owl:annotatedTarget>
+        <sssom:author_id rdf:resource="https://orcid.org/0000-0001-9439-5346"/>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+        <sssom:mapping_provider>https://github.com/biopragmatics/biomappings</sssom:mapping_provider>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_0012325">
+        <oboInOwl:hasDbXref>FBbt:00001718</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_0012325"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>FBbt:00001718</owl:annotatedTarget>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_0013218">
+        <oboInOwl:hasDbXref>BTO:0006363</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_0013218"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>BTO:0006363</owl:annotatedTarget>
+        <sssom:author_id rdf:resource="https://orcid.org/0000-0003-4423-4370"/>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+        <sssom:mapping_provider>https://github.com/biopragmatics/biomappings</sssom:mapping_provider>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_0013422">
+        <oboInOwl:hasDbXref>https://meshb.nlm.nih.gov/record/ui?ui=D000080884</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_0013422"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>https://meshb.nlm.nih.gov/record/ui?ui=D000080884</owl:annotatedTarget>
+        <sssom:author_id rdf:resource="https://orcid.org/0000-0001-9439-5346"/>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+        <sssom:mapping_provider>https://github.com/biopragmatics/biomappings</sssom:mapping_provider>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_0013755">
+        <oboInOwl:hasDbXref>BTO:0006188</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_0013755"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>BTO:0006188</owl:annotatedTarget>
+        <sssom:author_id rdf:resource="https://orcid.org/0000-0003-4423-4370"/>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+        <sssom:mapping_provider>https://github.com/biopragmatics/biomappings</sssom:mapping_provider>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_0013756">
+        <oboInOwl:hasDbXref>BTO:0006187</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_0013756"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>BTO:0006187</owl:annotatedTarget>
+        <sssom:author_id rdf:resource="https://orcid.org/0000-0003-4423-4370"/>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+        <sssom:mapping_provider>https://github.com/biopragmatics/biomappings</sssom:mapping_provider>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_0014374">
+        <oboInOwl:hasDbXref>https://meshb.nlm.nih.gov/record/ui?ui=D058732</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_0014374"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>https://meshb.nlm.nih.gov/record/ui?ui=D058732</owl:annotatedTarget>
+        <sssom:author_id rdf:resource="https://orcid.org/0000-0001-9439-5346"/>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+        <sssom:mapping_provider>https://github.com/biopragmatics/biomappings</sssom:mapping_provider>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_0014398">
+        <oboInOwl:hasDbXref>https://meshb.nlm.nih.gov/record/ui?ui=D012132</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_0014398"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>https://meshb.nlm.nih.gov/record/ui?ui=D012132</owl:annotatedTarget>
+        <sssom:author_id rdf:resource="https://orcid.org/0000-0001-9439-5346"/>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+        <sssom:mapping_provider>https://github.com/biopragmatics/biomappings</sssom:mapping_provider>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_0014621">
+        <oboInOwl:hasDbXref>https://meshb.nlm.nih.gov/record/ui?ui=D066151</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_0014621"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>https://meshb.nlm.nih.gov/record/ui?ui=D066151</owl:annotatedTarget>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/LexicalMatching"/>
+        <sssom:mapping_provider>https://github.com/biopragmatics/biomappings</sssom:mapping_provider>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_0014732">
+        <oboInOwl:hasDbXref>FBbt:00007230</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_0014732"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>FBbt:00007230</owl:annotatedTarget>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_0015169">
+        <oboInOwl:hasDbXref>BTO:0001350</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_0015169"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>BTO:0001350</owl:annotatedTarget>
+        <sssom:author_id rdf:resource="https://orcid.org/0000-0003-4423-4370"/>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+        <sssom:mapping_provider>https://github.com/biopragmatics/biomappings</sssom:mapping_provider>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_0015203">
+        <oboInOwl:hasDbXref>FBbt:00007278</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_0015203"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>FBbt:00007278</owl:annotatedTarget>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_0015230">
+        <oboInOwl:hasDbXref>FBbt:00003154</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_0015230"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>FBbt:00003154</owl:annotatedTarget>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_0015231">
+        <oboInOwl:hasDbXref>FBbt:00058291</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_0015231"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>FBbt:00058291</owl:annotatedTarget>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_0015488">
+        <oboInOwl:hasDbXref>https://meshb.nlm.nih.gov/record/ui?ui=D013497</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_0015488"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>https://meshb.nlm.nih.gov/record/ui?ui=D013497</owl:annotatedTarget>
+        <sssom:author_id rdf:resource="https://orcid.org/0000-0001-9439-5346"/>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+        <sssom:mapping_provider>https://github.com/biopragmatics/biomappings</sssom:mapping_provider>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_0016435">
+        <oboInOwl:hasDbXref>https://meshb.nlm.nih.gov/record/ui?ui=D035441</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_0016435"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>https://meshb.nlm.nih.gov/record/ui?ui=D035441</owl:annotatedTarget>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/LexicalMatching"/>
+        <sssom:mapping_provider>https://github.com/biopragmatics/biomappings</sssom:mapping_provider>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_0016530">
+        <oboInOwl:hasDbXref>https://meshb.nlm.nih.gov/record/ui?ui=D010296</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_0016530"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>https://meshb.nlm.nih.gov/record/ui?ui=D010296</owl:annotatedTarget>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/LexicalMatching"/>
+        <sssom:mapping_provider>https://github.com/biopragmatics/biomappings</sssom:mapping_provider>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_0016538">
+        <oboInOwl:hasDbXref>https://meshb.nlm.nih.gov/record/ui?ui=D013702</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_0016538"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>https://meshb.nlm.nih.gov/record/ui?ui=D013702</owl:annotatedTarget>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/LexicalMatching"/>
+        <sssom:mapping_provider>https://github.com/biopragmatics/biomappings</sssom:mapping_provider>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_0016884">
+        <oboInOwl:hasDbXref>https://meshb.nlm.nih.gov/record/ui?ui=D012785</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_0016884"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>https://meshb.nlm.nih.gov/record/ui?ui=D012785</owl:annotatedTarget>
+        <sssom:author_id rdf:resource="https://orcid.org/0000-0001-9439-5346"/>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+        <sssom:mapping_provider>https://github.com/biopragmatics/biomappings</sssom:mapping_provider>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_0018144">
+        <oboInOwl:hasDbXref>https://meshb.nlm.nih.gov/record/ui?ui=D057070</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_0018144"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>https://meshb.nlm.nih.gov/record/ui?ui=D057070</owl:annotatedTarget>
+        <sssom:author_id rdf:resource="https://orcid.org/0000-0001-9439-5346"/>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+        <sssom:mapping_provider>https://github.com/biopragmatics/biomappings</sssom:mapping_provider>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_0018382">
+        <oboInOwl:hasDbXref>FBbt:00005338</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_0018382"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>FBbt:00005338</owl:annotatedTarget>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_0018388">
+        <oboInOwl:hasDbXref>https://meshb.nlm.nih.gov/record/ui?ui=D058487</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_0018388"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>https://meshb.nlm.nih.gov/record/ui?ui=D058487</owl:annotatedTarget>
+        <sssom:author_id rdf:resource="https://orcid.org/0000-0001-9439-5346"/>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+        <sssom:mapping_provider>https://github.com/biopragmatics/biomappings</sssom:mapping_provider>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_0018656">
+        <oboInOwl:hasDbXref>FBbt:00004987</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_0018656"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>FBbt:00004987</owl:annotatedTarget>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_0034923">
+        <oboInOwl:hasDbXref>FBbt:00007276</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_0034923"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>FBbt:00007276</owl:annotatedTarget>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_0034926">
+        <oboInOwl:hasDbXref>FBbt:00100152</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_0034926"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>FBbt:00100152</owl:annotatedTarget>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_0034971">
+        <oboInOwl:hasDbXref>BTO:0006193</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref>https://meshb.nlm.nih.gov/record/ui?ui=D001016</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_0034971"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>BTO:0006193</owl:annotatedTarget>
+        <sssom:author_id rdf:resource="https://orcid.org/0000-0003-4423-4370"/>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+        <sssom:mapping_provider>https://github.com/biopragmatics/biomappings</sssom:mapping_provider>
+    </owl:Axiom>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_0034971"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>https://meshb.nlm.nih.gov/record/ui?ui=D001016</owl:annotatedTarget>
+        <sssom:author_id rdf:resource="https://orcid.org/0000-0001-9439-5346"/>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+        <sssom:mapping_provider>https://github.com/biopragmatics/biomappings</sssom:mapping_provider>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_0035032">
+        <oboInOwl:hasDbXref>https://meshb.nlm.nih.gov/record/ui?ui=D000071596</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_0035032"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>https://meshb.nlm.nih.gov/record/ui?ui=D000071596</owl:annotatedTarget>
+        <sssom:author_id rdf:resource="https://orcid.org/0000-0001-9439-5346"/>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+        <sssom:mapping_provider>https://github.com/biopragmatics/biomappings</sssom:mapping_provider>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_0035050">
+        <oboInOwl:hasDbXref>BTO:0006341</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_0035050"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>BTO:0006341</owl:annotatedTarget>
+        <sssom:author_id rdf:resource="https://orcid.org/0000-0003-4423-4370"/>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+        <sssom:mapping_provider>https://github.com/biopragmatics/biomappings</sssom:mapping_provider>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_0035618">
+        <oboInOwl:hasDbXref>https://meshb.nlm.nih.gov/record/ui?ui=D000080886</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_0035618"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>https://meshb.nlm.nih.gov/record/ui?ui=D000080886</owl:annotatedTarget>
+        <sssom:author_id rdf:resource="https://orcid.org/0000-0001-9439-5346"/>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+        <sssom:mapping_provider>https://github.com/biopragmatics/biomappings</sssom:mapping_provider>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_0036016">
+        <oboInOwl:hasDbXref>https://meshb.nlm.nih.gov/record/ui?ui=D006722</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_0036016"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>https://meshb.nlm.nih.gov/record/ui?ui=D006722</owl:annotatedTarget>
+        <sssom:author_id rdf:resource="https://orcid.org/0000-0001-9439-5346"/>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+        <sssom:mapping_provider>https://github.com/biopragmatics/biomappings</sssom:mapping_provider>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_0036145">
+        <oboInOwl:hasDbXref>https://meshb.nlm.nih.gov/record/ui?ui=D000077502</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_0036145"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>https://meshb.nlm.nih.gov/record/ui?ui=D000077502</owl:annotatedTarget>
+        <sssom:author_id rdf:resource="https://orcid.org/0000-0001-9439-5346"/>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+        <sssom:mapping_provider>https://github.com/biopragmatics/biomappings</sssom:mapping_provider>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_0036243">
+        <oboInOwl:hasDbXref>BTO:0003084</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_0036243"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>BTO:0003084</owl:annotatedTarget>
+        <sssom:author_id rdf:resource="https://orcid.org/0000-0003-4423-4370"/>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+        <sssom:mapping_provider>https://github.com/biopragmatics/biomappings</sssom:mapping_provider>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_1000010">
+        <oboInOwl:hasDbXref>https://meshb.nlm.nih.gov/record/ui?ui=D009506</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_1000010"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>https://meshb.nlm.nih.gov/record/ui?ui=D009506</owl:annotatedTarget>
+        <sssom:author_id rdf:resource="https://orcid.org/0000-0001-9439-5346"/>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+        <sssom:mapping_provider>https://github.com/biopragmatics/biomappings</sssom:mapping_provider>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_2000006">
+        <oboInOwl:hasDbXref>https://meshb.nlm.nih.gov/record/ui?ui=D015452</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_2000006"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>https://meshb.nlm.nih.gov/record/ui?ui=D015452</owl:annotatedTarget>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/LexicalMatching"/>
+        <sssom:mapping_provider>https://github.com/biopragmatics/biomappings</sssom:mapping_provider>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_2000188">
+        <oboInOwl:hasDbXref>https://meshb.nlm.nih.gov/record/ui?ui=D002531</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_2000188"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>https://meshb.nlm.nih.gov/record/ui?ui=D002531</owl:annotatedTarget>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/LexicalMatching"/>
+        <sssom:mapping_provider>https://github.com/biopragmatics/biomappings</sssom:mapping_provider>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_2000293">
+        <oboInOwl:hasDbXref>BTO:0006476</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_2000293"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>BTO:0006476</owl:annotatedTarget>
+        <sssom:author_id rdf:resource="https://orcid.org/0000-0003-4423-4370"/>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+        <sssom:mapping_provider>https://github.com/biopragmatics/biomappings</sssom:mapping_provider>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_2000297">
+        <oboInOwl:hasDbXref>BTO:0006431</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_2000297"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>BTO:0006431</owl:annotatedTarget>
+        <sssom:author_id rdf:resource="https://orcid.org/0000-0003-4423-4370"/>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+        <sssom:mapping_provider>https://github.com/biopragmatics/biomappings</sssom:mapping_provider>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_2000356">
+        <oboInOwl:hasDbXref>BTO:0002149</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_2000356"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>BTO:0002149</owl:annotatedTarget>
+        <sssom:author_id rdf:resource="https://orcid.org/0000-0003-4423-4370"/>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+        <sssom:mapping_provider>https://github.com/biopragmatics/biomappings</sssom:mapping_provider>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_2001553">
+        <oboInOwl:hasDbXref>https://meshb.nlm.nih.gov/record/ui?ui=D008371</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_2001553"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>https://meshb.nlm.nih.gov/record/ui?ui=D008371</owl:annotatedTarget>
+        <sssom:author_id rdf:resource="https://orcid.org/0000-0001-9439-5346"/>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+        <sssom:mapping_provider>https://github.com/biopragmatics/biomappings</sssom:mapping_provider>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_2001977">
+        <oboInOwl:hasDbXref>https://meshb.nlm.nih.gov/record/ui?ui=D058729</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_2001977"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>https://meshb.nlm.nih.gov/record/ui?ui=D058729</owl:annotatedTarget>
+        <sssom:author_id rdf:resource="https://orcid.org/0000-0001-9439-5346"/>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+        <sssom:mapping_provider>https://github.com/biopragmatics/biomappings</sssom:mapping_provider>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_3010463">
+        <oboInOwl:hasDbXref>BTO:0004724</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_3010463"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>BTO:0004724</owl:annotatedTarget>
+        <sssom:author_id rdf:resource="https://orcid.org/0000-0003-4423-4370"/>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+        <sssom:mapping_provider>https://github.com/biopragmatics/biomappings</sssom:mapping_provider>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_3010586">
+        <oboInOwl:hasDbXref>BTO:0002254</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_3010586"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>BTO:0002254</owl:annotatedTarget>
+        <sssom:author_id rdf:resource="https://orcid.org/0000-0003-4423-4370"/>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+        <sssom:mapping_provider>https://github.com/biopragmatics/biomappings</sssom:mapping_provider>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_4000104">
+        <oboInOwl:hasDbXref>https://meshb.nlm.nih.gov/record/ui?ui=C067951</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_4000104"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>https://meshb.nlm.nih.gov/record/ui?ui=C067951</owl:annotatedTarget>
+        <sssom:author_id rdf:resource="https://orcid.org/0000-0001-9439-5346"/>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+        <sssom:mapping_provider>https://github.com/biopragmatics/biomappings</sssom:mapping_provider>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_4000163">
+        <oboInOwl:hasDbXref>BTO:0004652</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_4000163"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>BTO:0004652</owl:annotatedTarget>
+        <sssom:author_id rdf:resource="https://orcid.org/0000-0003-4423-4370"/>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+        <sssom:mapping_provider>https://github.com/biopragmatics/biomappings</sssom:mapping_provider>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_4000164">
+        <oboInOwl:hasDbXref>BTO:0001827</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_4000164"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>BTO:0001827</owl:annotatedTarget>
+        <sssom:author_id rdf:resource="https://orcid.org/0000-0003-4423-4370"/>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+        <sssom:mapping_provider>https://github.com/biopragmatics/biomappings</sssom:mapping_provider>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_4200215">
+        <oboInOwl:hasDbXref>https://meshb.nlm.nih.gov/record/ui?ui=D013537</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_4200215"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>https://meshb.nlm.nih.gov/record/ui?ui=D013537</owl:annotatedTarget>
+        <sssom:author_id rdf:resource="https://orcid.org/0000-0001-9439-5346"/>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+        <sssom:mapping_provider>https://github.com/biopragmatics/biomappings</sssom:mapping_provider>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_4300194">
+        <oboInOwl:hasDbXref>BTO:0001477</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_4300194"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>BTO:0001477</owl:annotatedTarget>
+        <sssom:author_id rdf:resource="https://orcid.org/0000-0003-4423-4370"/>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+        <sssom:mapping_provider>https://github.com/biopragmatics/biomappings</sssom:mapping_provider>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_6000002">
+        <oboInOwl:hasDbXref>FBbt:00000002</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_6000002"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>FBbt:00000002</owl:annotatedTarget>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_6000004">
+        <oboInOwl:hasDbXref>FBbt:00000004</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_6000004"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>FBbt:00000004</owl:annotatedTarget>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_6000005">
+        <oboInOwl:hasDbXref>FBbt:00000005</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_6000005"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>FBbt:00000005</owl:annotatedTarget>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_6000006">
+        <oboInOwl:hasDbXref>FBbt:00000006</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_6000006"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>FBbt:00000006</owl:annotatedTarget>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_6000007">
+        <oboInOwl:hasDbXref>FBbt:00000007</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_6000007"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>FBbt:00000007</owl:annotatedTarget>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_6000008">
+        <oboInOwl:hasDbXref>FBbt:00000008</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_6000008"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>FBbt:00000008</owl:annotatedTarget>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_6000009">
+        <oboInOwl:hasDbXref>FBbt:00000009</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_6000009"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>FBbt:00000009</owl:annotatedTarget>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_6000011">
+        <oboInOwl:hasDbXref>FBbt:00000011</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_6000011"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>FBbt:00000011</owl:annotatedTarget>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_6000014">
+        <oboInOwl:hasDbXref>FBbt:00000014</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_6000014"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>FBbt:00000014</owl:annotatedTarget>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_6000015">
+        <oboInOwl:hasDbXref>FBbt:00000015</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_6000015"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>FBbt:00000015</owl:annotatedTarget>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_6000016">
+        <oboInOwl:hasDbXref>FBbt:00000016</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_6000016"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>FBbt:00000016</owl:annotatedTarget>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_6000017">
+        <oboInOwl:hasDbXref>FBbt:00000017</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_6000017"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>FBbt:00000017</owl:annotatedTarget>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_6000018">
+        <oboInOwl:hasDbXref>FBbt:00000018</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_6000018"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>FBbt:00000018</owl:annotatedTarget>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_6000019">
+        <oboInOwl:hasDbXref>FBbt:00000019</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_6000019"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>FBbt:00000019</owl:annotatedTarget>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_6000020">
+        <oboInOwl:hasDbXref>FBbt:00000020</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_6000020"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>FBbt:00000020</owl:annotatedTarget>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_6000021">
+        <oboInOwl:hasDbXref>FBbt:00000021</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_6000021"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>FBbt:00000021</owl:annotatedTarget>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_6000029">
+        <oboInOwl:hasDbXref>FBbt:00000029</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_6000029"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>FBbt:00000029</owl:annotatedTarget>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_6000030">
+        <oboInOwl:hasDbXref>FBbt:00000030</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_6000030"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>FBbt:00000030</owl:annotatedTarget>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_6000046">
+        <oboInOwl:hasDbXref>FBbt:00000046</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_6000046"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>FBbt:00000046</owl:annotatedTarget>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_6000096">
+        <oboInOwl:hasDbXref>FBbt:00000096</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_6000096"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>FBbt:00000096</owl:annotatedTarget>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_6000097">
+        <oboInOwl:hasDbXref>FBbt:00000097</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_6000097"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>FBbt:00000097</owl:annotatedTarget>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_6000104">
+        <oboInOwl:hasDbXref>FBbt:00000104</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_6000104"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>FBbt:00000104</owl:annotatedTarget>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_6000112">
+        <oboInOwl:hasDbXref>FBbt:00000112</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_6000112"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>FBbt:00000112</owl:annotatedTarget>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_6000119">
+        <oboInOwl:hasDbXref>FBbt:00000119</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_6000119"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>FBbt:00000119</owl:annotatedTarget>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_6000128">
+        <oboInOwl:hasDbXref>FBbt:00000128</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_6000128"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>FBbt:00000128</owl:annotatedTarget>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_6000130">
+        <oboInOwl:hasDbXref>FBbt:00000130</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_6000130"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>FBbt:00000130</owl:annotatedTarget>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_6000137">
+        <oboInOwl:hasDbXref>FBbt:00000137</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_6000137"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>FBbt:00000137</owl:annotatedTarget>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_6000154">
+        <oboInOwl:hasDbXref>FBbt:00000154</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_6000154"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>FBbt:00000154</owl:annotatedTarget>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_6000157">
+        <oboInOwl:hasDbXref>FBbt:00000157</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_6000157"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>FBbt:00000157</owl:annotatedTarget>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_6000158">
+        <oboInOwl:hasDbXref>FBbt:00000158</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_6000158"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>FBbt:00000158</owl:annotatedTarget>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_6000160">
+        <oboInOwl:hasDbXref>FBbt:00000160</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_6000160"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>FBbt:00000160</owl:annotatedTarget>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_6000162">
+        <oboInOwl:hasDbXref>FBbt:00000162</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_6000162"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>FBbt:00000162</owl:annotatedTarget>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_6000165">
+        <oboInOwl:hasDbXref>FBbt:00000165</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_6000165"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>FBbt:00000165</owl:annotatedTarget>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_6000166">
+        <oboInOwl:hasDbXref>FBbt:00000166</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_6000166"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>FBbt:00000166</owl:annotatedTarget>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_6000167">
+        <oboInOwl:hasDbXref>FBbt:00000167</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_6000167"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>FBbt:00000167</owl:annotatedTarget>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_6000168">
+        <oboInOwl:hasDbXref>FBbt:00000168</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_6000168"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>FBbt:00000168</owl:annotatedTarget>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_6000169">
+        <oboInOwl:hasDbXref>FBbt:00000169</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_6000169"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>FBbt:00000169</owl:annotatedTarget>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_6000170">
+        <oboInOwl:hasDbXref>FBbt:00000170</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_6000170"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>FBbt:00000170</owl:annotatedTarget>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_6000171">
+        <oboInOwl:hasDbXref>FBbt:00000171</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_6000171"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>FBbt:00000171</owl:annotatedTarget>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_6000172">
+        <oboInOwl:hasDbXref>FBbt:00000172</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_6000172"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>FBbt:00000172</owl:annotatedTarget>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_6000180">
+        <oboInOwl:hasDbXref>FBbt:00000180</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_6000180"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>FBbt:00000180</owl:annotatedTarget>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_6000181">
+        <oboInOwl:hasDbXref>FBbt:00000181</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_6000181"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>FBbt:00000181</owl:annotatedTarget>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_6000186">
+        <oboInOwl:hasDbXref>FBbt:00000186</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_6000186"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>FBbt:00000186</owl:annotatedTarget>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_6001055">
+        <oboInOwl:hasDbXref>FBbt:00001055</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_6001055"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>FBbt:00001055</owl:annotatedTarget>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_6001056">
+        <oboInOwl:hasDbXref>FBbt:00001056</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_6001056"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>FBbt:00001056</owl:annotatedTarget>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_6001059">
+        <oboInOwl:hasDbXref>FBbt:00001059</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_6001059"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>FBbt:00001059</owl:annotatedTarget>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_6001060">
+        <oboInOwl:hasDbXref>FBbt:00001060</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_6001060"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>FBbt:00001060</owl:annotatedTarget>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_6001135">
+        <oboInOwl:hasDbXref>FBbt:00001135</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_6001135"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>FBbt:00001135</owl:annotatedTarget>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_6001648">
+        <oboInOwl:hasDbXref>FBbt:00001648</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_6001648"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>FBbt:00001648</owl:annotatedTarget>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_6001649">
+        <oboInOwl:hasDbXref>FBbt:00001649</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_6001649"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>FBbt:00001649</owl:annotatedTarget>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_6001650">
+        <oboInOwl:hasDbXref>FBbt:00001650</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_6001650"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>FBbt:00001650</owl:annotatedTarget>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_6001652">
+        <oboInOwl:hasDbXref>FBbt:00001652</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_6001652"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>FBbt:00001652</owl:annotatedTarget>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_6001653">
+        <oboInOwl:hasDbXref>FBbt:00001653</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_6001653"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>FBbt:00001653</owl:annotatedTarget>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_6001655">
+        <oboInOwl:hasDbXref>FBbt:00001655</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_6001655"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>FBbt:00001655</owl:annotatedTarget>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_6001656">
+        <oboInOwl:hasDbXref>FBbt:00001656</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_6001656"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>FBbt:00001656</owl:annotatedTarget>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_6001657">
+        <oboInOwl:hasDbXref>FBbt:00001657</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_6001657"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>FBbt:00001657</owl:annotatedTarget>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_6001658">
+        <oboInOwl:hasDbXref>FBbt:00001658</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_6001658"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>FBbt:00001658</owl:annotatedTarget>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_6001661">
+        <oboInOwl:hasDbXref>FBbt:00001661</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_6001661"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>FBbt:00001661</owl:annotatedTarget>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_6001662">
+        <oboInOwl:hasDbXref>FBbt:00001662</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_6001662"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>FBbt:00001662</owl:annotatedTarget>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_6001663">
+        <oboInOwl:hasDbXref>FBbt:00001663</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_6001663"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>FBbt:00001663</owl:annotatedTarget>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_6001664">
+        <oboInOwl:hasDbXref>FBbt:00001664</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_6001664"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>FBbt:00001664</owl:annotatedTarget>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_6001668">
+        <oboInOwl:hasDbXref>FBbt:00001668</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_6001668"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>FBbt:00001668</owl:annotatedTarget>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_6001722">
+        <oboInOwl:hasDbXref>FBbt:00001722</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_6001722"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>FBbt:00001722</owl:annotatedTarget>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_6001728">
+        <oboInOwl:hasDbXref>FBbt:00001728</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_6001728"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>FBbt:00001728</owl:annotatedTarget>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_6001729">
+        <oboInOwl:hasDbXref>FBbt:00001729</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_6001729"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>FBbt:00001729</owl:annotatedTarget>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_6001730">
+        <oboInOwl:hasDbXref>FBbt:00001730</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_6001730"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>FBbt:00001730</owl:annotatedTarget>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_6001731">
+        <oboInOwl:hasDbXref>FBbt:00001731</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_6001731"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>FBbt:00001731</owl:annotatedTarget>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_6001732">
+        <oboInOwl:hasDbXref>FBbt:00001732</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_6001732"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>FBbt:00001732</owl:annotatedTarget>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_6001733">
+        <oboInOwl:hasDbXref>FBbt:00001733</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_6001733"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>FBbt:00001733</owl:annotatedTarget>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_6001734">
+        <oboInOwl:hasDbXref>FBbt:00001734</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_6001734"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>FBbt:00001734</owl:annotatedTarget>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_6001735">
+        <oboInOwl:hasDbXref>FBbt:00001735</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_6001735"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>FBbt:00001735</owl:annotatedTarget>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_6001737">
+        <oboInOwl:hasDbXref>FBbt:00001737</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_6001737"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>FBbt:00001737</owl:annotatedTarget>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_6001740">
+        <oboInOwl:hasDbXref>FBbt:00001740</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_6001740"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>FBbt:00001740</owl:annotatedTarget>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_6001741">
+        <oboInOwl:hasDbXref>FBbt:00001741</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_6001741"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>FBbt:00001741</owl:annotatedTarget>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_6001742">
+        <oboInOwl:hasDbXref>FBbt:00001742</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_6001742"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>FBbt:00001742</owl:annotatedTarget>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_6001743">
+        <oboInOwl:hasDbXref>FBbt:00001743</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_6001743"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>FBbt:00001743</owl:annotatedTarget>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_6001744">
+        <oboInOwl:hasDbXref>FBbt:00001744</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_6001744"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>FBbt:00001744</owl:annotatedTarget>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_6001745">
+        <oboInOwl:hasDbXref>FBbt:00001745</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_6001745"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>FBbt:00001745</owl:annotatedTarget>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_6001746">
+        <oboInOwl:hasDbXref>FBbt:00001746</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_6001746"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>FBbt:00001746</owl:annotatedTarget>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_6001747">
+        <oboInOwl:hasDbXref>FBbt:00001747</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_6001747"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>FBbt:00001747</owl:annotatedTarget>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_6001755">
+        <oboInOwl:hasDbXref>FBbt:00001755</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_6001755"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>FBbt:00001755</owl:annotatedTarget>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_6001756">
+        <oboInOwl:hasDbXref>FBbt:00001756</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_6001756"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>FBbt:00001756</owl:annotatedTarget>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_6001760">
+        <oboInOwl:hasDbXref>FBbt:00001760</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_6001760"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>FBbt:00001760</owl:annotatedTarget>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_6001764">
+        <oboInOwl:hasDbXref>FBbt:00001764</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_6001764"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>FBbt:00001764</owl:annotatedTarget>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_6001765">
+        <oboInOwl:hasDbXref>FBbt:00001765</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_6001765"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>FBbt:00001765</owl:annotatedTarget>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_6001766">
+        <oboInOwl:hasDbXref>FBbt:00001766</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_6001766"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>FBbt:00001766</owl:annotatedTarget>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_6001767">
+        <oboInOwl:hasDbXref>FBbt:00001767</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_6001767"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>FBbt:00001767</owl:annotatedTarget>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_6001776">
+        <oboInOwl:hasDbXref>FBbt:00001776</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_6001776"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>FBbt:00001776</owl:annotatedTarget>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_6001778">
+        <oboInOwl:hasDbXref>FBbt:00001778</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_6001778"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>FBbt:00001778</owl:annotatedTarget>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_6001779">
+        <oboInOwl:hasDbXref>FBbt:00001779</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_6001779"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>FBbt:00001779</owl:annotatedTarget>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_6001780">
+        <oboInOwl:hasDbXref>FBbt:00001780</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_6001780"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>FBbt:00001780</owl:annotatedTarget>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_6001781">
+        <oboInOwl:hasDbXref>FBbt:00001781</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_6001781"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>FBbt:00001781</owl:annotatedTarget>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_6001784">
+        <oboInOwl:hasDbXref>FBbt:00001784</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_6001784"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>FBbt:00001784</owl:annotatedTarget>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_6001785">
+        <oboInOwl:hasDbXref>FBbt:00001785</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_6001785"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>FBbt:00001785</owl:annotatedTarget>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_6001787">
+        <oboInOwl:hasDbXref>FBbt:00001787</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_6001787"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>FBbt:00001787</owl:annotatedTarget>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_6001790">
+        <oboInOwl:hasDbXref>FBbt:00001790</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_6001790"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>FBbt:00001790</owl:annotatedTarget>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_6001842">
+        <oboInOwl:hasDbXref>FBbt:00001842</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_6001842"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>FBbt:00001842</owl:annotatedTarget>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_6001845">
+        <oboInOwl:hasDbXref>FBbt:00001845</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_6001845"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>FBbt:00001845</owl:annotatedTarget>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_6001848">
+        <oboInOwl:hasDbXref>FBbt:00001848</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_6001848"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>FBbt:00001848</owl:annotatedTarget>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_6001911">
+        <oboInOwl:hasDbXref>FBbt:00001911</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_6001911"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>FBbt:00001911</owl:annotatedTarget>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_6001919">
+        <oboInOwl:hasDbXref>FBbt:00001919</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_6001919"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>FBbt:00001919</owl:annotatedTarget>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_6001920">
+        <oboInOwl:hasDbXref>FBbt:00001920</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_6001920"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>FBbt:00001920</owl:annotatedTarget>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_6001925">
+        <oboInOwl:hasDbXref>FBbt:00001925</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_6001925"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>FBbt:00001925</owl:annotatedTarget>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_6002639">
+        <oboInOwl:hasDbXref>FBbt:00002639</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_6002639"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>FBbt:00002639</owl:annotatedTarget>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_6002642">
+        <oboInOwl:hasDbXref>FBbt:00002642</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_6002642"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>FBbt:00002642</owl:annotatedTarget>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_6003005">
+        <oboInOwl:hasDbXref>FBbt:00003005</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_6003005"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>FBbt:00003005</owl:annotatedTarget>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_6003006">
+        <oboInOwl:hasDbXref>FBbt:00003006</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_6003006"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>FBbt:00003006</owl:annotatedTarget>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_6003007">
+        <oboInOwl:hasDbXref>FBbt:00003007</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_6003007"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>FBbt:00003007</owl:annotatedTarget>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_6003009">
+        <oboInOwl:hasDbXref>FBbt:00003009</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_6003009"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>FBbt:00003009</owl:annotatedTarget>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_6003010">
+        <oboInOwl:hasDbXref>FBbt:00003010</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_6003010"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>FBbt:00003010</owl:annotatedTarget>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_6003011">
+        <oboInOwl:hasDbXref>FBbt:00003011</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_6003011"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>FBbt:00003011</owl:annotatedTarget>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_6003012">
+        <oboInOwl:hasDbXref>FBbt:00003012</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_6003012"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>FBbt:00003012</owl:annotatedTarget>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_6003018">
+        <oboInOwl:hasDbXref>FBbt:00003018</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_6003018"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>FBbt:00003018</owl:annotatedTarget>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_6003019">
+        <oboInOwl:hasDbXref>FBbt:00003019</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_6003019"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>FBbt:00003019</owl:annotatedTarget>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_6003020">
+        <oboInOwl:hasDbXref>FBbt:00003020</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_6003020"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>FBbt:00003020</owl:annotatedTarget>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_6003021">
+        <oboInOwl:hasDbXref>FBbt:00003021</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_6003021"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>FBbt:00003021</owl:annotatedTarget>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_6003023">
+        <oboInOwl:hasDbXref>FBbt:00003023</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_6003023"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>FBbt:00003023</owl:annotatedTarget>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_6003024">
+        <oboInOwl:hasDbXref>FBbt:00003024</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_6003024"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>FBbt:00003024</owl:annotatedTarget>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_6003039">
+        <oboInOwl:hasDbXref>FBbt:00003039</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_6003039"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>FBbt:00003039</owl:annotatedTarget>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_6003259">
+        <oboInOwl:hasDbXref>FBbt:00003259</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_6003259"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>FBbt:00003259</owl:annotatedTarget>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_6003559">
+        <oboInOwl:hasDbXref>FBbt:00003559</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_6003559"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>FBbt:00003559</owl:annotatedTarget>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_6003623">
+        <oboInOwl:hasDbXref>FBbt:00003623</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_6003623"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>FBbt:00003623</owl:annotatedTarget>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_6003624">
+        <oboInOwl:hasDbXref>FBbt:00003624</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_6003624"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>FBbt:00003624</owl:annotatedTarget>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_6003626">
+        <oboInOwl:hasDbXref>FBbt:00003626</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_6003626"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>FBbt:00003626</owl:annotatedTarget>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_6003627">
+        <oboInOwl:hasDbXref>FBbt:00003627</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_6003627"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>FBbt:00003627</owl:annotatedTarget>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_6003632">
+        <oboInOwl:hasDbXref>FBbt:00003632</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_6003632"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>FBbt:00003632</owl:annotatedTarget>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_6004296">
+        <oboInOwl:hasDbXref>FBbt:00004296</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_6004296"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>FBbt:00004296</owl:annotatedTarget>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_6004340">
+        <oboInOwl:hasDbXref>FBbt:00004340</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_6004340"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>FBbt:00004340</owl:annotatedTarget>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_6004475">
+        <oboInOwl:hasDbXref>FBbt:00004475</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_6004475"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>FBbt:00004475</owl:annotatedTarget>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_6004476">
+        <oboInOwl:hasDbXref>FBbt:00004476</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_6004476"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>FBbt:00004476</owl:annotatedTarget>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_6004477">
+        <oboInOwl:hasDbXref>FBbt:00004477</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_6004477"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>FBbt:00004477</owl:annotatedTarget>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_6004481">
+        <oboInOwl:hasDbXref>FBbt:00004481</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_6004481"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>FBbt:00004481</owl:annotatedTarget>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_6004519">
+        <oboInOwl:hasDbXref>FBbt:00004519</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_6004519"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>FBbt:00004519</owl:annotatedTarget>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_6004520">
+        <oboInOwl:hasDbXref>FBbt:00004520</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_6004520"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>FBbt:00004520</owl:annotatedTarget>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_6004521">
+        <oboInOwl:hasDbXref>FBbt:00004521</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_6004521"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>FBbt:00004521</owl:annotatedTarget>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_6004535">
+        <oboInOwl:hasDbXref>FBbt:00004535</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_6004535"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>FBbt:00004535</owl:annotatedTarget>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_6004540">
+        <oboInOwl:hasDbXref>FBbt:00004540</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_6004540"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>FBbt:00004540</owl:annotatedTarget>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_6004551">
+        <oboInOwl:hasDbXref>FBbt:00004551</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_6004551"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>FBbt:00004551</owl:annotatedTarget>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_6004552">
+        <oboInOwl:hasDbXref>FBbt:00004552</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_6004552"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>FBbt:00004552</owl:annotatedTarget>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_6004578">
+        <oboInOwl:hasDbXref>FBbt:00004578</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_6004578"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>FBbt:00004578</owl:annotatedTarget>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_6004579">
+        <oboInOwl:hasDbXref>FBbt:00004579</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_6004579"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>FBbt:00004579</owl:annotatedTarget>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_6004580">
+        <oboInOwl:hasDbXref>FBbt:00004580</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_6004580"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>FBbt:00004580</owl:annotatedTarget>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_6004646">
+        <oboInOwl:hasDbXref>FBbt:00004646</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_6004646"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>FBbt:00004646</owl:annotatedTarget>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_6004648">
+        <oboInOwl:hasDbXref>FBbt:00004648</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_6004648"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>FBbt:00004648</owl:annotatedTarget>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_6004663">
+        <oboInOwl:hasDbXref>FBbt:00004663</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_6004663"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>FBbt:00004663</owl:annotatedTarget>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_6004668">
+        <oboInOwl:hasDbXref>FBbt:00004668</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_6004668"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>FBbt:00004668</owl:annotatedTarget>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_6004670">
+        <oboInOwl:hasDbXref>FBbt:00004670</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_6004670"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>FBbt:00004670</owl:annotatedTarget>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_6004788">
+        <oboInOwl:hasDbXref>FBbt:00004788</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_6004788"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>FBbt:00004788</owl:annotatedTarget>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_6004823">
+        <oboInOwl:hasDbXref>FBbt:00004823</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_6004823"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>FBbt:00004823</owl:annotatedTarget>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_6004824">
+        <oboInOwl:hasDbXref>FBbt:00004824</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_6004824"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>FBbt:00004824</owl:annotatedTarget>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_6004825">
+        <oboInOwl:hasDbXref>FBbt:00004825</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_6004825"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>FBbt:00004825</owl:annotatedTarget>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_6004979">
+        <oboInOwl:hasDbXref>FBbt:00004979</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_6004979"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>FBbt:00004979</owl:annotatedTarget>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_6004983">
+        <oboInOwl:hasDbXref>FBbt:00004983</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_6004983"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>FBbt:00004983</owl:annotatedTarget>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_6004986">
+        <oboInOwl:hasDbXref>FBbt:00004986</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_6004986"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>FBbt:00004986</owl:annotatedTarget>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_6005023">
+        <oboInOwl:hasDbXref>FBbt:00005023</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_6005023"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>FBbt:00005023</owl:annotatedTarget>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_6005036">
+        <oboInOwl:hasDbXref>FBbt:00005036</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_6005036"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>FBbt:00005036</owl:annotatedTarget>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_6005037">
+        <oboInOwl:hasDbXref>FBbt:00005037</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_6005037"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>FBbt:00005037</owl:annotatedTarget>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_6005043">
+        <oboInOwl:hasDbXref>FBbt:00005043</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_6005043"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>FBbt:00005043</owl:annotatedTarget>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_6005054">
+        <oboInOwl:hasDbXref>FBbt:00005054</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_6005054"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>FBbt:00005054</owl:annotatedTarget>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_6005096">
+        <oboInOwl:hasDbXref>FBbt:00005096</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_6005096"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>FBbt:00005096</owl:annotatedTarget>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_6005168">
+        <oboInOwl:hasDbXref>FBbt:00005168</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_6005168"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>FBbt:00005168</owl:annotatedTarget>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_6005177">
+        <oboInOwl:hasDbXref>FBbt:00005177</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_6005177"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>FBbt:00005177</owl:annotatedTarget>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_6005378">
+        <oboInOwl:hasDbXref>FBbt:00005378</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_6005378"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>FBbt:00005378</owl:annotatedTarget>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_6005380">
+        <oboInOwl:hasDbXref>FBbt:00005380</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_6005380"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>FBbt:00005380</owl:annotatedTarget>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_6005393">
+        <oboInOwl:hasDbXref>FBbt:00005393</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_6005393"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>FBbt:00005393</owl:annotatedTarget>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_6005396">
+        <oboInOwl:hasDbXref>FBbt:00005396</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_6005396"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>FBbt:00005396</owl:annotatedTarget>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_6005427">
+        <oboInOwl:hasDbXref>FBbt:00005427</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_6005427"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>FBbt:00005427</owl:annotatedTarget>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_6005461">
+        <oboInOwl:hasDbXref>FBbt:00005461</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_6005461"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>FBbt:00005461</owl:annotatedTarget>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_6005467">
+        <oboInOwl:hasDbXref>FBbt:00005467</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_6005467"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>FBbt:00005467</owl:annotatedTarget>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_6005514">
+        <oboInOwl:hasDbXref>FBbt:00005514</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_6005514"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>FBbt:00005514</owl:annotatedTarget>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_6005526">
+        <oboInOwl:hasDbXref>FBbt:00005526</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_6005526"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>FBbt:00005526</owl:annotatedTarget>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_6005533">
+        <oboInOwl:hasDbXref>FBbt:00005533</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_6005533"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>FBbt:00005533</owl:annotatedTarget>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_6005538">
+        <oboInOwl:hasDbXref>FBbt:00005538</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_6005538"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>FBbt:00005538</owl:annotatedTarget>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_6005558">
+        <oboInOwl:hasDbXref>FBbt:00005558</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_6005558"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>FBbt:00005558</owl:annotatedTarget>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_6005569">
+        <oboInOwl:hasDbXref>FBbt:00005569</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_6005569"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>FBbt:00005569</owl:annotatedTarget>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_6005805">
+        <oboInOwl:hasDbXref>FBbt:00005805</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_6005805"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>FBbt:00005805</owl:annotatedTarget>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_6005830">
+        <oboInOwl:hasDbXref>FBbt:00005830</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_6005830"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>FBbt:00005830</owl:annotatedTarget>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_6005831">
+        <oboInOwl:hasDbXref>FBbt:00005831</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_6005831"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>FBbt:00005831</owl:annotatedTarget>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_6005913">
+        <oboInOwl:hasDbXref>FBbt:00005913</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_6005913"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>FBbt:00005913</owl:annotatedTarget>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_6006011">
+        <oboInOwl:hasDbXref>FBbt:00006011</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_6006011"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>FBbt:00006011</owl:annotatedTarget>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_6006032">
+        <oboInOwl:hasDbXref>FBbt:00006032</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_6006032"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>FBbt:00006032</owl:annotatedTarget>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_6007020">
+        <oboInOwl:hasDbXref>FBbt:00007020</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_6007020"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>FBbt:00007020</owl:annotatedTarget>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_6007045">
+        <oboInOwl:hasDbXref>FBbt:00007045</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_6007045"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>FBbt:00007045</owl:annotatedTarget>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_6007046">
+        <oboInOwl:hasDbXref>FBbt:00007046</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_6007046"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>FBbt:00007046</owl:annotatedTarget>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_6007070">
+        <oboInOwl:hasDbXref>FBbt:00007070</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_6007070"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>FBbt:00007070</owl:annotatedTarget>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_6007116">
+        <oboInOwl:hasDbXref>FBbt:00007116</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_6007116"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>FBbt:00007116</owl:annotatedTarget>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_6007145">
+        <oboInOwl:hasDbXref>FBbt:00007145</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_6007145"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>FBbt:00007145</owl:annotatedTarget>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_6007149">
+        <oboInOwl:hasDbXref>FBbt:00007149</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_6007149"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>FBbt:00007149</owl:annotatedTarget>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_6007150">
+        <oboInOwl:hasDbXref>FBbt:00007150</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_6007150"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>FBbt:00007150</owl:annotatedTarget>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_6007231">
+        <oboInOwl:hasDbXref>FBbt:00007231</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_6007231"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>FBbt:00007231</owl:annotatedTarget>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_6007232">
+        <oboInOwl:hasDbXref>FBbt:00007232</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_6007232"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>FBbt:00007232</owl:annotatedTarget>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_6007233">
+        <oboInOwl:hasDbXref>FBbt:00007233</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_6007233"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>FBbt:00007233</owl:annotatedTarget>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_6007240">
+        <oboInOwl:hasDbXref>FBbt:00007240</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_6007240"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>FBbt:00007240</owl:annotatedTarget>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_6007242">
+        <oboInOwl:hasDbXref>FBbt:00007242</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_6007242"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>FBbt:00007242</owl:annotatedTarget>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_6007245">
+        <oboInOwl:hasDbXref>FBbt:00007245</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_6007245"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>FBbt:00007245</owl:annotatedTarget>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_6007248">
+        <oboInOwl:hasDbXref>FBbt:00007248</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_6007248"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>FBbt:00007248</owl:annotatedTarget>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_6007280">
+        <oboInOwl:hasDbXref>FBbt:00007280</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_6007280"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>FBbt:00007280</owl:annotatedTarget>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_6007284">
+        <oboInOwl:hasDbXref>FBbt:00007284</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_6007284"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>FBbt:00007284</owl:annotatedTarget>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_6007285">
+        <oboInOwl:hasDbXref>FBbt:00007285</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_6007285"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>FBbt:00007285</owl:annotatedTarget>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_6007288">
+        <oboInOwl:hasDbXref>FBbt:00007288</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_6007288"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>FBbt:00007288</owl:annotatedTarget>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_6007289">
+        <oboInOwl:hasDbXref>FBbt:00007289</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_6007289"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>FBbt:00007289</owl:annotatedTarget>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_6007331">
+        <oboInOwl:hasDbXref>FBbt:00007331</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_6007331"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>FBbt:00007331</owl:annotatedTarget>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_6007373">
+        <oboInOwl:hasDbXref>FBbt:00007373</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_6007373"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>FBbt:00007373</owl:annotatedTarget>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_6007424">
+        <oboInOwl:hasDbXref>FBbt:00007424</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_6007424"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>FBbt:00007424</owl:annotatedTarget>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_6016022">
+        <oboInOwl:hasDbXref>FBbt:00016022</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_6016022"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>FBbt:00016022</owl:annotatedTarget>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_6040003">
+        <oboInOwl:hasDbXref>FBbt:00040003</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_6040003"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>FBbt:00040003</owl:annotatedTarget>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_6040005">
+        <oboInOwl:hasDbXref>FBbt:00040005</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_6040005"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>FBbt:00040005</owl:annotatedTarget>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_6040007">
+        <oboInOwl:hasDbXref>FBbt:00040007</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_6040007"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>FBbt:00040007</owl:annotatedTarget>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_6041000">
+        <oboInOwl:hasDbXref>FBbt:00041000</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_6041000"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>FBbt:00041000</owl:annotatedTarget>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_6100153">
+        <oboInOwl:hasDbXref>FBbt:00100153</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_6100153"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>FBbt:00100153</owl:annotatedTarget>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_6110636">
+        <oboInOwl:hasDbXref>FBbt:00110636</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_6110636"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>FBbt:00110636</owl:annotatedTarget>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_6110746">
+        <oboInOwl:hasDbXref>FBbt:00110746</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_6110746"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>FBbt:00110746</owl:annotatedTarget>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_6110811">
+        <oboInOwl:hasDbXref>FBbt:00110811</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_6110811"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>FBbt:00110811</owl:annotatedTarget>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_8440012">
+        <oboInOwl:hasDbXref>BTO:0006534</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_8440012"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>BTO:0006534</owl:annotatedTarget>
+        <sssom:author_id rdf:resource="https://orcid.org/0000-0003-4423-4370"/>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+        <sssom:mapping_provider>https://github.com/biopragmatics/biomappings</sssom:mapping_provider>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_8450002">
+        <oboInOwl:hasDbXref>BTO:0006338</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_8450002"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>BTO:0006338</owl:annotatedTarget>
+        <sssom:author_id rdf:resource="https://orcid.org/0000-0003-4423-4370"/>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+        <sssom:mapping_provider>https://github.com/biopragmatics/biomappings</sssom:mapping_provider>
+    </owl:Axiom>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_8480040">
+        <oboInOwl:hasDbXref>BTO:0004569</oboInOwl:hasDbXref>
+    </rdf:Description>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_8480040"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget>BTO:0004569</owl:annotatedTarget>
+        <sssom:author_id rdf:resource="https://orcid.org/0000-0003-4423-4370"/>
+        <sssom:mapping_justification rdf:resource="https://w3id.org/semapv/vocab/ManualMappingCuration"/>
+        <sssom:mapping_provider>https://github.com/biopragmatics/biomappings</sssom:mapping_provider>
+    </owl:Axiom>
 </rdf:RDF>
+
+
+
+<!-- Generated by the OWL API (version 4.5.26) https://github.com/owlcs/owlapi -->
+

--- a/src/ontology/mappings/biomappings-mappings.sssom.tsv
+++ b/src/ontology/mappings/biomappings-mappings.sssom.tsv
@@ -1,0 +1,371 @@
+#creator_id:
+#- orcid:0000-0001-9439-5346
+#- orcid:0000-0002-1216-4761
+#- orcid:0000-0002-2046-6145
+#- orcid:0000-0002-2627-0696
+#- orcid:0000-0002-6601-2165
+#- orcid:0000-0003-1307-2508
+#- orcid:0000-0003-4423-4370
+#curie_map:
+#  AGRO: http://purl.obolibrary.org/obo/AGRO_
+#  APOLLO_SV: http://purl.obolibrary.org/obo/APOLLO_SV_
+#  BFO: http://purl.obolibrary.org/obo/BFO_
+#  BTO: http://purl.obolibrary.org/obo/BTO_
+#  CARO: http://purl.obolibrary.org/obo/CARO_
+#  CHEBI: http://purl.obolibrary.org/obo/CHEBI_
+#  CHMO: http://purl.obolibrary.org/obo/CHMO_
+#  CIDO: http://purl.obolibrary.org/obo/CIDO_
+#  CL: http://purl.obolibrary.org/obo/CL_
+#  CLO: http://purl.obolibrary.org/obo/CLO_
+#  DOID: http://purl.obolibrary.org/obo/DOID_
+#  DRON: http://purl.obolibrary.org/obo/DRON_
+#  EFO: http://www.ebi.ac.uk/efo/EFO_
+#  ENVO: http://purl.obolibrary.org/obo/ENVO_
+#  FMA: http://purl.org/sig/ont/fma/fma
+#  GO: http://purl.obolibrary.org/obo/GO_
+#  HP: http://purl.obolibrary.org/obo/HP_
+#  IAO: http://purl.obolibrary.org/obo/IAO_
+#  IDO: http://purl.obolibrary.org/obo/IDO_
+#  IDOMAL: http://purl.obolibrary.org/obo/IDOMAL_
+#  MAXO: http://purl.obolibrary.org/obo/MAXO_
+#  MI: http://purl.obolibrary.org/obo/MI_
+#  MIAPA: http://purl.obolibrary.org/obo/MIAPA_
+#  MIRO: http://purl.obolibrary.org/obo/MIRO_
+#  MONDO: http://purl.obolibrary.org/obo/MONDO_
+#  MPATH: http://purl.obolibrary.org/obo/MPATH_
+#  NBO: http://purl.obolibrary.org/obo/NBO_
+#  NCBIProtein: https://www.ncbi.nlm.nih.gov/protein/
+#  NCBITaxon: http://purl.obolibrary.org/obo/NCBITaxon_
+#  NCIT: http://purl.obolibrary.org/obo/NCIT_
+#  OAE: http://purl.obolibrary.org/obo/OAE_
+#  OBI: http://purl.obolibrary.org/obo/OBI_
+#  OGG: http://purl.obolibrary.org/obo/OGG_
+#  OGMS: http://purl.obolibrary.org/obo/OGMS_
+#  OPMI: http://purl.obolibrary.org/obo/OPMI_
+#  PATO: http://purl.obolibrary.org/obo/PATO_
+#  PCO: http://purl.obolibrary.org/obo/PCO_
+#  PR: http://purl.obolibrary.org/obo/PR_
+#  RO: http://purl.obolibrary.org/obo/RO_
+#  STATO: http://purl.obolibrary.org/obo/STATO_
+#  UBERON: http://purl.obolibrary.org/obo/UBERON_
+#  VO: http://purl.obolibrary.org/obo/VO_
+#  agrovoc: http://aims.fao.org/aos/agrovoc/c_
+#  aio: https://w3id.org/aio/
+#  ccle: https://www.cbioportal.org/patient?studyId=ccle_broad_2019&caseId=
+#  cellosaurus: https://www.cellosaurus.org/CVCL_
+#  cemo: https://biopragmatics.github.io/providers/cemo/
+#  commoncoreontology: http://www.ontologyrepository.com/CommonCoreOntologies/
+#  cpt: https://www.aapc.com/codes/cpt-codes/
+#  cvx: https://biopragmatics.github.io/providers/cvx/
+#  dc: http://purl.org/dc/elements/1.1/
+#  debio: https://biopragmatics.github.io/debio/
+#  depmap: https://depmap.org/portal/cell_line/
+#  drugbank: http://www.drugbank.ca/drugs/
+#  fplx: https://sorgerlab.github.io/famplex/
+#  hgnc: https://www.genenames.org/data/gene-symbol-report/#!/hgnc_id/
+#  idocovid19: http://purl.obolibrary.org/obo/COVIDO_
+#  interpro: http://purl.obolibrary.org/obo/IPR_
+#  ito: https://bioportal.bioontology.org/ontologies/ITO/?p=classes&conceptid=https://identifiers.org/ito:ITO_
+#  kegg.pathway: https://www.kegg.jp/entry/
+#  kestrelo: http://purl.obolibrary.org/obo/kestrelo_
+#  mesh: https://meshb.nlm.nih.gov/record/ui?ui=
+#  ndfrt: https://evs.nci.nih.gov/ftp1/NDF-RT/NDF-RT.owl#
+#  obo: http://purl.obolibrary.org/obo/
+#  oboInOwl: http://www.geneontology.org/formats/oboInOwl#
+#  orcid: https://orcid.org/
+#  pfam: https://www.ebi.ac.uk/interpro/entry/pfam/
+#  pubchem.compound: https://pubchem.ncbi.nlm.nih.gov/compound/
+#  reactome: https://reactome.org/content/detail/
+#  skos: http://www.w3.org/2004/02/skos/core#
+#  umls: http://linkedlifedata.com/resource/umls/id/
+#  uniprot: https://purl.uniprot.org/uniprot/
+#  uniprot.chain: http://purl.uniprot.org/annotation/
+#  vido: http://purl.obolibrary.org/obo/VIDO_
+#  vsmo: http://purl.obolibrary.org/obo/VSMO_
+#  wikipathways: http://www.wikipathways.org/instance/
+#license: https://creativecommons.org/publicdomain/zero/1.0/
+#mapping_provider: https://github.com/biopragmatics/biomappings
+#mapping_set_description: Biomappings is a repository of community curated and predicted
+#  equivalences and related mappings between named biological entities that are not
+#  available from primary sources. It's also a place where anyone can contribute curations
+#  of predicted mappings or their own novel mappings.
+#mapping_set_id: https://w3id.org/biopragmatics/biomappings/sssom/biomappings.sssom.tsv
+#mapping_set_title: Biomappings
+#mapping_set_version: 0.3.7.dev0
+subject_id	subject_label	predicate_id	predicate_modifier	object_id	object_label	mapping_justification	author_id	confidence	mapping_tool
+IDOMAL:0000302	zygote stage	skos:exactMatch		UBERON:0000106	zygote stage	semapv:ManualMappingCuration	orcid:0000-0003-4423-4370		
+IDOMAL:0000646	embryo	skos:exactMatch		UBERON:0000922	embryo	semapv:ManualMappingCuration	orcid:0000-0003-4423-4370	0.7777777777777778	mira
+IDOMAL:0002421	compound eye	skos:exactMatch		UBERON:0000018	compound eye	semapv:ManualMappingCuration	orcid:0000-0003-4423-4370	0.7777777777777778	mira
+IDOMAL:0002459	anatomical group	skos:exactMatch		UBERON:0000480	anatomical group	semapv:ManualMappingCuration	orcid:0000-0003-4423-4370	0.7777777777777778	mira
+IDOMAL:0002460	anatomical system	skos:exactMatch		UBERON:0000467	anatomical system	semapv:ManualMappingCuration	orcid:0000-0003-4423-4370	0.7777777777777778	mira
+IDOMAL:0002461	anatomical cluster	skos:exactMatch		UBERON:0000477	anatomical cluster	semapv:ManualMappingCuration	orcid:0000-0003-4423-4370	0.7777777777777778	mira
+UBERON:0000017	exocrine pancreas	skos:exactMatch		mesh:D046790	Pancreas, Exocrine	semapv:ManualMappingCuration	orcid:0000-0001-9439-5346		
+UBERON:0000076	external ectoderm	skos:exactMatch		BTO:0006242	external ectoderm	semapv:ManualMappingCuration	orcid:0000-0003-4423-4370	0.9	generate_uberon_bto_mappings.py
+UBERON:0000105	life cycle stage	skos:exactMatch		mesh:D008018	Life Cycle Stages	semapv:ManualMappingCuration	orcid:0000-0001-9439-5346		
+UBERON:0000120	blood brain barrier	skos:exactMatch		mesh:D001812	Blood-Brain Barrier	semapv:ManualMappingCuration	orcid:0000-0001-9439-5346		
+UBERON:0000127	facial nucleus	skos:exactMatch		mesh:D065828	Facial Nucleus	semapv:ManualMappingCuration	orcid:0000-0001-9439-5346		
+UBERON:0000159	anal canal	skos:exactMatch		mesh:D001003	Anal Canal	semapv:ManualMappingCuration	orcid:0000-0001-9439-5346		
+UBERON:0000175	pleural effusion	skos:exactMatch		mesh:D010996	Pleural Effusion	semapv:ManualMappingCuration	orcid:0000-0001-9439-5346		
+UBERON:0000220	atlanto-occipital joint	skos:exactMatch		mesh:D001269	Atlanto-Occipital Joint	semapv:ManualMappingCuration	orcid:0000-0001-9439-5346		
+UBERON:0000353	parenchyma	skos:exactMatch		BTO:0001539	parenchyma	semapv:ManualMappingCuration	orcid:0000-0003-4423-4370	0.9	generate_uberon_bto_mappings.py
+UBERON:0000387	meniscus	skos:exactMatch		mesh:D000072600	Meniscus	semapv:ManualMappingCuration	orcid:0000-0001-9439-5346		
+UBERON:0000569	ileocecal valve	skos:exactMatch		mesh:D007080	Ileocecal Valve	semapv:ManualMappingCuration	orcid:0000-0001-9439-5346		
+UBERON:0000939	imaginal disc	skos:exactMatch		mesh:D060227	Imaginal Discs	semapv:ManualMappingCuration	orcid:0000-0001-9439-5346		
+UBERON:0001049	neural tube	skos:exactMatch		mesh:D054259	Neural Tube	semapv:ManualMappingCuration	orcid:0000-0001-9439-5346		
+UBERON:0001156	ascending colon	skos:exactMatch		mesh:D044682	Colon, Ascending	semapv:ManualMappingCuration	orcid:0000-0001-9439-5346		
+UBERON:0001157	transverse colon	skos:exactMatch		mesh:D044684	Colon, Transverse	semapv:ManualMappingCuration	orcid:0000-0001-9439-5346		
+UBERON:0001158	descending colon	skos:exactMatch		mesh:D044683	Colon, Descending	semapv:ManualMappingCuration	orcid:0000-0001-9439-5346		
+UBERON:0001347	white adipose tissue	skos:exactMatch		mesh:D052436	Adipose Tissue, White	semapv:ManualMappingCuration	orcid:0000-0001-9439-5346		
+UBERON:0001473	lymphatic vessel	skos:exactMatch		mesh:D042601	Lymphatic Vessels	semapv:ManualMappingCuration	orcid:0000-0001-9439-5346		
+UBERON:0001642	superior sagittal sinus	skos:exactMatch		mesh:D054063	Superior Sagittal Sinus	semapv:ManualMappingCuration	orcid:0000-0001-9439-5346		
+UBERON:0001715	oculomotor nuclear complex	skos:exactMatch		mesh:D065838	Oculomotor Nuclear Complex	semapv:ManualMappingCuration	orcid:0000-0001-9439-5346		
+UBERON:0001806	sympathetic ganglion	skos:exactMatch		mesh:D005728	Ganglia, Sympathetic	semapv:ManualMappingCuration	orcid:0000-0001-9439-5346		
+UBERON:0001808	parasympathetic ganglion	skos:exactMatch		mesh:D005726	Ganglia, Parasympathetic	semapv:ManualMappingCuration	orcid:0000-0001-9439-5346		
+UBERON:0001823	nasal cartilage	skos:exactMatch		mesh:D055171	Nasal Cartilages	semapv:ManualMappingCuration	orcid:0000-0001-9439-5346		
+UBERON:0001856	semicircular duct	skos:exactMatch		mesh:D054776	Semicircular Ducts	semapv:ManualMappingCuration	orcid:0000-0001-9439-5346		
+UBERON:0001862	vestibular labyrinth	skos:exactMatch		mesh:D014722	Vestibule, Labyrinth	semapv:ManualMappingCuration	orcid:0000-0001-9439-5346		
+UBERON:0001863	scala vestibuli	skos:exactMatch		mesh:D054738	Scala Vestibuli	semapv:ManualMappingCuration	orcid:0000-0001-9439-5346		
+UBERON:0001883	olfactory tubercle	skos:exactMatch		mesh:D066208	Olfactory Tubercle	semapv:ManualMappingCuration	orcid:0000-0001-9439-5346		
+UBERON:0001907	zona incerta	skos:exactMatch		mesh:D065820	Zona Incerta	semapv:ManualMappingCuration	orcid:0000-0001-9439-5346		
+UBERON:0001931	lateral preoptic nucleus	skos:exactMatch		BTO:0006166	nucleus preopticus lateralis	semapv:ManualMappingCuration	orcid:0000-0003-4423-4370	0.556	https://github.com/biomappings/biomappings/blob/530a1b/scripts/generate_uberon_bto_mappings.py
+UBERON:0001944	pretectal region	skos:exactMatch		mesh:D066250	Pretectal Region	semapv:ManualMappingCuration	orcid:0000-0001-9439-5346		
+UBERON:0001947	red nucleus	skos:exactMatch		BTO:0006329	red nucleus	semapv:ManualMappingCuration	orcid:0000-0003-4423-4370	0.9	generate_uberon_bto_mappings.py
+UBERON:0001977	blood serum	skos:exactMatch		mesh:D044967	Serum	semapv:ManualMappingCuration	orcid:0000-0001-9439-5346		
+UBERON:0001995	fibrocartilage	skos:exactMatch		mesh:D051445	Fibrocartilage	semapv:ManualMappingCuration	orcid:0000-0001-9439-5346		
+UBERON:0002020	gray matter	skos:exactMatch		mesh:D066128	Gray Matter	semapv:ManualMappingCuration	orcid:0000-0001-9439-5346		
+UBERON:0002035	medial preoptic nucleus	skos:exactMatch		BTO:0006167	nucleus preopticus medialis	semapv:ManualMappingCuration	orcid:0000-0003-4423-4370	0.556	https://github.com/biomappings/biomappings/blob/530a1b/scripts/generate_uberon_bto_mappings.py
+UBERON:0002043	dorsal raphe nucleus	skos:exactMatch		mesh:D065847	Dorsal Raphe Nucleus	semapv:ManualMappingCuration	orcid:0000-0001-9439-5346		
+UBERON:0002062	endocardial cushion	skos:exactMatch		mesh:D054089	Endocardial Cushions	semapv:ManualMappingCuration	orcid:0000-0001-9439-5346		
+UBERON:0002120	pronephros	skos:exactMatch		mesh:D060910	Pronephros	semapv:ManualMappingCuration	orcid:0000-0001-9439-5346		
+UBERON:0002128	superior olivary complex	skos:exactMatch		mesh:D065832	Superior Olivary Complex	semapv:ManualMappingCuration	orcid:0000-0001-9439-5346		
+UBERON:0002142	pedunculopontine tegmental nucleus	skos:exactMatch		mesh:D045042	Pedunculopontine Tegmental Nucleus	semapv:ManualMappingCuration	orcid:0000-0003-4423-4370		
+UBERON:0002145	interpeduncular nucleus	skos:exactMatch		mesh:D066268	Interpeduncular Nucleus	semapv:ManualMappingCuration	orcid:0000-0001-9439-5346		
+UBERON:0002152	middle cerebellar peduncle	skos:exactMatch		mesh:D065837	Middle Cerebellar Peduncle	semapv:ManualMappingCuration	orcid:0000-0001-9439-5346		
+UBERON:0002156	nucleus raphe magnus	skos:exactMatch		mesh:D065846	Nucleus Raphe Magnus	semapv:ManualMappingCuration	orcid:0000-0001-9439-5346		
+UBERON:0002157	nucleus raphe pallidus	skos:exactMatch		mesh:D065848	Nucleus Raphe Pallidus	semapv:ManualMappingCuration	orcid:0000-0001-9439-5346		
+UBERON:0002186	bronchiole	skos:exactMatch		mesh:D055745	Bronchioles	semapv:ManualMappingCuration	orcid:0000-0001-9439-5346		
+UBERON:0002219	subfornical organ	skos:exactMatch		BTO:0006266	subfornical organ	semapv:ManualMappingCuration	orcid:0000-0003-4423-4370	0.9	generate_uberon_bto_mappings.py
+UBERON:0002236	costal cartilage	skos:exactMatch		mesh:D066186	Costal Cartilage	semapv:ManualMappingCuration	orcid:0000-0001-9439-5346		
+UBERON:0002242	nucleus pulposus	skos:exactMatch		mesh:D000070614	Nucleus Pulposus	semapv:ManualMappingCuration	orcid:0000-0001-9439-5346		
+UBERON:0002262	celiac ganglion	skos:exactMatch		BTO:0006296	celiac ganglion	semapv:ManualMappingCuration	orcid:0000-0003-4423-4370	0.9	generate_uberon_bto_mappings.py
+UBERON:0002316	white matter	skos:exactMatch		mesh:D066127	White Matter	semapv:ManualMappingCuration	orcid:0000-0001-9439-5346		
+UBERON:0002373	palatine tonsil	skos:exactMatch		mesh:D014066	Palatine Tonsil	semapv:ManualMappingCuration	orcid:0000-0001-9439-5346		
+UBERON:0002396	vomer	skos:exactMatch		mesh:D055172	Vomer	semapv:ManualMappingCuration	orcid:0000-0001-9439-5346		
+UBERON:0002409	pericardial fluid	skos:exactMatch		mesh:D000069236	Pericardial Fluid	semapv:ManualMappingCuration	orcid:0000-0001-9439-5346		
+UBERON:0002412	vertebra	skos:exactMatch		BTO:0006196	vertebra	semapv:ManualMappingCuration	orcid:0000-0003-4423-4370	0.9	generate_uberon_bto_mappings.py
+UBERON:0002430	lateral hypothalamic area	skos:exactMatch		BTO:0006481	lateral hypothalamus	semapv:ManualMappingCuration	orcid:0000-0003-4423-4370	0.556	https://github.com/biomappings/biomappings/blob/530a1b/scripts/generate_uberon_bto_mappings.py
+UBERON:0002469	esophagus mucosa	skos:exactMatch		mesh:D000071041	Esophageal Mucosa	semapv:ManualMappingCuration	orcid:0000-0001-9439-5346		
+UBERON:0002493	uterine artery	skos:exactMatch		mesh:D055988	Uterine Artery	semapv:ManualMappingCuration	orcid:0000-0001-9439-5346		
+UBERON:0002540	lateral line system	skos:exactMatch		mesh:D053403	Lateral Line System	semapv:ManualMappingCuration	orcid:0000-0001-9439-5346		
+UBERON:0002548	larva	skos:exactMatch		mesh:D007814	Larva	semapv:ManualMappingCuration	orcid:0000-0001-9439-5346		
+UBERON:0002600	limbic lobe	skos:exactMatch		mesh:D065726	Limbic Lobe	semapv:ManualMappingCuration	orcid:0000-0001-9439-5346		
+UBERON:0002623	cerebral peduncle	skos:exactMatch		mesh:D065850	Cerebral Peduncle	semapv:ManualMappingCuration	orcid:0000-0001-9439-5346		
+UBERON:0002625	median preoptic nucleus	skos:exactMatch		BTO:0006168	nucleus preopticus medianus	semapv:ManualMappingCuration	orcid:0000-0003-4423-4370	0.556	https://github.com/biomappings/biomappings/blob/530a1b/scripts/generate_uberon_bto_mappings.py
+UBERON:0002631	cerebral crus	skos:exactMatch		mesh:D065843	Cerebral Crus	semapv:ManualMappingCuration	orcid:0000-0001-9439-5346		
+UBERON:0002639	midbrain reticular formation	skos:exactMatch		mesh:D066265	Midbrain Reticular Formation	semapv:ManualMappingCuration	orcid:0000-0001-9439-5346		
+UBERON:0002682	abducens nucleus	skos:exactMatch		mesh:D065827	Abducens Nucleus	semapv:ManualMappingCuration	orcid:0000-0001-9439-5346		
+UBERON:0002684	nucleus raphe obscurus	skos:exactMatch		mesh:D065849	Nucleus Raphe Obscurus	semapv:ManualMappingCuration	orcid:0000-0001-9439-5346		
+UBERON:0002689	supraoptic crest	skos:exactMatch		BTO:0006268	organum vasculosum laminae terminalis	semapv:ManualMappingCuration	orcid:0000-0003-4423-4370	0.556	https://github.com/biomappings/biomappings/blob/530a1b/scripts/generate_uberon_bto_mappings.py
+UBERON:0002707	corticospinal tract	skos:exactMatch		BTO:0006132	corticospinal tract	semapv:ManualMappingCuration	orcid:0000-0003-4423-4370	0.9	generate_uberon_bto_mappings.py
+UBERON:0002714	rubrospinal tract	skos:exactMatch		BTO:0006159	rubrospinal tract	semapv:ManualMappingCuration	orcid:0000-0003-4423-4370	0.9	generate_uberon_bto_mappings.py
+UBERON:0002743	basal forebrain	skos:exactMatch		mesh:D066187	Basal Forebrain	semapv:ManualMappingCuration	orcid:0000-0001-9439-5346		
+UBERON:0002751	inferior temporal gyrus	skos:exactMatch		BTO:0006175	inferior temporal gyrus	semapv:ManualMappingCuration	orcid:0000-0003-4423-4370	0.9	generate_uberon_bto_mappings.py
+UBERON:0002752	olivocerebellar tract	skos:exactMatch		BTO:0006157	olivocerebellar fiber system	semapv:ManualMappingCuration	orcid:0000-0003-4423-4370	0.556	https://github.com/biomappings/biomappings/blob/530a1b/scripts/generate_uberon_bto_mappings.py
+UBERON:0002769	superior temporal gyrus	skos:exactMatch		BTO:0006177	superior temporal gyrus	semapv:ManualMappingCuration	orcid:0000-0003-4423-4370	0.9	generate_uberon_bto_mappings.py
+UBERON:0002771	middle temporal gyrus	skos:exactMatch		BTO:0006176	middle temporal gyrus	semapv:ManualMappingCuration	orcid:0000-0003-4423-4370	0.9	generate_uberon_bto_mappings.py
+UBERON:0002883	central amygdaloid nucleus	skos:exactMatch		mesh:D066274	Central Amygdaloid Nucleus	semapv:ManualMappingCuration	orcid:0000-0001-9439-5346		
+UBERON:0002894	olfactory cortex	skos:exactMatch		mesh:D066194	Olfactory Cortex	semapv:ManualMappingCuration	orcid:0000-0001-9439-5346		
+UBERON:0002932	trapezoid body	skos:exactMatch		mesh:D065833	Trapezoid Body	semapv:ManualMappingCuration	orcid:0000-0001-9439-5346		
+UBERON:0003023	pontine tegmentum	skos:exactMatch		mesh:D065821	Pontine Tegmentum	semapv:ManualMappingCuration	orcid:0000-0001-9439-5346		
+UBERON:0003044	uncinate fasciculus	skos:exactMatch		mesh:D000083382	Uncinate Fasciculus	semapv:ManualMappingCuration	orcid:0000-0001-9439-5346		
+UBERON:0003050	olfactory placode	skos:exactMatch		BTO:0006222	olfactory placode	semapv:ManualMappingCuration	orcid:0000-0003-4423-4370	0.9	generate_uberon_bto_mappings.py
+UBERON:0003055	periderm	skos:exactMatch		BTO:0003377	periderm	semapv:ManualMappingCuration	orcid:0000-0003-4423-4370	0.9	generate_uberon_bto_mappings.py
+UBERON:0003060	pronephric duct	skos:exactMatch		BTO:0005991	pronephric duct	semapv:ManualMappingCuration	orcid:0000-0003-4423-4370	0.9	generate_uberon_bto_mappings.py
+UBERON:0003074	mesonephric duct	skos:exactMatch		BTO:0005990	mesonephric duct	semapv:ManualMappingCuration	orcid:0000-0003-4423-4370	0.9	generate_uberon_bto_mappings.py
+UBERON:0003075	neural plate	skos:exactMatch		mesh:D054258	Neural Plate	semapv:ManualMappingCuration	orcid:0000-0001-9439-5346		
+UBERON:0003089	sclerotome	skos:exactMatch		BTO:0006255	sclerotome	semapv:ManualMappingCuration	orcid:0000-0003-4423-4370	0.9	generate_uberon_bto_mappings.py
+UBERON:0003143	pupa	skos:exactMatch		mesh:D011679	Pupa	semapv:ManualMappingCuration	orcid:0000-0001-9439-5346		
+UBERON:0003209	blood nerve barrier	skos:exactMatch		mesh:D049428	Blood-Nerve Barrier	semapv:ManualMappingCuration	orcid:0000-0001-9439-5346		
+UBERON:0003460	arm bone	skos:exactMatch		mesh:D050280	Arm Bones	semapv:ManualMappingCuration	orcid:0000-0001-9439-5346		
+UBERON:0003462	facial bone	skos:exactMatch		mesh:D005147	Facial Bones	semapv:ManualMappingCuration	orcid:0000-0001-9439-5346		
+UBERON:0003679	mouth floor	skos:exactMatch		BTO:0006184	mouth floor	semapv:ManualMappingCuration	orcid:0000-0003-4423-4370	0.9	generate_uberon_bto_mappings.py
+UBERON:0003687	foramen magnum	skos:exactMatch		BTO:0006035	foramen magnum	semapv:ManualMappingCuration	orcid:0000-0003-4423-4370	0.9	generate_uberon_bto_mappings.py
+UBERON:0003881	CA1 field of hippocampus	skos:exactMatch		mesh:D056547	CA1 Region, Hippocampal	semapv:ManualMappingCuration	orcid:0000-0001-9439-5346		
+UBERON:0003882	CA2 field of hippocampus	skos:exactMatch		mesh:D056651	CA2 Region, Hippocampal	semapv:ManualMappingCuration	orcid:0000-0001-9439-5346		
+UBERON:0003883	CA3 field of hippocampus	skos:exactMatch		mesh:D056654	CA3 Region, Hippocampal	semapv:ManualMappingCuration	orcid:0000-0001-9439-5346		
+UBERON:0003911	choroid plexus epithelium	skos:exactMatch		BTO:0006008	choroid plexus epithelium	semapv:ManualMappingCuration	orcid:0000-0003-4423-4370	0.9	generate_uberon_bto_mappings.py
+UBERON:0003937	reproductive gland	skos:exactMatch		BTO:0006162	reproductive gland	semapv:ManualMappingCuration	orcid:0000-0003-4423-4370	0.9	generate_uberon_bto_mappings.py
+UBERON:0004016	dermatome	skos:exactMatch		BTO:0006248	dermatome	semapv:ManualMappingCuration	orcid:0000-0003-4423-4370	0.9	generate_uberon_bto_mappings.py
+UBERON:0004341	primitive streak	skos:exactMatch		mesh:D054240	Primitive Streak	semapv:ManualMappingCuration	orcid:0000-0001-9439-5346		
+UBERON:0004637	otic capsule	skos:exactMatch		BTO:0005981	auditory capsule	semapv:ManualMappingCuration	orcid:0000-0003-4423-4370	0.556	https://github.com/biomappings/biomappings/blob/530a1b/scripts/generate_uberon_bto_mappings.py
+UBERON:0004676	spinal cord lateral horn	skos:exactMatch		mesh:D066152	Spinal Cord Lateral Horn	semapv:ManualMappingCuration	orcid:0000-0001-9439-5346		
+UBERON:0004720	cerebellar vermis	skos:exactMatch		mesh:D065814	Cerebellar Vermis	semapv:ManualMappingCuration	orcid:0000-0001-9439-5346		
+UBERON:0004725	piriform cortex	skos:exactMatch		mesh:D066195	Piriform Cortex	semapv:ManualMappingCuration	orcid:0000-0001-9439-5346		
+UBERON:0004749	blastodisc	skos:exactMatch		mesh:D054239	Blastodisc	semapv:ManualMappingCuration	orcid:0000-0001-9439-5346		
+UBERON:0005290	myelencephalon	skos:exactMatch		mesh:D054024	Myelencephalon	semapv:ManualMappingCuration	orcid:0000-0001-9439-5346		
+UBERON:0005335	chorioallantoic membrane	skos:exactMatch		mesh:D049033	Chorioallantoic Membrane	semapv:ManualMappingCuration	orcid:0000-0001-9439-5346		
+UBERON:0005403	ventral striatum	skos:exactMatch		mesh:D066328	Ventral Striatum	semapv:ManualMappingCuration	orcid:0000-0001-9439-5346		
+UBERON:0005408	circumventricular organ	skos:exactMatch		BTO:0006267	circumventricular organ	semapv:ManualMappingCuration	orcid:0000-0003-4423-4370	0.9	generate_uberon_bto_mappings.py
+UBERON:0005408	circumventricular organ	skos:exactMatch		mesh:D066280	Circumventricular Organs	semapv:ManualMappingCuration	orcid:0000-0001-9439-5346		
+UBERON:0005438	coronary sinus	skos:exactMatch		mesh:D054326	Coronary Sinus	semapv:ManualMappingCuration	orcid:0000-0001-9439-5346		
+UBERON:0005456	jugular foramen	skos:exactMatch		mesh:D000080869	Jugular Foramina	semapv:ManualMappingCuration	orcid:0000-0001-9439-5346		
+UBERON:0005498	primitive heart tube	skos:exactMatch		BTO:0006179	cardiac tube	semapv:ManualMappingCuration	orcid:0000-0003-4423-4370	0.556	https://github.com/biomappings/biomappings/blob/530a1b/scripts/generate_uberon_bto_mappings.py
+UBERON:0005631	extraembryonic membrane	skos:exactMatch		mesh:D005321	Extraembryonic Membranes	semapv:ManualMappingCuration	orcid:0000-0001-9439-5346		
+UBERON:0005742	adventitia	skos:exactMatch		mesh:D063194	Adventitia	semapv:ManualMappingCuration	orcid:0000-0001-9439-5346		
+UBERON:0005777	glomerular basement membrane	skos:exactMatch		mesh:D050533	Glomerular Basement Membrane	semapv:ManualMappingCuration	orcid:0000-0001-9439-5346		
+UBERON:0006083	perirhinal cortex	skos:exactMatch		mesh:D000071039	Perirhinal Cortex	semapv:ManualMappingCuration	orcid:0000-0001-9439-5346		
+UBERON:0006108	corticomedial nuclear complex	skos:exactMatch		mesh:D066276	Corticomedial Nuclear Complex	semapv:ManualMappingCuration	orcid:0000-0001-9439-5346		
+UBERON:0006444	annulus fibrosus	skos:exactMatch		mesh:D000070616	Annulus Fibrosus	semapv:ManualMappingCuration	orcid:0000-0001-9439-5346		
+UBERON:0006562	pharynx	skos:exactMatch		mesh:D010614	Pharynx	semapv:ManualMappingCuration	orcid:0000-0001-9439-5346		
+UBERON:0006588	round ligament of liver	skos:exactMatch		mesh:D000069592	Round Ligament of Liver	semapv:ManualMappingCuration	orcid:0000-0001-9439-5346		
+UBERON:0006589	round ligament of uterus	skos:exactMatch		mesh:D012404	Round Ligament of Uterus	semapv:ManualMappingCuration	orcid:0000-0001-9439-5346		
+UBERON:0006614	aponeurosis	skos:exactMatch		mesh:D000070606	Aponeurosis	semapv:ManualMappingCuration	orcid:0000-0001-9439-5346		
+UBERON:0006675	venous valve	skos:exactMatch		mesh:D055422	Venous Valves	semapv:ManualMappingCuration	orcid:0000-0001-9439-5346		
+UBERON:0006812	mental foramen	skos:exactMatch		mesh:D000080383	Mental Foramen	semapv:ManualMappingCuration	orcid:0000-0001-9439-5346		
+UBERON:0007109	meconium	skos:exactMatch		mesh:D008470	Meconium	semapv:ManualMappingCuration	orcid:0000-0001-9439-5346		
+UBERON:0007132	head kidney	skos:exactMatch		mesh:D060226	Head Kidney	semapv:ManualMappingCuration	orcid:0000-0001-9439-5346		
+UBERON:0007268	upper esophageal sphincter	skos:exactMatch		mesh:D049631	Esophageal Sphincter, Upper	semapv:ManualMappingCuration	orcid:0000-0001-9439-5346		
+UBERON:0007329	pancreatic duct	skos:exactMatch		mesh:D010183	Pancreatic Ducts	semapv:ManualMappingCuration	orcid:0000-0001-9439-5346		
+UBERON:0007412	midbrain raphe nuclei	skos:exactMatch		mesh:D066267	Midbrain Raphe Nuclei	semapv:ManualMappingCuration	orcid:0000-0001-9439-5346		
+UBERON:0007632	Barrington's nucleus	skos:exactMatch		mesh:D065835	Barrington's Nucleus	semapv:ManualMappingCuration	orcid:0000-0001-9439-5346		
+UBERON:0007634	parabrachial nucleus	skos:exactMatch		mesh:D065823	Parabrachial Nucleus	semapv:ManualMappingCuration	orcid:0000-0001-9439-5346		
+UBERON:0007703	spinothalamic tract	skos:exactMatch		BTO:0006128	spinothalamic tract	semapv:ManualMappingCuration	orcid:0000-0003-4423-4370	0.9	generate_uberon_bto_mappings.py
+UBERON:0007703	spinothalamic tract	skos:exactMatch		mesh:D013133	Spinothalamic Tracts	semapv:ManualMappingCuration	orcid:0000-0001-9439-5346		
+UBERON:0008266	periodontal ligament	skos:exactMatch		mesh:D010513	Periodontal Ligament	semapv:ManualMappingCuration	orcid:0000-0001-9439-5346		
+UBERON:0008269	nacre	skos:exactMatch		mesh:D060734	Nacre	semapv:ManualMappingCuration	orcid:0000-0001-9439-5346		
+UBERON:0008826	pulmonary surfactant	skos:exactMatch		mesh:D011663	Pulmonary Surfactants	semapv:ManualMappingCuration	orcid:0000-0001-9439-5346		
+UBERON:0008904	neuromast	skos:exactMatch		BTO:0006219	neuromast	semapv:ManualMappingCuration	orcid:0000-0003-4423-4370	0.9	generate_uberon_bto_mappings.py
+UBERON:0008974	apocrine gland	skos:exactMatch		mesh:D001050	Apocrine Glands	semapv:ManualMappingCuration	orcid:0000-0001-9439-5346		
+UBERON:0009127	epibranchial ganglion	skos:exactMatch		BTO:0006250	epibranchial ganglion	semapv:ManualMappingCuration	orcid:0000-0003-4423-4370	0.9	generate_uberon_bto_mappings.py
+UBERON:0009755	spermaceti	skos:exactMatch		mesh:C009301	spermaceti	semapv:ManualMappingCuration	orcid:0000-0001-9439-5346		
+UBERON:0009757	ambergris	skos:exactMatch		mesh:D018648	Ambergris	semapv:ManualMappingCuration	orcid:0000-0001-9439-5346		
+UBERON:0010264	hepatopancreas	skos:exactMatch		mesh:D043143	Hepatopancreas	semapv:ManualMappingCuration	orcid:0000-0001-9439-5346		
+UBERON:0010361	synostosis	skos:exactMatch		mesh:D013580	Synostosis	semapv:ManualMappingCuration	orcid:0000-0001-9439-5346		
+UBERON:0010725	accessory navicular bone	skos:exactMatch		mesh:C536002	Accessory navicular bone	semapv:ManualMappingCuration	orcid:0000-0001-9439-5346		
+UBERON:0011004	pharyngeal arch cartilage	skos:exactMatch		BTO:0006051	pharyngeal arch cartilage	semapv:ManualMappingCuration	orcid:0000-0003-4423-4370	0.9	generate_uberon_bto_mappings.py
+UBERON:0011119	carpometacarpal joint	skos:exactMatch		mesh:D052737	Carpometacarpal Joints	semapv:ManualMappingCuration	orcid:0000-0001-9439-5346		
+UBERON:0011166	patellofemoral joint	skos:exactMatch		mesh:D057071	Patellofemoral Joint	semapv:ManualMappingCuration	orcid:0000-0001-9439-5346		
+UBERON:0011390	pudendal nerve	skos:exactMatch		mesh:D060525	Pudendal Nerve	semapv:ManualMappingCuration	orcid:0000-0001-9439-5346		
+UBERON:0011895	endomysium	skos:exactMatch		BTO:0006241	endomysium	semapv:ManualMappingCuration	orcid:0000-0003-4423-4370	0.9	generate_uberon_bto_mappings.py
+UBERON:0011905	plantaris	skos:exactMatch		BTO:0006312	plantaris muscle	semapv:ManualMappingCuration	orcid:0000-0003-4423-4370	0.556	https://github.com/biomappings/biomappings/blob/530a1b/scripts/generate_uberon_bto_mappings.py
+UBERON:0012245	silk	skos:exactMatch		mesh:D047011	Silk	semapv:ManualMappingCuration	orcid:0000-0001-9439-5346		
+UBERON:0013218	rete mirabile	skos:exactMatch		BTO:0006363	rete mirabile	semapv:ManualMappingCuration	orcid:0000-0003-4423-4370	0.9	generate_uberon_bto_mappings.py
+UBERON:0013422	infratemporal fossa	skos:exactMatch		mesh:D000080884	Infratemporal Fossa	semapv:ManualMappingCuration	orcid:0000-0001-9439-5346		
+UBERON:0013755	arterial blood	skos:exactMatch		BTO:0006188	arterial blood	semapv:ManualMappingCuration	orcid:0000-0003-4423-4370	0.9	generate_uberon_bto_mappings.py
+UBERON:0013756	venous blood	skos:exactMatch		BTO:0006187	venous blood	semapv:ManualMappingCuration	orcid:0000-0003-4423-4370	0.9	generate_uberon_bto_mappings.py
+UBERON:0014374	embryoid body	skos:exactMatch		mesh:D058732	Embryoid Bodies	semapv:ManualMappingCuration	orcid:0000-0001-9439-5346		
+UBERON:0014398	respiratory muscle	skos:exactMatch		mesh:D012132	Respiratory Muscles	semapv:ManualMappingCuration	orcid:0000-0001-9439-5346		
+UBERON:0014537	periamygdaloid cortex	skos:exactMatch		mesh:D066277	Periamygdaloid Cortex	semapv:ManualMappingCuration	orcid:0000-0001-9439-5346		
+UBERON:0015169	tapetum	skos:exactMatch		BTO:0001350	tapetum	semapv:ManualMappingCuration	orcid:0000-0003-4423-4370	0.9	generate_uberon_bto_mappings.py
+UBERON:0015488	sural nerve	skos:exactMatch		mesh:D013497	Sural Nerve	semapv:ManualMappingCuration	orcid:0000-0001-9439-5346		
+UBERON:0016884	shoulder joint	skos:exactMatch		mesh:D012785	Shoulder Joint	semapv:ManualMappingCuration	orcid:0000-0001-9439-5346		
+UBERON:0018144	cervical rib	skos:exactMatch		mesh:D057070	Cervical Rib	semapv:ManualMappingCuration	orcid:0000-0001-9439-5346		
+UBERON:0018388	cercaria	skos:exactMatch		mesh:D058487	Cercaria	semapv:ManualMappingCuration	orcid:0000-0001-9439-5346		
+UBERON:0034971	aortic body	skos:exactMatch		BTO:0006193	aortic body	semapv:ManualMappingCuration	orcid:0000-0003-4423-4370	0.9	generate_uberon_bto_mappings.py
+UBERON:0034971	aortic body	skos:exactMatch		mesh:D001016	Aortic Bodies	semapv:ManualMappingCuration	orcid:0000-0001-9439-5346		
+UBERON:0035032	abdominal oblique muscle	skos:exactMatch		mesh:D000071596	Abdominal Oblique Muscles	semapv:ManualMappingCuration	orcid:0000-0001-9439-5346		
+UBERON:0035050	excretory duct	skos:exactMatch		BTO:0006341	excretory duct	semapv:ManualMappingCuration	orcid:0000-0003-4423-4370	0.9	generate_uberon_bto_mappings.py
+UBERON:0035618	parapharyngeal space	skos:exactMatch		mesh:D000080886	Parapharyngeal Space	semapv:ManualMappingCuration	orcid:0000-0001-9439-5346		
+UBERON:0036016	honey	skos:exactMatch		mesh:D006722	Honey	semapv:ManualMappingCuration	orcid:0000-0001-9439-5346		
+UBERON:0036145	glymphatic system	skos:exactMatch		mesh:D000077502	Glymphatic System	semapv:ManualMappingCuration	orcid:0000-0001-9439-5346		
+UBERON:0036243	vaginal fluid	skos:exactMatch		BTO:0003084	vaginal fluid	semapv:ManualMappingCuration	orcid:0000-0003-4423-4370	0.9	generate_uberon_bto_mappings.py
+UBERON:1000010	mole	skos:exactMatch		mesh:D009506	Nevus	semapv:ManualMappingCuration	orcid:0000-0001-9439-5346		
+UBERON:2000293	synencephalon	skos:exactMatch		BTO:0006476	synencephalon	semapv:ManualMappingCuration	orcid:0000-0003-4423-4370	0.9	generate_uberon_bto_mappings.py
+UBERON:2000297	vagal lobe	skos:exactMatch		BTO:0006431	vagal lobe	semapv:ManualMappingCuration	orcid:0000-0003-4423-4370	0.9	generate_uberon_bto_mappings.py
+UBERON:2000356	gill raker	skos:exactMatch		BTO:0002149	gill raker	semapv:ManualMappingCuration	orcid:0000-0003-4423-4370	0.9	generate_uberon_bto_mappings.py
+UBERON:2001553	manubrium	skos:exactMatch		mesh:D008371	Manubrium	semapv:ManualMappingCuration	orcid:0000-0001-9439-5346		
+UBERON:3010463	animal cap	skos:exactMatch		BTO:0004724	animal cap	semapv:ManualMappingCuration	orcid:0000-0003-4423-4370	0.9	generate_uberon_bto_mappings.py
+UBERON:3010586	vasa efferentia	skos:exactMatch		BTO:0002254	vas efferens	semapv:ManualMappingCuration	orcid:0000-0003-4423-4370	0.556	https://github.com/biomappings/biomappings/blob/530a1b/scripts/generate_uberon_bto_mappings.py
+UBERON:4000104	ganoine	skos:exactMatch		mesh:C067951	ganoine	semapv:ManualMappingCuration	orcid:0000-0001-9439-5346		
+UBERON:4000163	anal fin	skos:exactMatch		BTO:0004652	anal fin	semapv:ManualMappingCuration	orcid:0000-0003-4423-4370	0.9	generate_uberon_bto_mappings.py
+UBERON:4000164	caudal fin	skos:exactMatch		BTO:0001827	tail fin	semapv:ManualMappingCuration	orcid:0000-0003-4423-4370	0.556	https://github.com/biomappings/biomappings/blob/530a1b/scripts/generate_uberon_bto_mappings.py
+UBERON:4200215	suture	skos:exactMatch		mesh:D013537	Sutures	semapv:ManualMappingCuration	orcid:0000-0001-9439-5346		
+UBERON:4300194	photophore	skos:exactMatch		BTO:0001477	photophore	semapv:ManualMappingCuration	orcid:0000-0003-4423-4370	0.9	generate_uberon_bto_mappings.py
+UBERON:8440012	cerebral nuclei	skos:exactMatch		BTO:0006534	cerebral nucleus	semapv:ManualMappingCuration	orcid:0000-0003-4423-4370	0.556	https://github.com/biomappings/biomappings/blob/530a1b/scripts/generate_uberon_bto_mappings.py
+UBERON:8450002	excretory system	skos:exactMatch		BTO:0006338	excretory system	semapv:ManualMappingCuration	orcid:0000-0003-4423-4370	0.9	generate_uberon_bto_mappings.py
+UBERON:8480040	ovarian fluid	skos:exactMatch		BTO:0004569	ovarian fluid	semapv:ManualMappingCuration	orcid:0000-0003-4423-4370	0.9	generate_uberon_bto_mappings.py
+UBERON:0000104	life cycle	skos:exactMatch	Not	mesh:D008018	Life Cycle Stages	semapv:ManualMappingCuration	orcid:0000-0001-9439-5346		
+UBERON:0000353	parenchyma	skos:exactMatch	Not	BTO:0000999	plant parenchyma	semapv:ManualMappingCuration	orcid:0000-0003-4423-4370	0.556	https://github.com/biomappings/biomappings/blob/530a1b/scripts/generate_uberon_bto_mappings.py
+UBERON:0001263	pancreatic acinus	skos:exactMatch	Not	BTO:0000028	pancreatic acinar cell	semapv:ManualMappingCuration	orcid:0000-0003-4423-4370	0.556	https://github.com/biomappings/biomappings/blob/530a1b/scripts/generate_uberon_bto_mappings.py
+UBERON:0012245	silk	skos:exactMatch	Not	BTO:0002854	corn silk	semapv:ManualMappingCuration	orcid:0000-0003-4423-4370	0.556	https://github.com/biomappings/biomappings/blob/530a1b/scripts/generate_uberon_bto_mappings.py
+UBERON:0022469	primary olfactory cortex	skos:exactMatch	Not	mesh:D066194	Olfactory Cortex	semapv:ManualMappingCuration	orcid:0000-0001-9439-5346		
+UBERON:2001977	pad	skos:exactMatch	Not	mesh:D058729	Peripheral Arterial Disease	semapv:ManualMappingCuration	orcid:0000-0001-9439-5346		
+VO:0010896	Ssb	skos:exactMatch	Not	UBERON:0004199	S-shaped body	semapv:ManualMappingCuration	orcid:0000-0003-4423-4370		
+VO:0010971	SurA	skos:exactMatch	Not	UBERON:0003823	hindlimb zeugopod	semapv:ManualMappingCuration	orcid:0000-0003-4423-4370	0.5209235209235209	mira
+VO:0011021	CP	skos:exactMatch	Not	UBERON:0001886	choroid plexus	semapv:ManualMappingCuration	orcid:0000-0003-4423-4370	0.5555555555555556	mira
+VO:0011021	CP	skos:exactMatch	Not	UBERON:0005343	cortical plate	semapv:ManualMappingCuration	orcid:0000-0003-4423-4370	0.5555555555555556	mira
+VO:0011276	SP	skos:exactMatch	Not	UBERON:0004035	cortical subplate	semapv:ManualMappingCuration	orcid:0000-0003-4423-4370		
+VO:0012403	Rib	skos:exactMatch	Not	UBERON:0002228	rib	semapv:ManualMappingCuration	orcid:0000-0003-4423-4370		
+IDOMAL:0000443	gravid	skos:exactMatch		UBERON:0009097	gravid organism	semapv:LexicalMatching		0.5555555555555556	mira
+IDOMAL:0001253	adult stage	skos:exactMatch		UBERON:0000066	fully formed stage	semapv:LexicalMatching		0.5555555555555556	mira
+IDOMAL:0001253	adult stage	skos:exactMatch		UBERON:0000113	post-juvenile adult stage	semapv:LexicalMatching		0.5555555555555556	mira
+IDOMAL:0002126	visceral nervous system	skos:exactMatch		UBERON:0002410	autonomic nervous system	semapv:LexicalMatching		0.5555555555555556	mira
+IDOMAL:0002461	anatomical cluster	skos:exactMatch		UBERON:0034921	multi organ part structure	semapv:LexicalMatching		0.5555555555555556	mira
+UBERON:0000016	endocrine pancreas	skos:exactMatch		mesh:D007515	Islets of Langerhans	semapv:LexicalMatching		0.9	generate_uberon_mesh_mappings.py
+UBERON:0000044	dorsal root ganglion	skos:exactMatch		mesh:D005727	Ganglia, Spinal	semapv:LexicalMatching		0.9	generate_uberon_mesh_mappings.py
+UBERON:0000167	oral cavity	skos:exactMatch		mesh:D009055	Mouth	semapv:LexicalMatching		0.9	generate_uberon_mesh_mappings.py
+UBERON:0000341	throat	skos:exactMatch		mesh:D010614	Pharynx	semapv:LexicalMatching		0.9	generate_uberon_mesh_mappings.py
+UBERON:0000990	reproductive system	skos:exactMatch		mesh:D005835	Genitalia	semapv:LexicalMatching		0.9	generate_uberon_mesh_mappings.py
+UBERON:0001009	circulatory system	skos:exactMatch		mesh:D002319	Cardiovascular System	semapv:LexicalMatching		0.9	generate_uberon_mesh_mappings.py
+UBERON:0001173	biliary tree	skos:exactMatch		mesh:D001659	Biliary Tract	semapv:LexicalMatching		0.9	generate_uberon_mesh_mappings.py
+UBERON:0001268	peritoneal fluid	skos:exactMatch		mesh:D001202	Ascitic Fluid	semapv:LexicalMatching		0.9	generate_uberon_mesh_mappings.py
+UBERON:0001377	quadriceps femoris	skos:exactMatch		mesh:D052097	Quadriceps Muscle	semapv:LexicalMatching		0.9	generate_uberon_mesh_mappings.py
+UBERON:0001439	compact bone tissue	skos:exactMatch		mesh:D000071538	Cortical Bone	semapv:LexicalMatching		0.9	generate_uberon_mesh_mappings.py
+UBERON:0001555	digestive tract	skos:exactMatch		mesh:D041981	Gastrointestinal Tract	semapv:LexicalMatching		0.9	generate_uberon_mesh_mappings.py
+UBERON:0001601	extra-ocular muscle	skos:exactMatch		mesh:D009801	Oculomotor Muscles	semapv:LexicalMatching		0.9	generate_uberon_mesh_mappings.py
+UBERON:0001683	jugal bone	skos:exactMatch		mesh:D015050	Zygoma	semapv:LexicalMatching		0.9	generate_uberon_mesh_mappings.py
+UBERON:0001742	epiglottic cartilage	skos:exactMatch		mesh:D004825	Epiglottis	semapv:LexicalMatching		0.9	generate_uberon_mesh_mappings.py
+UBERON:0001797	vitreous humor	skos:exactMatch		mesh:D014822	Vitreous Body	semapv:LexicalMatching		0.9	generate_uberon_mesh_mappings.py
+UBERON:0001870	frontal cortex	skos:exactMatch		mesh:D005625	Frontal Lobe	semapv:LexicalMatching		0.9	generate_uberon_mesh_mappings.py
+UBERON:0001943	midbrain tegmentum	skos:exactMatch		mesh:D013681	Tegmentum Mesencephali	semapv:LexicalMatching		0.9	generate_uberon_mesh_mappings.py
+UBERON:0001965	substantia nigra pars compacta	skos:exactMatch		mesh:D065842	Pars Compacta	semapv:LexicalMatching		0.9	generate_uberon_mesh_mappings.py
+UBERON:0001966	substantia nigra pars reticulata	skos:exactMatch		mesh:D065841	Pars Reticulata	semapv:LexicalMatching		0.9	generate_uberon_mesh_mappings.py
+UBERON:0002072	hypodermis	skos:exactMatch		mesh:D040521	Subcutaneous Tissue	semapv:LexicalMatching		0.9	generate_uberon_mesh_mappings.py
+UBERON:0002090	postcranial axial skeleton	skos:exactMatch		mesh:D013131	Spine	semapv:LexicalMatching		0.9	generate_uberon_mesh_mappings.py
+UBERON:0002101	limb	skos:exactMatch		mesh:D005121	Extremities	semapv:LexicalMatching		0.9	generate_uberon_mesh_mappings.py
+UBERON:0002141	parvocellular oculomotor nucleus	skos:exactMatch		mesh:D065839	Edinger-Westphal Nucleus	semapv:LexicalMatching		0.9	generate_uberon_mesh_mappings.py
+UBERON:0002190	subcutaneous adipose tissue	skos:exactMatch		mesh:D015434	Panniculitis	semapv:LexicalMatching		0.9	generate_uberon_mesh_mappings.py
+UBERON:0002207	xiphoid process	skos:exactMatch		mesh:D014989	Xiphoid Bone	semapv:LexicalMatching		0.9	generate_uberon_mesh_mappings.py
+UBERON:0002295	scala media	skos:exactMatch		mesh:D003053	Cochlear Duct	semapv:LexicalMatching		0.9	generate_uberon_mesh_mappings.py
+UBERON:0002393	pharyngotympanic tube	skos:exactMatch		mesh:D005064	Eustachian Tube	semapv:LexicalMatching		0.9	generate_uberon_mesh_mappings.py
+UBERON:0002590	prepyriform area	skos:exactMatch		mesh:D066195	Piriform Cortex	semapv:LexicalMatching		0.9	generate_uberon_mesh_mappings.py
+UBERON:0002633	motor nucleus of trigeminal nerve	skos:exactMatch		mesh:D066266	Trigeminal Motor Nucleus	semapv:LexicalMatching		0.9	generate_uberon_mesh_mappings.py
+UBERON:0002656	periamygdaloid area	skos:exactMatch		mesh:D066277	Periamygdaloid Cortex	semapv:LexicalMatching		0.9	generate_uberon_mesh_mappings.py
+UBERON:0002689	supraoptic crest	skos:exactMatch		mesh:D066278	Organum Vasculosum	semapv:LexicalMatching		0.9	generate_uberon_mesh_mappings.py
+UBERON:0002704	metathalamus	skos:exactMatch		mesh:D005829	Geniculate Bodies	semapv:LexicalMatching		0.9	generate_uberon_mesh_mappings.py
+UBERON:0002705	midline nuclear group	skos:exactMatch		mesh:D020644	Midline Thalamic Nuclei	semapv:LexicalMatching		0.9	generate_uberon_mesh_mappings.py
+UBERON:0002726	cervical spinal cord	skos:exactMatch		mesh:D066193	Cervical Cord	semapv:LexicalMatching		0.9	generate_uberon_mesh_mappings.py
+UBERON:0002754	predorsal bundle	skos:exactMatch		mesh:D065844	Tectospinal Fibers	semapv:LexicalMatching		0.9	generate_uberon_mesh_mappings.py
+UBERON:0002776	ventral nuclear group	skos:exactMatch		mesh:D020651	Ventral Thalamic Nuclei	semapv:LexicalMatching		0.9	generate_uberon_mesh_mappings.py
+UBERON:0002895	secondary olfactory cortex	skos:exactMatch		mesh:D018728	Entorhinal Cortex	semapv:LexicalMatching		0.9	generate_uberon_mesh_mappings.py
+UBERON:0002967	cingulate gyrus	skos:exactMatch		mesh:D006179	Gyrus Cinguli	semapv:LexicalMatching		0.9	generate_uberon_mesh_mappings.py
+UBERON:0003011	facial motor nucleus	skos:exactMatch		mesh:D065828	Facial Nucleus	semapv:LexicalMatching		0.9	generate_uberon_mesh_mappings.py
+UBERON:0003128	cranium	skos:exactMatch		mesh:D012886	Skull	semapv:LexicalMatching		0.9	generate_uberon_mesh_mappings.py
+UBERON:0004550	gastroesophageal sphincter	skos:exactMatch		mesh:D049630	Esophageal Sphincter, Lower	semapv:LexicalMatching		0.9	generate_uberon_mesh_mappings.py
+UBERON:0005343	cortical plate	skos:exactMatch		mesh:D002540	Cerebral Cortex	semapv:LexicalMatching		0.9	generate_uberon_mesh_mappings.py
+UBERON:0005366	olfactory lobe	skos:exactMatch		mesh:D066194	Olfactory Cortex	semapv:LexicalMatching		0.9	generate_uberon_mesh_mappings.py
+UBERON:0005902	occipital region	skos:exactMatch		mesh:D009778	Occipital Lobe	semapv:LexicalMatching		0.9	generate_uberon_mesh_mappings.py
+UBERON:0006098	basal nuclear complex	skos:exactMatch		mesh:D001479	Basal Ganglia	semapv:LexicalMatching		0.9	generate_uberon_mesh_mappings.py
+UBERON:0006514	pallidum	skos:exactMatch		mesh:D005917	Globus Pallidus	semapv:LexicalMatching		0.9	generate_uberon_mesh_mappings.py
+UBERON:0006657	glenoid fossa	skos:exactMatch		mesh:D061165	Glenoid Cavity	semapv:LexicalMatching		0.9	generate_uberon_mesh_mappings.py
+UBERON:0006692	vertebral canal	skos:exactMatch		mesh:D013115	Spinal Canal	semapv:LexicalMatching		0.9	generate_uberon_mesh_mappings.py
+UBERON:0006810	olecranon	skos:exactMatch		mesh:D056740	Olecranon Process	semapv:LexicalMatching		0.9	generate_uberon_mesh_mappings.py
+UBERON:0007251	preoptic nucleus	skos:exactMatch		mesh:D011301	Preoptic Area	semapv:LexicalMatching		0.9	generate_uberon_mesh_mappings.py
+UBERON:0007380	dermal scale	skos:exactMatch		mesh:D000075342	Animal Scales	semapv:LexicalMatching		0.9	generate_uberon_mesh_mappings.py
+UBERON:0007381	epidermal scale	skos:exactMatch		mesh:D000075342	Animal Scales	semapv:LexicalMatching		0.9	generate_uberon_mesh_mappings.py
+UBERON:0007641	trigeminal nuclear complex	skos:exactMatch		mesh:D014278	Trigeminal Nuclei	semapv:LexicalMatching		0.9	generate_uberon_mesh_mappings.py
+UBERON:0008275	carapace	skos:exactMatch		mesh:D060105	Animal Shells	semapv:LexicalMatching		0.9	generate_uberon_mesh_mappings.py
+UBERON:0008969	dental follicle	skos:exactMatch		mesh:D003795	Dental Sac	semapv:LexicalMatching		0.9	generate_uberon_mesh_mappings.py
+UBERON:0009040	deep circumflex iliac artery	skos:exactMatch		mesh:D007083	Iliac Artery	semapv:LexicalMatching		0.9	generate_uberon_mesh_mappings.py
+UBERON:0009951	main olfactory bulb	skos:exactMatch		mesh:D009830	Olfactory Bulb	semapv:LexicalMatching		0.9	generate_uberon_mesh_mappings.py
+UBERON:0011117	superior tibiofibular joint	skos:exactMatch		mesh:D007719	Knee Joint	semapv:LexicalMatching		0.9	generate_uberon_mesh_mappings.py
+UBERON:0011132	intercarpal joint	skos:exactMatch		mesh:D050824	Carpal Joints	semapv:LexicalMatching		0.9	generate_uberon_mesh_mappings.py
+UBERON:0014621	cervical spinal cord ventral horn	skos:exactMatch		mesh:D066151	Spinal Cord Ventral Horn	semapv:LexicalMatching		0.9	generate_uberon_mesh_mappings.py
+UBERON:0016435	chest wall	skos:exactMatch		mesh:D035441	Thoracic Wall	semapv:LexicalMatching		0.9	generate_uberon_mesh_mappings.py
+UBERON:0016530	parietal cortex	skos:exactMatch		mesh:D010296	Parietal Lobe	semapv:LexicalMatching		0.9	generate_uberon_mesh_mappings.py
+UBERON:0016538	temporal cortex	skos:exactMatch		mesh:D013702	Temporal Lobe	semapv:LexicalMatching		0.9	generate_uberon_mesh_mappings.py
+UBERON:0018141	anterior perforated substance	skos:exactMatch		mesh:D066208	Olfactory Tubercle	semapv:LexicalMatching		0.9	generate_uberon_mesh_mappings.py
+UBERON:2000006	ball	skos:exactMatch		mesh:D015452	Precursor B-Cell Lymphoblastic Leukemia-Lymphoma	semapv:LexicalMatching		0.9	generate_uberon_mesh_mappings.py
+UBERON:2000188	corpus cerebelli	skos:exactMatch		mesh:D002531	Cerebellum	semapv:LexicalMatching		0.9	generate_uberon_mesh_mappings.py
+UBERON:3011045	gasserian ganglion	skos:exactMatch		mesh:D012668	Trigeminal Ganglion	semapv:LexicalMatching		0.9	generate_uberon_mesh_mappings.py
+UBERON:3011048	genital system	skos:exactMatch		mesh:D005835	Genitalia	semapv:LexicalMatching		0.9	generate_uberon_mesh_mappings.py

--- a/src/ontology/uberon.Makefile
+++ b/src/ontology/uberon.Makefile
@@ -124,7 +124,7 @@ export ROBOT_PLUGINS_DIRECTORY
 # Make sure the SSSOM plugin for ROBOT is available.
 $(TMPDIR)/plugins/sssom.jar:
 	mkdir -p $(TMPDIR)/plugins
-	curl -L -o $@ https://github.com/gouttegd/sssom-java/releases/download/sssom-java-0.6.1/sssom-robot-plugin-0.6.1.jar
+	curl -L -o $@ https://github.com/gouttegd/sssom-java/releases/download/sssom-java-0.6.2/sssom-robot-plugin-0.6.2.jar
 
 # Ditto for the specific Uberon plugin
 $(TMPDIR)/plugins/uberon.jar:
@@ -1429,9 +1429,8 @@ $(COMPONENTSDIR)/hra_depiction_3d_images.owl: $(TMPDIR)/hra_depiction_3d_images.
 $(COMPONENTSDIR)/mappings.owl: $(SRC) $(EXTERNAL_SSSOM_SETS) $(TMPDIR)/plugins/sssom.jar
 	$(ROBOT) sssom:inject -i $< \
 		              $(foreach set, $(EXTERNAL_SSSOM_SETS), --sssom $(set)) \
-		              --invert --only-subject-in UBERON \
-		              --check-subject --drop-duplicate-objects \
-		              --hasdbxref --no-merge --bridge-file $@ \
+		              --ruleset $(SCRIPTSDIR)/mappings-to-xrefs.rules \
+		              --no-merge --bridge-file $@ \
 		              --bridge-iri http://purl.obolibrary.org/obo/uberon/components/mappings.owl
 
 

--- a/src/scripts/mappings-to-xrefs.rules
+++ b/src/scripts/mappings-to-xrefs.rules
@@ -1,0 +1,19 @@
+prefix UBERON:   <http://purl.obolibrary.org/obo/UBERON_>
+prefix oboInOwl: <http://www.geneontology.org/formats/oboInOwl#>
+
+# Make sure UBERON classes, and only UBERON classes, are on the object side
+subject==UBERON:* -> invert();
+!object==UBERON:* -> stop();
+
+# Ignore any mapping to an inexistent or obsolete UBERON class.
+predicate==* -> check_object_existence();
+
+# Ignore any mapping where the same foreign term is mapped to more than one UBERON class.
+!cardinality==*:1 -> stop();
+
+# Create the hasDbXref annotation and annotate it with a subset of the mapping metadata
+object==UBERON:* -> annotate_object(oboInOwl:hasDbXref, "%subject_curie",
+                                    "direct:mapping_justification,
+                                            author_id,
+                                            creator_id,
+                                            mapping_provider");


### PR DESCRIPTION
This PR adds [Biomappings](https://biopragmatics.github.io/biomappings/) as an “external SSSOM provider”, allowing to automatically import Uberon-related mappings from Biomappings into Uberon as cross-references.

Roughly, we fetch the SSSOM mapping set exported from Biomappings, filter it to only keep the mappings pertaining to Uberon (strictly speaking this is not necessary, but we do it because of the sheer size of the Biomappings set: we commit the fetched set to the repository as for all the external resources, and we don’t want to commit a ~10MB file which mostly contains things unrelated to Uberon), and then use it along with all the other mapping sets to generate the `components/mappings.owl` component, which contains a user-friendly representation of all the mappings as cross-references.

closes #3078 