### PR TITLE
Overhaul taxon subsets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -217,6 +217,7 @@ subsets/*.tsv
 src/ontology/subsets/*.json
 src/ontology/subsets/*.obo
 src/ontology/subsets/*.owl
+src/ontology/subsets/*.ofn
 src/ontology/subsets/*.tsv
 src/ontology/imports/*_import.owl
 !src/ontology/imports/orcidio_import.owl

--- a/src/ontology/Makefile
+++ b/src/ontology/Makefile
@@ -10,7 +10,7 @@
 # More information: https://github.com/INCATools/ontology-development-kit/
 
 # Fingerprint of the configuration file when this Makefile was last generated
-CONFIG_HASH=                df7a0ce93b9cd6fe7e773a7a41a0b597562118f01ad45e6a2563fbedddaf9fe9
+CONFIG_HASH=                943829f9eb8e1b8d46bf5f3f878364bb18f10e0d9eee11d7c28bfb3dfba894c7
 
 
 # ----------------------------------------
@@ -189,7 +189,7 @@ all_imports: $(IMPORT_FILES)
 # ----------------------------------------
 
 
-SUBSETS =  appendicular-minimal circulatory-minimal cranial-minimal cumbo digestive-minimal excretory-minimal human-view immune-minimal life-stages-composite life-stages-core life-stages-minimal merged-partonomy mouse-view musculoskeletal-minimal nephron-minimal nervous-minimal pulmonary-minimal renal-minimal reproductive-minimal sensory-minimal xenopus-view amniote-basic euarchontoglires-basic
+SUBSETS =  appendicular-minimal circulatory-minimal cranial-minimal cumbo digestive-minimal excretory-minimal human-view immune-minimal life-stages-composite life-stages-core life-stages-minimal merged-partonomy mouse-view musculoskeletal-minimal nephron-minimal nervous-minimal pulmonary-minimal renal-minimal reproductive-minimal sensory-minimal xenopus-view amniote-view euarchontoglires-view
 
 SUBSET_ROOTS = $(patsubst %, $(SUBSETDIR)/%, $(SUBSETS))
 SUBSET_FILES = $(foreach n,$(SUBSET_ROOTS), $(foreach f,$(FORMATS_INCL_TSV), $(n).$(f)))

--- a/src/ontology/Makefile
+++ b/src/ontology/Makefile
@@ -10,7 +10,7 @@
 # More information: https://github.com/INCATools/ontology-development-kit/
 
 # Fingerprint of the configuration file when this Makefile was last generated
-CONFIG_HASH=                9531f9cc87d9bbbcf0d424b5845e95234e9cd34df6d28bdbb856a4ba7b5557ad
+CONFIG_HASH=                df7a0ce93b9cd6fe7e773a7a41a0b597562118f01ad45e6a2563fbedddaf9fe9
 
 
 # ----------------------------------------
@@ -154,7 +154,7 @@ $(ROBOT_PLUGINS_DIRECTORY)/%.jar:
 # Specific rules for supplementary plugins defined in configuration
 
 $(ROBOT_PLUGINS_DIRECTORY)/uberon.jar:
-	curl -L -o $@ https://github.com/gouttegd/uberon-robot-plugin/releases/download/uberon-robot-plugin-0.2.0/uberon.jar
+	curl -L -o $@ https://github.com/gouttegd/uberon-robot-plugin/releases/download/uberon-robot-plugin-0.3.1/uberon.jar
 
 
 # ----------------------------------------

--- a/src/ontology/contexts/context-drosophila.owl
+++ b/src/ontology/contexts/context-drosophila.owl
@@ -1,4 +1,0 @@
-Ontology(<http://purl.obolibrary.org/obo/uberon/contexts/context-human.owl>
-SubClassOf(<http://purl.obolibrary.org/obo/UBERON_0000061> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/NCBITaxon_7227>))
-SubClassOf(ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/UBERON_0000061>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/NCBITaxon_7227>))
-)

--- a/src/ontology/contexts/context-gnathostome.owl
+++ b/src/ontology/contexts/context-gnathostome.owl
@@ -1,4 +1,0 @@
-Ontology(<http://purl.obolibrary.org/obo/uberon/contexts/context-gnathosotome.owl>
-SubClassOf(<http://purl.obolibrary.org/obo/UBERON_0000061> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/NCBITaxon_7776>))
-SubClassOf(ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/UBERON_0000061>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/NCBITaxon_7776>))
-)

--- a/src/ontology/contexts/context-human.owl
+++ b/src/ontology/contexts/context-human.owl
@@ -1,4 +1,0 @@
-Ontology(<http://purl.obolibrary.org/obo/uberon/contexts/context-human.owl>
-SubClassOf(<http://purl.obolibrary.org/obo/UBERON_0000061> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/NCBITaxon_9606>))
-SubClassOf(ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/UBERON_0000061>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/NCBITaxon_9606>))
-)

--- a/src/ontology/contexts/context-mouse.owl
+++ b/src/ontology/contexts/context-mouse.owl
@@ -1,4 +1,0 @@
-Ontology(<http://purl.obolibrary.org/obo/uberon/contexts/context-mouse.owl>
-SubClassOf(<http://purl.obolibrary.org/obo/UBERON_0000061> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/NCBITaxon_10090>))
-SubClassOf(ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/UBERON_0000061>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/NCBITaxon_10090>))
-)

--- a/src/ontology/contexts/context-nematode.owl
+++ b/src/ontology/contexts/context-nematode.owl
@@ -1,3 +1,0 @@
-Ontology(<http://purl.obolibrary.org/obo/uberon/contexts/context-human.owl>
-SubClassOf(<http://purl.obolibrary.org/obo/UBERON_0000061> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/NCBITaxon_6237>))
-)

--- a/src/ontology/contexts/context-xenopus.owl
+++ b/src/ontology/contexts/context-xenopus.owl
@@ -1,4 +1,0 @@
-Ontology(<http://purl.obolibrary.org/obo/uberon/contexts/context-human.owl>
-SubClassOf(<http://purl.obolibrary.org/obo/UBERON_0000061> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/NCBITaxon_8353>))
-SubClassOf(ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/UBERON_0000061>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/NCBITaxon_8353>))
-)

--- a/src/ontology/contexts/context-zebrafish.owl
+++ b/src/ontology/contexts/context-zebrafish.owl
@@ -1,4 +1,0 @@
-Ontology(<http://purl.obolibrary.org/obo/uberon/contexts/context-zebrafish.owl>
-SubClassOf(<http://purl.obolibrary.org/obo/UBERON_0000061> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/NCBITaxon_7955>))
-SubClassOf(ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/UBERON_0000061>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/NCBITaxon_7955>))
-)

--- a/src/ontology/uberon-odk.yaml
+++ b/src/ontology/uberon-odk.yaml
@@ -103,8 +103,8 @@ subset_group:
     - id: reproductive-minimal
     - id: sensory-minimal
     - id: xenopus-view
-    - id: amniote-basic
-    - id: euarchontoglires-basic
+    - id: amniote-view
+    - id: euarchontoglires-view
 sssom_mappingset_group:
   products:
     - id: fbbt

--- a/src/ontology/uberon-odk.yaml
+++ b/src/ontology/uberon-odk.yaml
@@ -123,7 +123,7 @@ robot_java_args: '-Xmx20G'
 robot_plugins:
   plugins:
     - name: uberon
-      mirror_from: https://github.com/gouttegd/uberon-robot-plugin/releases/download/uberon-robot-plugin-0.2.0/uberon.jar
+      mirror_from: https://github.com/gouttegd/uberon-robot-plugin/releases/download/uberon-robot-plugin-0.3.1/uberon.jar
 robot_report:
   release_reports: False
   fail_on: ERROR

--- a/src/ontology/uberon.Makefile
+++ b/src/ontology/uberon.Makefile
@@ -144,10 +144,6 @@ POSTPROCESS_ADDITIONS = subsets/human-tags.ofn \
 uberon.owl: $(POSTPROCESS_SRC) $(POSTPROCESS_ADDITIONS)
 	$(ROBOT) merge $(foreach prereq,$^,-i $(prereq)) -o $@
 
-uberon.json.gz: uberon.json
-	gzip -c $< > $@.tmp && mv $@.tmp $@
-.PRECIOUS: uberon.json.gz
-
 
 # ----------------------------------------
 # MIRRORS
@@ -1513,6 +1509,10 @@ refresh-external-resources:
 # Everything that does not belong to any of the sections above.
 # May include both actually useful stuff and stuff that nobody
 # remembers why it was written in the first place.
+
+uberon.json.gz: uberon.json
+	gzip -c $< > $@.tmp && mv $@.tmp $@
+.PRECIOUS: uberon.json.gz
 
 TEMPLATESDIR=templates
 

--- a/src/ontology/uberon.Makefile
+++ b/src/ontology/uberon.Makefile
@@ -142,7 +142,7 @@ $(POSTPROCESS_SRC): $(OWLSRC) $(BRIDGEDIR)/uberon-bridge-to-bfo.owl $(DEVELOPS_F
 POSTPROCESS_ADDITIONS = subsets/human-tags.ofn \
 			subsets/mouse-tags.ofn
 uberon.owl: $(POSTPROCESS_SRC) $(POSTPROCESS_ADDITIONS)
-	$(ROBOT) merge $(foreach prereq,$^,-i $(prereq)) -o $@
+	$(ROBOT) merge -i $< $(foreach add,$(POSTPROCESS_ADDITIONS),-i $(add)) -o $@
 
 
 # ----------------------------------------


### PR DESCRIPTION
This PR updates the way we are building “taxon subsets”.

As explained in #3362, we currently have, for reasons unknown (to me at least), two slightly different methods to create taxon subsets: one producing the `-view` subsets (`human-view`, `mouse-view`, `xenopus-view`) and one producing the `-basic` subsets (`amniote-basic`, `euarchotonglires-basic`). Both methods rely on the use of OWLTools.

This PR replaces both methods by a single one (so that all taxon subsets are produced in the same way) that relies on a new command in Uberon’s custom ROBOT plugin.

The PR does not change _which_ taxon subsets are produced and released by default (the five subsets aforementioned: `human`, `mouse`, `xenopus`, `amniote`, and `euarchotonglires`). 

More subsets can be produced on demand, all that is needed is to define a `TAXON_ID_subsetname` Make variable pointing to the desired NCBITaxon ID.

For example, to create a subset for, say, insects, one can do:

```sh
sh run.sh make subsets/insect-view.owl TAXON_ID_insect=NCBITaxon:50557
```

The PR also adds a possibility to create, not a subset directly, but a small component containing only `oboInOwl:inSubset` annotations to “tag” classes that belong to a taxon subset. For example:

```sh
sh run.sh make subsets/human-tags.ofn
```

would create a `human-tags.ofn` component containing, for all Uberon classes that belong to the human subset, `oboInOwl:inSubset <http://purl.obolibrary.org/obo/uberon/core#human_subset>` annotation assertion axioms. Such a component can then be merged with the main ontology for downstream use (e.g., extracting all the classes of the subset).

closes #3362