### PR TITLE
Remove basic.owl and metazoan-view.owl

### DIFF
--- a/src/ontology/Makefile
+++ b/src/ontology/Makefile
@@ -62,7 +62,7 @@ PATTERN_RELEASE_FILES=      $(PATTERNDIR)/definitions.owl $(PATTERNDIR)/pattern.
 
 FORMATS = $(sort  owl obo json owl)
 FORMATS_INCL_TSV = $(sort $(FORMATS) tsv)
-RELEASE_ARTEFACTS = $(sort $(ONT)-base $(ONT)-full $(ONT)-simple $(ONT)-basic basic collected-metazoan composite-metazoan composite-metazoan-basic composite-vertebrate composite-vertebrate-basic common-anatomy )
+RELEASE_ARTEFACTS = $(sort $(ONT)-base $(ONT)-full $(ONT)-simple $(ONT)-basic collected-metazoan composite-metazoan composite-metazoan-basic composite-vertebrate composite-vertebrate-basic common-anatomy )
 
 # ----------------------------------------
 # Top-level targets
@@ -129,7 +129,7 @@ all_imports: $(IMPORT_FILES)
 # ----------------------------------------
 
 
-SUBSETS =  appendicular-minimal circulatory-minimal cranial-minimal cumbo digestive-minimal excretory-minimal human-view immune-minimal life-stages-composite life-stages-core life-stages-minimal merged-partonomy metazoan-view mouse-view musculoskeletal-minimal nephron-minimal nervous-minimal pulmonary-minimal renal-minimal reproductive-minimal sensory-minimal xenopus-view amniote-basic euarchontoglires-basic
+SUBSETS =  appendicular-minimal circulatory-minimal cranial-minimal cumbo digestive-minimal excretory-minimal human-view immune-minimal life-stages-composite life-stages-core life-stages-minimal merged-partonomy mouse-view musculoskeletal-minimal nephron-minimal nervous-minimal pulmonary-minimal renal-minimal reproductive-minimal sensory-minimal xenopus-view amniote-basic euarchontoglires-basic
 
 SUBSET_ROOTS = $(patsubst %, $(SUBSETDIR)/%, $(SUBSETS))
 SUBSET_FILES = $(foreach n,$(SUBSET_ROOTS), $(foreach f,$(FORMATS_INCL_TSV), $(n).$(f)))
@@ -701,12 +701,6 @@ $(ONT)-basic.json: $(ONT)-basic.owl
 	$(ROBOT) annotate --input $< --ontology-iri $(ONTBASE)/$@ $(ANNOTATE_ONTOLOGY_VERSION) \
 		convert --check false -f json -o $@.tmp.json &&\
 		mv $@.tmp.json $@
-basic.obo: basic.owl
-	$(ROBOT) convert --input $< --check false -f obo $(OBO_FORMAT_OPTIONS) -o $@.tmp.obo && grep -v ^owl-axioms $@.tmp.obo > $@ && rm $@.tmp.obo
-basic.json: basic.owl
-	$(ROBOT) annotate --input $< --ontology-iri $(ONTBASE)/$@ $(ANNOTATE_ONTOLOGY_VERSION) \
-		convert --check false -f json -o $@.tmp.json &&\
-		mv $@.tmp.json $@
 collected-metazoan.obo: collected-metazoan.owl
 	$(ROBOT) convert --input $< --check false -f obo $(OBO_FORMAT_OPTIONS) -o $@.tmp.obo && grep -v ^owl-axioms $@.tmp.obo > $@ && rm $@.tmp.obo
 collected-metazoan.json: collected-metazoan.owl
