### PR TITLE
Fix downloading of FBbt mapping set

### DIFF
--- a/src/ontology/uberon.Makefile
+++ b/src/ontology/uberon.Makefile
@@ -1259,7 +1259,8 @@ ifeq ($(strip $(IMP)),true)
 
 # FBbt mapping set. Nominally a simple mirror, but we need a custom rule
 # because the default, ODK-generated rule would ignore the MIR variable.
-$(MAPPINGDIR)/fbbt.sssom.tsv:
+.PHONY: fbbt-mappings
+$(MAPPINGDIR)/fbbt.sssom.tsv: fbbt-mappings
 	wget "http://purl.obolibrary.org/obo/fbbt/fbbt.sssom.tsv" -O $@
 
 # CL mapping set (extracted from CL cross-references). We need to first

--- a/src/ontology/uberon.Makefile
+++ b/src/ontology/uberon.Makefile
@@ -1260,7 +1260,7 @@ ifeq ($(strip $(IMP)),true)
 # FBbt mapping set. Nominally a simple mirror, but we need a custom rule
 # because the default, ODK-generated rule would ignore the MIR variable.
 $(MAPPINGDIR)/fbbt.sssom.tsv:
-	wget "http://purl.obolibrary.org/obo/fbbt/fbbt-mappings.sssom.tsv" -O $@
+	wget "http://purl.obolibrary.org/obo/fbbt/fbbt.sssom.tsv" -O $@
 
 # CL mapping set (extracted from CL cross-references). We need to first
 # merge Uberon with CL, because the treat-xrefs-as-... annotations are

--- a/src/ontology/uberon.Makefile
+++ b/src/ontology/uberon.Makefile
@@ -1259,8 +1259,7 @@ ifeq ($(strip $(IMP)),true)
 
 # FBbt mapping set. Nominally a simple mirror, but we need a custom rule
 # because the default, ODK-generated rule would ignore the MIR variable.
-.PHONY: fbbt-mappings
-$(MAPPINGDIR)/fbbt.sssom.tsv: fbbt-mappings
+$(MAPPINGDIR)/fbbt.sssom.tsv: .FORCE
 	wget "http://purl.obolibrary.org/obo/fbbt/fbbt.sssom.tsv" -O $@
 
 # CL mapping set (extracted from CL cross-references). We need to first


### PR DESCRIPTION
This PR amends the code that refreshes the FBbt mapping set to:

* use the new canonical location of the set (`http://purl.obolibrary.org/obo/fbbt.sssom.tsv`, valid since today’s FBbt release, instead of the old `http://purl.obolibrary.org/obo/fbbt-mappings.sssom.tsv`);
* ensure the remote file is always downloaded (unless `IMP=false`) even if the target file already exists (otherwise the rule would always be ignored and the set would never be refreshed – this is a bug inadvertently introduced in #3249).