### PR TITLE
Use a dedicated token for the ontobot workflow.

### DIFF
--- a/.github/workflows/auto-pr-ontobot.yml
+++ b/.github/workflows/auto-pr-ontobot.yml
@@ -47,7 +47,7 @@ jobs:
         id: gh-script-issue
         uses: actions/github-script@v6
         with:
-          # github-token: ${{ secrets.GH_TOKEN }}
+          github-token: ${{ secrets.ONTOBOT_TOKEN }}
           script: |
             const issue_number = context.issue.number
             const repo = context.repo.owner+"/"+context.repo.repo
@@ -57,7 +57,7 @@ jobs:
         id: gh-script-repo
         uses: actions/github-script@v6
         with:
-          # github-token: ${{ secrets.GH_TOKEN }}
+          github-token: ${{ secrets.ONTOBOT_TOKEN }}
           script: |
             const repo = context.repo.owner+"/"+context.repo.repo
             return repo
@@ -78,7 +78,7 @@ jobs:
           ochange process-issue ${{ env.resource }} \
           -r ${{ steps.gh-script-repo.outputs.result }} \
           -n ${{ steps.gh-script-issue.outputs.result }} \
-          -g ${{ secrets.GH_TOKEN }} \
+          -g ${{ secrets.ONTOBOT_TOKEN }} \
           -p UBERON
 
       - name: Create Pull Request
@@ -93,4 +93,4 @@ jobs:
           committer: ${{ env.ISSUE_CREATOR }} <${{ env.ISSUE_CREATOR }}@users.noreply.github.com>
           base: ${{ github.head_ref }}
           branch: ${{ env.branch-name }}
-          # token: ${{ secrets.GH_TOKEN }}
+          token: ${{ secrets.ONTOBOT_TOKEN }}


### PR DESCRIPTION
This commit updates the ontobot workflow (`auto-pr-ontobot`) to make it use a dedicated authentication token (`ONTOBOT_TOKEN`), rather than the default `GITHUB_TOKEN`.

This should ensures that PRs created by the bot can trigger other workflows, notably the CI workflow.

related to #3223