### PR TITLE
Make the SSSOM/T ruleset future-proof.

### DIFF
--- a/src/scripts/sssomt.m4
+++ b/src/scripts/sssomt.m4
@@ -9,7 +9,7 @@ ifelse($2, , `dnl
     predicate==skos:exactMatch               -> create_axiom("%subject_id EquivalentTo: %object_id");
     predicate==skos:broadMatch               -> create_axiom("%subject_id SubClassOf: %object_id");
     predicate==skos:narrowMatch              -> create_axiom("%object_id SubClassOf: %subject_id");',`dnl
-    predicate==semapv:crossSpeciesExactMatch -> create_axiom("%subject_id EquivalentTo: %object_id and (<%TAXREL> some $2)");')')
+    predicate==semapv:crossSpeciesExactMatch -> create_axiom("%subject_id EquivalentTo: %object_id and (%TAXREL some $2)");')')
 
 dnl Expand to instructions to create all possible bridging axioms
 dnl both for Uberon and for CL


### PR DESCRIPTION
There is one particular bit of syntax that is currently used in the SSSOM/T ruleset that I would like to disallow in the upcoming version of SSSOM/Java. Specifically, the dereferencing of a variable enclosed in angled brackets, as in:

```
  "... and (<%TAXREL> some NCBITaxon:????)"
```

It should either be `%TAXREL` (no angled brackets, preferred form as it is more readable) or `<%{TAXREL}>` (angled brackets + variable name enclosed in curly brackets — cumbersome, but more consistent throughout SSSOM/T).

The first form is already allowed with current versions of SSSOM-Java, so we can switch to it immediately without breaking anything. And this will ensure nothing will also break when the upcoming SSSOM-Java will land in the ODK.