### PR TITLE
Update Robot diff GH Action on PRs

### DIFF
--- a/.github/workflows/diff.yml
+++ b/.github/workflows/diff.yml
@@ -4,12 +4,14 @@ on:
 
   issue_comment:
         types: [created]
+env:
+  DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
 
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
-  diff-reports:
+  branch_status:
     if: ${{ github.event.issue.pull_request }}
-    runs-on: macos-latest
+    runs-on: ubuntu-latest
     permissions:
       contents: read
       pull-requests: read
@@ -20,58 +22,157 @@ jobs:
           trigger: '#gogoeditdiff'
         env:
           GITHUB_TOKEN: '${{ secrets.GITHUB_TOKEN }}'
-      - uses: better0fdead/actions-setup-docker@better0fdead/increase-timeout
-        if: steps.check.outputs.triggered == 'true'
-      - run: |
-          set -x
-          docker version
-        if: steps.check.outputs.triggered == 'true'
-      - name: Install ODK
-        run: docker pull obolibrary/odklite
-        if: steps.check.outputs.triggered == 'true'
       # Checks-out current branch
-      - uses: xt0rted/pull-request-comment-branch@v2.0.0
+      - uses: xt0rted/pull-request-comment-branch@v2
         id: comment-branch
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         if: steps.check.outputs.triggered == 'true'
         with:
           ref: ${{ steps.comment-branch.outputs.head_ref }}
       # Checks-out master branch under "master" directory
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
+        if: steps.check.outputs.triggered == 'true'
+        with:
+          ref: ${{ steps.comment-branch.outputs.head_ref }}
+          fetch-depth: 0
+      - name: Check current branch status
+        if: steps.check.outputs.triggered == 'true'
+        id: info
+        run: |
+          echo "status=$(git rev-list --left-right --count origin/$DEFAULT_BRANCH...origin/`git branch --show-current` | awk '{print $1}')"
+          echo "status=$(git rev-list --left-right --count origin/$DEFAULT_BRANCH...origin/`git branch --show-current` | awk '{print $1}')" >> $GITHUB_OUTPUT
+      - name: Warn users with a comment
+        if: steps.info.outputs.status >= 1
+        run: echo "Your branch is ${{ steps.info.outputs.status }} commit/s behind, please update your branch." > warncomment.md
+      - name: Post comment
+        if: steps.info.outputs.status >= 1 && steps.check.outputs.triggered == 'true'
+        env:
+          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
+        uses: NejcZdovc/comment-pr@v2
+        with:
+          github_token: ${{secrets.GITHUB_TOKEN}}
+          file: "../../warncomment.md"
+      - name: Fail step if branch is behind
+        if: steps.info.outputs.status >= 1 && steps.check.outputs.triggered == 'true'
+        run: |
+          echo "Your branch is ${{ steps.info.outputs.status }} commit/s behind, please update your branch."
+          exit 1
+  edit_file:
+    needs: [branch_status]
+    if: ${{ github.event.issue.pull_request }}
+    runs-on: ubuntu-latest
+    container: obolibrary/odkfull:v1.5
+    steps:
+      - uses: khan/pull-request-comment-trigger@v1.1.0
+        id: check
+        with:
+          trigger: '#gogoeditdiff'
+        env:
+          GITHUB_TOKEN: '${{ secrets.GITHUB_TOKEN }}'
+      - uses: actions/checkout@v4
         if: steps.check.outputs.triggered == 'true'
         with:
           ref: master
           path: master
       - name: Diff classification
         if: steps.check.outputs.triggered == 'true'
