### PR TITLE
Allow to optionally keep disjointness axioms when building composite products.

### DIFF
--- a/src/ontology/uberon.Makefile
+++ b/src/ontology/uberon.Makefile
@@ -1160,6 +1160,14 @@ COLLECTED_metazoan_SOURCES =         $(COLLECTED_vertebrate_SOURCES) \
 # Composite pipeline proper
 # ----------------------------------------
 
+# Set to false to keep disjointness axioms in collected/composite
+# products. Such axioms are stripped by default because too many
+# taxon-specific ontologies are inconsistent with Uberon.
+COMPOSITE_STRIP_DISJOINTS=true
+ifeq ($(COMPOSITE_STRIP_DISJOINTS),true)
+COMPOSITE_STRIPPING_COMMAND = remove --axioms "DisjointClasses DisjointUnion"
+endif
+
 # Step 1: Create a "collected" ontology, which is simply a merge of
 # Uberon, CL, and the components listed in the COLLECTED_*_SOURCES
 # variables above.
@@ -1171,20 +1179,18 @@ $(TMPDIR)/collected-%.owl: $(BRIDGEDIR)/collected-%-hdr.owl uberon.owl $(IMPORTD
 # Step 1b: collected-metazoan is not merely an intermediate towards
 # composite-metazoan, it is also a released artefact.
 collected-metazoan.owl: $(TMPDIR)/collected-metazoan.owl
-	$(ROBOT) remove -i $< --axioms "DisjointClasses DisjointUnion" \
+	$(ROBOT) merge -i $< $(COMPOSITE_STRIPPING_COMMAND) \
 		 annotate --ontology-iri $(ONTBASE)/$@ $(ANNOTATE_ONTOLOGY_VERSION) -o $@
 
 # Step 2: Create a "composite" ontology. This is the core of the
 # composite pipeline. It heavily relies on the Uberon plugin for ROBOT,
 # which provides the 'merge-species' and 'merge-equivalent-sets'
 # commands.
-# The pipeline starts by removing all the disjointness axioms, because
-# many external ontologies do not adhere to all Uberon constraints.
 TAXON_GCI_RELS = RO:0002202 RO:0002496 RO:0002497 BFO:0000051
 MERGESPECIES_OPTS = --remove-declarations --extended-translation --translate-gcas
 .PRECIOUS: $(TMPDIR)/composite-%.owl
 $(TMPDIR)/composite-%.owl: $(TMPDIR)/collected-%.owl $(TMPDIR)/plugins/uberon.jar
-	$(ROBOT) remove -i $< --axioms "DisjointClasses DisjointUnion" \
+	$(ROBOT) merge -i $< $(COMPOSITE_STRIPPING_COMMAND) \
 		 uberon:merge-species $(MERGESPECIES_OPTS) -s 'mouse'      -t NCBITaxon:10090 $(foreach rel,$(TAXON_GCI_RELS),-q $(rel)) \
 		 uberon:merge-species $(MERGESPECIES_OPTS) -s 'human'      -t NCBITaxon:9606  $(foreach rel,$(TAXON_GCI_RELS),-q $(rel)) \
 		 uberon:merge-species $(MERGESPECIES_OPTS) -s 'primate'    -t NCBITaxon:9443 \


### PR DESCRIPTION
All `composite-*` products are built by, among other operations, stripping any disjointness axiom in the merged ontology. This is necessary as most `composite-*` products would be impossible to build otherwise (the `merge-species` step requires the ontology to be consistent, and most of the `collected-*` merges are not because of incompatibilities between Uberon and one or several of the taxon-specific ontologies).

This will not change anytime soon, but we should still at least _aim_ to achieve inter-ontology consistency in the (far) future. This has already been achieved at least for the `composite-drosophila` product (Uberon + CL + FBbt), so it _is_ possible.

This PR makes the removal of the disjointness axioms optional, so one can easily try to build a `composite-*` product with the disjointness axioms still in place. Simply run the pipeline with `COMPOSITE_STRIP_DISJOINTS=false`, e.g.

```sh
sh run.sh make composite-mouse.owl COMPOSITE_STRIP_DISJOINTS=false
```

For most products this is likely to fail, but this gives us an easy way to _test_ building with disjointness axioms in place, so that we can start addressing the inconsistency issues.