### PR TITLE
Remove Anita from CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,10 +1,9 @@
 # Uberon code owners (Guardians of the main branch)
 # GitHub documentation about CODEOWNERS file - https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
 
-*       @anitacaron
 *.yaml @matentzn
 *Makefile @gouttegd
-*uberon.Makefile @gouttegd @matentzn @anitacaron
+*uberon.Makefile @gouttegd @matentzn
 
 
 #docs/*  action@github.com 


### PR DESCRIPTION
As per discussion with @anitacaron we remove her from codeowners so she is not assigned to everything automatically.

Anyone wanting to take up that huge burden please put your hands up.