@@ -813,9 +807,6 @@ $(ONT)-basic.owl: $(EDIT_PREPROCESSED) $(OTHER_SRC) $(SIMPLESEED) $(KEEPRELATION
 		filter --term-file $(SIMPLESEED) --select "annotations ontology anonymous self" --trim true --signature true \
 		reduce -r ELK \
 		$(SHARED_ROBOT_COMMANDS) annotate --ontology-iri $(ONTBASE)/$@ $(ANNOTATE_ONTOLOGY_VERSION) --output $@.tmp.owl && mv $@.tmp.owl $@
-
-basic.owl:
-	echo "ERROR: You have configured a custom release artefact ($@); this release artefact needs to be define in uberon.Makefile!" && false
 
 collected-metazoan.owl:
 	echo "ERROR: You have configured a custom release artefact ($@); this release artefact needs to be define in uberon.Makefile!" && false

--- a/src/ontology/uberon-odk.yaml
+++ b/src/ontology/uberon-odk.yaml
@@ -20,7 +20,6 @@ release_artefacts:
   - full
   - simple
   - basic
-  - custom-basic
   - custom-collected-metazoan
   - custom-composite-metazoan
   - custom-composite-metazoan-basic

--- a/src/ontology/uberon-odk.yaml
+++ b/src/ontology/uberon-odk.yaml
@@ -88,7 +88,6 @@ subset_group:
     - id: life-stages-core
     - id: life-stages-minimal
     - id: merged-partonomy
-    - id: metazoan-view
     - id: mouse-view
     - id: musculoskeletal-minimal
     - id: nephron-minimal

--- a/src/ontology/uberon.Makefile
+++ b/src/ontology/uberon.Makefile
@@ -1020,9 +1020,6 @@ subsets/immaterial.obo: uberon.owl
 		    --make-ontology-from-results $(URIBASE)/uberon/$@ \
 		    -o -f obo $@ --reasoner-dispose 2>&1 > $@.LOG
 
-subsets/metazoan-view.owl: uberon-basic.owl
-	cp $< $@
-
 # The first step is a simple "merge+reason", but it still requires
 # Owltools because ROBOT has no equivalent to the -x option to simply
 # ignore unsatisfiable classes without erroring out.

--- a/src/ontology/uberon.Makefile
+++ b/src/ontology/uberon.Makefile
@@ -69,7 +69,7 @@ update_dynamic_catalog:
 # This target is invoked as part of the automated CI workflow.
 # To include a specific check/report in the CI workflow, add it
 # to the pre-requisites here.
-test: $(REPORTDIR)/basic-allcycles \
+test: $(REPORTDIR)/uberon-basic-allcycles \
 	$(REPORTDIR)/bfo-check.txt \
 	$(REPORTDIR)/taxon-constraint-check.txt \
 	$(REPORTDIR)/uberon-edit-xp-check \
@@ -91,7 +91,7 @@ uberon-qc: checks \
 	quick-bridge-checks \
 	bridge-checks \
 	extra-full-bridge-checks \
-	$(REPORTDIR)/basic-allcycles \
+	$(REPORTDIR)/uberon-basic-allcycles \
 	$(REPORTDIR)/basic-orphans \
 	$(REPORTDIR)/composite-metazoan-dv.txt \
 	$(REPORTDIR)/taxon-constraint-check.txt \
@@ -670,9 +670,6 @@ src-cycles:
 $(REPORTDIR)/%-allcycles: %.owl
 	$(OWLTOOLS) --no-debug $< --list-cycles -f > $@
 
-$(REPORTDIR)/basic-allcycles: basic.owl
-	$(OWLTOOLS) --no-debug $< --list-cycles -f > $@
-
 
 # Other checks
 # ----------------------------------------
@@ -818,7 +815,7 @@ $(REPORTDIR)/bfo-check.txt: $(OWLSRC) $(BRIDGEDIR)/uberon-bridge-to-bfo.owl
 		 reason -r ELK --equivalent-classes-allowed asserted-only > $@
 
 # Similar to above, but with the basic product and without RO
-$(REPORTDIR)/bfo-basic-check.txt: basic.owl $(BRIDGEDIR)/uberon-bridge-to-bfo.owl
+$(REPORTDIR)/bfo-basic-check.txt: uberon-basic.owl $(BRIDGEDIR)/uberon-bridge-to-bfo.owl
 	$(ROBOT) merge -i $< -i $(BRIDGEDIR)/uberon-bridge-to-bfo.owl \
 		       -I $(URIBASE)/bfo.owl \
 		 reason -r ELK > $@
@@ -1004,7 +1001,7 @@ $(TMPDIR)/uberon-taxmod-%.owl: uberon.owl
 # ----------------------------------------
 
 # Cumbo subset
-subsets/cumbo.owl: basic.owl
+subsets/cumbo.owl: uberon-basic.owl
 	$(OWLTOOLS) $< --extract-ontology-subset --subset cumbo --iri $(URIBASE)/uberon/$@ -o $@
 
 subsets/cumbo.obo: subsets/cumbo.owl
@@ -1023,7 +1020,7 @@ subsets/immaterial.obo: uberon.owl
 		    --make-ontology-from-results $(URIBASE)/uberon/$@ \
 		    -o -f obo $@ --reasoner-dispose 2>&1 > $@.LOG
 
-subsets/metazoan-view.owl: basic.owl
+subsets/metazoan-view.owl: uberon-basic.owl
 	cp $< $@
 
 # The first step is a simple "merge+reason", but it still requires
@@ -1643,7 +1640,7 @@ normalise_release_serialisation_ofn:
 	sh ../scripts/normalisation/norm_ofn.sh ../../src/ontology/subsets/xenopus-view.owl
 
 normalise_release_serialisation_rdfmxml:
-	sh ../scripts/normalisation/norm_rdfxml.sh ../../basic.owl
+	sh ../scripts/normalisation/norm_rdfxml.sh ../../uberon-basic.owl
 	sh ../scripts/normalisation/norm_rdfxml.sh ../../uberon-base.owl
 	sh ../scripts/normalisation/norm_rdfxml.sh ../../src/ontology/imports/caro_import.owl src/ontology/imports/fbbt_import.owl
 	sh ../scripts/normalisation/norm_rdfxml.sh ../../src/ontology/subsets/amniote-basic.owl

--- a/src/ontology/uberon.Makefile
+++ b/src/ontology/uberon.Makefile
@@ -1003,14 +1003,6 @@ $(TMPDIR)/uberon-taxmod-%.owl: uberon.owl
 # Other subsets
 # ----------------------------------------
 
-# Basic subset
-# FIXME: https://github.com/obophenotype/uberon/issues/3013
-basic.owl:  uberon-basic.owl
-	$(ROBOT) merge -i $< annotate --ontology-iri $(ONTBASE)/$@ $(ANNOTATE_ONTOLOGY_VERSION) -o $@
-
-basic.obo: basic.owl
-	$(MAKEOBO)
-
 # Cumbo subset
 subsets/cumbo.owl: basic.owl
 	$(OWLTOOLS) $< --extract-ontology-subset --subset cumbo --iri $(URIBASE)/uberon/$@ -o $@


### PR DESCRIPTION
This PR removes two release products that are completely redundant since they are identical to another release product:

* `basic.owl`: exactly identical to `uberon-basic.owl` except that is has a different ontology IRI;
* `metazoan-view.owl`: exactly identical to `basic.owl` (and therefore to `uberon-basic.owl`).

There’s no need to waste time building those products and waste space hosting them. If some some pipelines out there are dependent on those files, they should be updated to use `uberon-basic.owl` instead. And if these are old pipelines that for some reason can’t be updated, then we should just have one more redirection in Uberon’s PURL configuration.

[Download statistics](https://tooomm.github.io/github-release-stats/?username=obophenotype&repository=uberon) for the Uberon releases suggest the `metazoan-view.owl` file at least is never downloaded by anyone.

closes #3013