### PR TITLE
Fixes #3411 to revise 'mesosalpinx' textual/logical definition, synonyms and oviduct synonyms

### DIFF
--- a/src/ontology/diffs/Makefile
+++ b/src/ontology/diffs/Makefile
@@ -4,9 +4,10 @@ SRC = ../../../$(ONT)-base.obo
 OWLSRC = ../../../$(ONT)-base.owl
 LAST = $(OBO)/$(ONT)/$(ONT)-base.obo
 OWLLAST = $(OBO)/$(ONT)/$(ONT)-base.owl
+REPORTDIR = ../reports
 
 #all: $(ONT)-obo-diff.html $(ONT)-def-diff.html $(ONT)-lastbuild.obo $(ONT)-combined-diff.txt $(ONT)-diff.md
-all: $(ONT)-diff.md
+all: $(ONT)-diff.md $(REPORTDIR)/diff_release_oak.md
 
 $(ONT)-combined-diff.txt: $(ONT)-def-diff.html $(ONT)-obo-diff.html
 	cat $(ONT)-def-diff.txt $(ONT)-obo-diff.txt > $@
@@ -23,3 +24,7 @@ $(ONT)-diff.md: $(ONT)-lastbuild.owl $(OWLSRC)
 $(ONT)-diff.txt: $(ONT)-lastbuild.owl $(OWLSRC)
 	robot diff --labels true -f plain -l $< -r $(OWLSRC) -o $@
 
+$(REPORTDIR)/diff_release_oak.md: $(ONT)-lastbuild.obo
+	runoak -i simpleobo:$(ONT)-lastbuild.obo \
+	       diff -X simpleobo:$(SRC) \
+	            -o $@ --output-type md


### PR DESCRIPTION
Fixes #3411 

While I was addressing the ticket I was conflicted if structures related to uterine tubes should have a different term for humans, since many synonyms make reference to fallopian tube. My decision was to keep them as exact synonyms (after all, uterine tube is an exact synonym of fallopian tube). 

Therefore, I believe [serosa of fallopian tube](http://purl.obolibrary.org/obo/UBERON_0012499) should be merged into [mesosalpinx](http://purl.obolibrary.org/obo/UBERON_0012331).