-        run: |
-          cd src/ontology
-          docker run -v $PWD/../../:/work -w /work/src/ontology -e ROBOT_JAVA_ARGS='-Xmx9G' -e JAVA_OPTS='-Xmx9G' --rm obolibrary/odklite robot diff --left ../../master/src/ontology/uberon-edit.obo --left-catalog ../../master/src/ontology/catalog-v001.xml --right uberon-edit.obo --right-catalog catalog-v001.xml -f markdown -o edit-diff.md
+        run: export ROBOT_JAVA_ARGS='-Xmx9G'; robot diff --labels True --left master/src/ontology/uberon-edit.obo --left-catalog master/src/ontology/catalog-v001.xml --right branch/src/ontology/uberon-edit.obo --right-catalog branch/src/ontology/catalog-v001.xml -f markdown -o edit-diff.md
       - name: Upload diff
         if: steps.check.outputs.triggered == 'true'
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: edit-diff.md
-          path: src/ontology/edit-diff.md
-      - name: Make step for branch
+          path: edit-diff.md
+  classify_branch:
+    needs: [branch_status]
+    if: ${{ github.event.issue.pull_request }}
+    runs-on: ubuntu-latest
+    container: obolibrary/odkfull:v1.5
+    steps:
+      - uses: khan/pull-request-comment-trigger@v1.1.0
+        id: check
+        with:
+          trigger: '#gogoeditdiff'
+        env:
+          GITHUB_TOKEN: '${{ secrets.GITHUB_TOKEN }}'
+      - uses: xt0rted/pull-request-comment-branch@v2
+        id: comment-branch
+      - uses: actions/checkout@v4
         if: steps.check.outputs.triggered == 'true'
-        run: cd src/ontology && mkdir -p tmp reports mirror && docker run -v $PWD/../../:/work -w /work/src/ontology -e ROBOT_JAVA_ARGS='-Xmx9G' -e JAVA_OPTS='-Xmx9G' --rm obolibrary/odklite make BRI=false MIR=false PAT=false IMP=false uberon-simple.owl > TESTLOG.log
-      - name: Make step for master
+        with:
+          ref: ${{ steps.comment-branch.outputs.head_ref }}
+      - name: Classify ontology PR branch
         if: steps.check.outputs.triggered == 'true'
-        run: cd master/src/ontology && mkdir -p tmp reports mirror && docker run -v $PWD/../../:/work -w /work/src/ontology -e ROBOT_JAVA_ARGS='-Xmx9G' -e JAVA_OPTS='-Xmx9G' --rm obolibrary/odklite make BRI=false MIR=false PAT=false IMP=false uberon-simple.owl > TESTLOG.log
-      - name: Diff report
+        run: export ROBOT_JAVA_ARGS='-Xmx9G'; cd src/ontology; make BRI=false MIR=false PAT=false IMP=false COMP=false uberon-base.owl > TESTLOG.log
+      - name: Upload classified ontology in PR branch
         if: steps.check.outputs.triggered == 'true'
-        run: |
-          cd src/ontology
-          docker run -v $PWD/../../:/work -w /work/src/ontology -e ROBOT_JAVA_ARGS='-Xmx9G' -e JAVA_OPTS='-Xmx9G' --rm obolibrary/odklite robot diff --left ../../master/src/ontology/uberon-simple.owl --left-catalog catalog-v001.xml --right uberon-simple.owl --right-catalog ../../master/src/ontology/catalog-v001.xml -f markdown -o simple-report.md
+        uses: actions/upload-artifact@v4
+        with:
+          name: uberon-base-pr.owl
+          path: src/ontology/uberon-base.owl
+          retention-days: 1
+  classify_main:
+    needs: [branch_status]
+    if: ${{ github.event.issue.pull_request }}
+    runs-on: ubuntu-latest
+    container: obolibrary/odkfull:v1.5
+    steps:
+      - uses: khan/pull-request-comment-trigger@v1.1.0
+        id: check
+        with:
+          trigger: '#gogoeditdiff'
+        env:
+          GITHUB_TOKEN: '${{ secrets.GITHUB_TOKEN }}'
+      - uses: actions/checkout@v4
+        if: steps.check.outputs.triggered == 'true'
+        with:
+          ref: master
+      - name: Classify ontology main branch
+        if: steps.check.outputs.triggered == 'true'
+        run: export ROBOT_JAVA_ARGS='-Xmx9G'; cd src/ontology; make BRI=false MIR=false PAT=false IMP=false COMP=false uberon-base.owl > TESTLOG.log
+      - name: Upload classified ontology main branch
+        if: steps.check.outputs.triggered == 'true'
+        uses: actions/upload-artifact@v4
+        with:
+          name: uberon-base-main.owl
+          path: src/ontology/uberon-base.owl
+          retention-days: 1
+  diff_classification:
+    needs: [classify_branch, classify_main]
+    runs-on: ubuntu-latest
+    container: obolibrary/odkfull:v1.5
+    steps:
+      - uses: khan/pull-request-comment-trigger@v1.1.0
+        id: check
+        with:
+          trigger: '#gogoeditdiff'
+        env:  
+          GITHUB_TOKEN: '${{ secrets.GITHUB_TOKEN }}'
+      - uses: actions/checkout@v4
+        if: steps.check.outputs.triggered == 'true'
+      - name: Download classified ontology main branch
+        if: steps.check.outputs.triggered == 'true'
+        uses: actions/download-artifact@v4
+        with:
+          name: uberon-base-main.owl
+          path: src/ontology/uberon-base-main.owl
+      - name: Download classified ontology in PR branch
+        if: steps.check.outputs.triggered == 'true'
+        uses: actions/download-artifact@v4
+        with:
+          name: uberon-base-pr.owl
+          path: src/ontology/uberon-base-pr.owl
+      - name: Diff classification
+        if: steps.check.outputs.triggered == 'true'
+        run: export ROBOT_JAVA_ARGS='-Xmx9G'; cd src/ontology; robot diff --labels True --left uberon-base-main.owl/uberon-base.owl --left-catalog catalog-v001.xml --right uberon-base-pr.owl/uberon-base.owl --right-catalog catalog-v001.xml -f markdown -o classification-diff.md
       - name: Upload diff
         if: steps.check.outputs.triggered == 'true'
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
-          name: simple-report.md
-          path: src/ontology/simple-report.md
+          name: classification-diff.md
+          path: src/ontology/classification-diff.md
   post_comment:
-    needs: [diff-reports]
+    needs: [edit_file, diff_classification]
     runs-on: ubuntu-latest
     steps:
       - uses: khan/pull-request-comment-trigger@v1.1.0
@@ -80,16 +181,16 @@ jobs:
           trigger: '#gogoeditdiff'
         env:
           GITHUB_TOKEN: '${{ secrets.GITHUB_TOKEN }}'
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         if: steps.check.outputs.triggered == 'true'
       - name: Download reasoned diff
         if: steps.check.outputs.triggered == 'true'
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
-          name: simple-report.md
+          name: classification-diff.md
       - name: Prepare reasoned comment
-        run: "echo \"<details>\n <summary> Here's a diff of how these changes impact the classified ontology (on -simple file): </summary> \n\" > comment.md; cat simple-report.md >> comment.md"
         if: steps.check.outputs.triggered == 'true'
+        run: "echo \"<details>\n <summary> Here's a diff of how these changes impact the classified ontology (on -base file): </summary> \n\" > comment.md; cat classification-diff.md >> comment.md"
       - name: Post reasoned comment
         if: steps.check.outputs.triggered == 'true'
         uses: NejcZdovc/comment-pr@v2.0.0
@@ -97,16 +198,17 @@ jobs:
           file: "../../comment.md"
           identifier: "REASONED"
           github_token: ${{secrets.GITHUB_TOKEN}}
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         if: steps.check.outputs.triggered == 'true'
       - name: Download edit diff
         if: steps.check.outputs.triggered == 'true'
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v4
         with:
           name: edit-diff.md
+          path: edit-diff.md
       - name: Prepare edit file comment
-        run: "echo \"<details>\n <summary> Here's a diff of your edit file (unreasoned) </summary> \n\" > edit-comment.md; cat edit-diff.md >> edit-comment.md"
         if: steps.check.outputs.triggered == 'true'
+        run: "echo \"<details>\n <summary> Here's a diff of your edit file (unreasoned) </summary> \n\" > edit-comment.md; cat edit-diff.md >> edit-comment.md"
       - name: Post comment
         if: steps.check.outputs.triggered == 'true'
         uses: NejcZdovc/comment-pr@v2.0.0


### PR DESCRIPTION
Remove alternative action to run docker on macos runner.  [GH increased memory on the ubuntu-latest label](https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners/about-github-hosted-runners#standard-github-hosted-runners-for-public-repositories), so we can update the diff action to use `ubuntu-latest`.

This also align more closely to the [same action available in CL](https://github.com/obophenotype/cell-ontology/blob/master/.github/workflows/diff.yml).
- Add branch status job before generating diff
- Create different jobs

It's also updated to generate the classified ontology on the base, which is now the case.

Technically fixes #3183