### PR TITLE
Fix `refresh-external-resources`.

### DIFF
--- a/src/ontology/uberon.Makefile
+++ b/src/ontology/uberon.Makefile
@@ -471,8 +471,9 @@ imports/local-ceph.owl: mirror/ceph.owl
 
 
 # Allow quickly refreshing all "local" imports
-LOCAL_IMPORTS = ceph cl cteno ehdaa2 emapa fbbt fbdv hsapdv ma mmusdv poro ssso wbbt wbls xao zfa
-all_local_imports: $(foreach imp,$(LOCAL_IMPORTS),$(IMPORTDIR)/local-$(imp).owl) allen_all
+LOCAL_IMPORTS = ceph cl cteno ehdaa2 emapa fbbt fbdv hsapdv ma mmusdv poro ssso wbbt wbls xao zfa \
+		allen-hba allen-dhba allen-mba allen-dmba allen-pba
+all_local_imports: $(foreach imp,$(LOCAL_IMPORTS),$(IMPORTDIR)/local-$(imp).owl)
 
 else # IMP=false
 all_local_imports:


### PR DESCRIPTION
This PR removes a reference to the old `allen_all` target, which no longer exists now that we changed the way we import the Allen ontologies. Instead, we make sure the Allen ontologies are explicitly listed in `LOCAL_IMPORTS`, which is used to generate the pre-requisites of the `all_local_imports` target. This makes the `refresh-external-resources` command work again.