### PR TITLE
Add GitHub action that assigns reviewers when equivalent class axioms are updated

### DIFF
--- a/.github/workflows/reviewers.yml
+++ b/.github/workflows/reviewers.yml
@@ -1,0 +1,47 @@
+name: Assign Reviewers for Uberon
+
+on:
+  pull_request:
+    types: [opened, synchronize]
+    paths:
+      - src/ontology/uberon-edit.obo
+
+jobs:
+  assign-reviewer:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0  # Fetch the entire history for all branches
+      
+      - name: Fetch base branch
+        run: |
+          git fetch origin ${{ github.base_ref }}  # Fetch base branch explicitly
+      
+      - name: Check if equivalent class axiom was edited
+        id: check_intersection_of
+        run: |
+          git diff origin/${{ github.base_ref }}...HEAD -- src/ontology/uberon-edit.obo > diff.txt
+          if grep -E '^(-|\+)intersection_of:' diff.txt; then
+            echo "intersection_of_found=true" >> $GITHUB_ENV
+          else
+            echo "intersection_of_found=false" >> $GITHUB_ENV
+          fi
+
+      - name: Assign reviewer
+        if: env.intersection_of_found == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh api repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/requested_reviewers \
+            --method POST \
+            --field reviewers[]=cmungall
+
+      - name: Block PR by requesting changes
+        if: env.intersection_of_found == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh pr review ${{ github.event.pull_request.number }} --request-changes --body "Changes detected in \`src/ontology/uberon-edit.obo\` involving \`intersection_of\`. Review by specific Uberon Core Team member is required."


### PR DESCRIPTION
The main use case for this action is to provide a way to assign specific reviewers when equivalent class axioms are added or updated, but it should be easy to extend the action to other kinds of edits, hence the generic name.

To achieve the above, we check the diff for changes to rows that signify a logical definition, i.e. starting with "intersection_of". If we find such a change, we set a special environment variable to "true"; if it is "true", in the next step, a reviewer is assigned. Lastly, we let the GitHub action itself make a review, which requests changes - the idea is that these need to be dismissed by a person which sufficient access to Uberon before the change is committed to the main (master) branch.

Issue: https://github.com/obophenotype/uberon/issues/2020