### PR TITLE
Update foreign SSSOM sets from the ontology.

### DIFF
--- a/.github/workflows/diff.yml
+++ b/.github/workflows/diff.yml
@@ -61,7 +61,7 @@ jobs:
     needs: [branch_status]
     if: ${{ github.event.issue.pull_request }}
     runs-on: ubuntu-latest
-    container: obolibrary/odkfull:v1.5
+    container: obolibrary/odkfull:v1.5.3
     steps:
       - uses: khan/pull-request-comment-trigger@v1.1.0
         id: check
@@ -94,7 +94,7 @@ jobs:
     needs: [branch_status]
     if: ${{ github.event.issue.pull_request }}
     runs-on: ubuntu-latest
-    container: obolibrary/odkfull:v1.5
+    container: obolibrary/odkfull:v1.5.3
     steps:
       - uses: khan/pull-request-comment-trigger@v1.1.0
         id: check
@@ -122,7 +122,7 @@ jobs:
     needs: [branch_status]
     if: ${{ github.event.issue.pull_request }}
     runs-on: ubuntu-latest
-    container: obolibrary/odkfull:v1.5
+    container: obolibrary/odkfull:v1.5.3
     steps:
       - uses: khan/pull-request-comment-trigger@v1.1.0
         id: check
@@ -147,7 +147,7 @@ jobs:
   diff_classification:
     needs: [classify_branch, classify_main]
     runs-on: ubuntu-latest
-    container: obolibrary/odkfull:v1.5
+    container: obolibrary/odkfull:v1.5.3
     steps:
       - uses: khan/pull-request-comment-trigger@v1.1.0
         id: check

--- a/.github/workflows/qc.yml
+++ b/.github/workflows/qc.yml
@@ -23,7 +23,7 @@ jobs:
   ontology_qc:
     # The type of runner that the job will run on
     runs-on: ubuntu-latest
-    container: obolibrary/odkfull:v1.5.2
+    container: obolibrary/odkfull:v1.5.3
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it

--- a/src/ontology/catalog-v001.xml
+++ b/src/ontology/catalog-v001.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <catalog prefer="public" xmlns="urn:oasis:names:tc:entity:xmlns:xml:catalog">
-    <group id="Folder Repository, directory=, recursive=false, Auto-Update=false, version=2" prefer="public" xml:base="">
+    <group id="Folder Repository, directory=, recursive=false, Auto-Update=false, version=2" prefer="public">
       <uri name="http://purl.obolibrary.org/obo/ceph.owl" uri="imports/local-ceph.owl"/>
       <uri name="http://purl.obolibrary.org/obo/cl.owl" uri="imports/local-cl.owl"/>
       <uri name="http://purl.obolibrary.org/obo/cteno.owl" uri="imports/local-cteno.owl"/>

--- a/src/ontology/uberon.Makefile
+++ b/src/ontology/uberon.Makefile
@@ -1257,7 +1257,8 @@ ifeq ($(strip $(IMP)),true)
 $(MAPPINGDIR)/fbbt.sssom.tsv: .FORCE
 	wget "http://purl.obolibrary.org/obo/fbbt/fbbt.sssom.tsv" -O - | \
 		sssom-cli --prefix-map-from-input \
-		          --rule 'object==UBERON:* -> include()' \
+		          --include 'object==UBERON:*' \
+		          --update-from-ontology=$(SRC):object,label,existence \
 		          --output $@
 
 # CL mapping set. We simply fetch it as it is from CL. It already
@@ -1276,7 +1277,8 @@ $(MAPPINGDIR)/biomappings.sssom.tsv: $(TMPDIR)/biomappings.sssom.tsv \
 	sssom-cli --input $< --prefix 'UBERON=http://purl.obolibrary.org/obo/UBERON_' \
 		  --rule '!(subject==UBERON:* || object==UBERON:*) -> stop()' \
 		  --rule 'object==UBERON:* -> invert()' \
-		  --include-all | \
+		  --include-all \
+		  --update-from-ontology=$(SRC):subject,label,existence | \
 	sssom-cli --mangle-iris obo --output $@
 
 $(TMPDIR)/biomappings.sssom.tsv:


### PR DESCRIPTION
This PR amends the rules that refresh the externally maintained SSSOM mapping sets (the FBbt set and the Biomappings set) to include a step that check those sets against the current version of the ontology to

(1) remove any mapping to a Uberon entity that does not exist or is deprecated;
(2) add any missing label, using the labels found in the ontology.

This necessitates, as a preliminary:

(1) making sure we are using ODK 1.5.3, as previous versions do not include a recent enough version of SSSOM-Java;
(2) removing a bogus empty `xml:base` attribute in the XML catalog, that prevents `sssom-cli` from reading it.