### PR TITLE
Use ODK 1.5.2 for the CI test suite.

### DIFF
--- a/.github/workflows/qc.yml
+++ b/.github/workflows/qc.yml
@@ -23,7 +23,7 @@ jobs:
   ontology_qc:
     # The type of runner that the job will run on
     runs-on: ubuntu-latest
-    container: obolibrary/odkfull:v1.5
+    container: obolibrary/odkfull:v1.5.2
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it


### PR DESCRIPTION
ROBOT 1.9.6 (and its 0.6 ELK reasoner) can catch TC violations that ROBOT 1.9.5 does not detect.

If Uberon releases are manually performed using the latest ODK (1.5.2, which includes ROBOT 1.9.6), then it means that we could run at release time into TC violations that were undetected during the normal development cycle. (The fact that it didn’t happen for now is solely due to the fact that the TC check has been broken for the past 6 months, cf #3336.)

To avoid that, this commit updates the QC workflow to make it use the latest point release of the ODK.