### PR TITLE
Add ID range for the NDI Cloud project.

### DIFF
--- a/src/ontology/uberon-idranges.owl
+++ b/src/ontology/uberon-idranges.owl
@@ -262,3 +262,9 @@ Datatype: idrange:35
         allocatedto: "Tiago Lubiana"
     EquivalentTo:
         xsd:integer[>= 8900000, <= 8909999]
+
+Datatype: idrange:40
+    Annotations:
+        allocatedto: "NDI Cloud"
+    EquivalentTo:
+        xsd:integer[>= 8910000, <= 8919999]


### PR DESCRIPTION
This PR assigns the ID range 8,910,000--8,919,999 to members of the [NDI](https://github.com/VH-Lab/NDI-matlab) Cloud project, so that they can participate in creating the terms they need to cover some aspects of arthropod neuroanatomy.

As discussed in Uberon call of 2024-11-18.