### PR TITLE
Do not "add OBO shorthands" to the RO mirror.

### DIFF
--- a/src/ontology/uberon.Makefile
+++ b/src/ontology/uberon.Makefile
@@ -145,11 +145,6 @@ uberon.json.gz: uberon.json
 # MIRRORS
 # ----------------------------------------
 
-# We add OBO shorthands to the RO mirror before merging it with the other mirrors
-# FIXME: https://github.com/obophenotype/uberon/issues/3016
-mirror/ro.owl: mirror-ro | $(MIRRORDIR)
-	if [ $(MIR) = true ] && [ $(IMP) = true ]; then $(OWLTOOLS) $(TMPDIR)/mirror-ro.owl --add-obo-shorthand-to-properties -o $@ ; fi
-
 # All the following mirrors are needed, not for imports, but for
 # Uberon-specific pipelines (especially the composite-* stuff).
 # That's why they are not handled by the ODK-generated Makefile.


### PR DESCRIPTION
RO is currently mirrored in Uberon using a custom rule that bypasses the normal ODK mirroring rule to include an additional step, the addition of OBO shorthands to RO relations.

"OBO shorthands" are basically a trick allowing to use, e.g. `part_of` instead of `BFO:0000050` in a class expression, as in:

```
relationship: part_of UBERON:00000033
```

However there is no reason to forcefully inject OBO shorthands to all RO relations as we are currently doing. We can already create OBO shorthands as needed within uberon-edit, for the relationships that are actually used. For example, we already have this in uberon-edit:

```
[Typedef]
id: part_of
name: part of
xref: BFO:0000050
```

which creates the `part_of` shorthand for BFO:0000050.

We should stick to doing that for the relations we are actually using, and stop injectinf fabricated shorthands for the entirety of RO. If people believe that all RO relations should have OBO shorthands, then they should ask the RO folks to add them at the source. It's not Uberon's job to do it.

So this commit removes the rule that adds the OBO shorthands to the RO mirror, so that RO is now mirrored using the standard ODK-generated rule.

closes #3016