### PR TITLE
Do not give a version IRI to bridge files.

### DIFF
--- a/src/ontology/bridge/bridges.dispatch
+++ b/src/ontology/bridge/bridges.dispatch
@@ -1,6 +1,5 @@
 [__default]
 ontology-iri: http://purl.obolibrary.org/obo/uberon/bridge/%filename.owl
-ontology-version: http://purl.obolibrary.org/obo/uberon/releases/%date/bridge/%filename.owl
 
 [aeo-uberon]
 file: uberon-bridge-to-aeo.owl


### PR DESCRIPTION
The current process that generates the cross-species bridges automatically inserts into them a Version IRI that includes the date of the day (e.g.
<http://purl.obolibrary.org/obo/uberon/releases/2024-11-25/bridge/uberon-bridge-to-fbbt.owl>).

I think that Version IRI is of very dubious usefulness.

* Many of our components do _not_ have a Version IRI.

* The bridges are primarily intended for Uberon's own purposes (for building Composite-Metazoan), even though they _are_ published and available to anyone wants to use them.

* The date in the inserted Version IRI does not necessarily match the date of the Uberon release the generated bridges will be a part of, since the bridges may not be re-generated on the same day than a release will be made.

The last point notably means that the Version IRI may not be resolvable, if the Uberon release happened on a different day than the day the bridges were generated. This happened for example for the 2024-08-07 release, whose bridges have a version IRI dated from 2024-08-06 (e.g. <http://purl.obolibrary.org/obo/uberon/releases/2024-08-06/bridge/uberon-bridge-to-fbbt.owl>).

In fact the only thing those Version IRIs do is pollute the diff of every "refresh external resources" PR (such as the last one: #3433).

So I hereby propose to get rid of them, so that every bridge has only a Ontology IRI (e.g.
<http://purl.obolibrary.org/obo/uberon/bridge/uberon-bridge-to-fbbt.owl>) but _no_ Version IRI.