### PR TITLE
Make sure the SSSOM-derived cross-reference use correct OBO prefixes.

### DIFF
--- a/src/scripts/mappings-to-xrefs.rules
+++ b/src/scripts/mappings-to-xrefs.rules
@@ -1,6 +1,29 @@
 prefix UBERON:    <http://purl.obolibrary.org/obo/UBERON_>
 prefix oboInOwl:  <http://www.geneontology.org/formats/oboInOwl#>
 prefix MESH:      <http://id.nlm.nih.gov/mesh/>
+prefix AcarDv:    <http://purl.obolibrary.org/obo/AcarDv_>
+prefix BtauDv:    <http://purl.obolibrary.org/obo/BtauDv_>
+prefix CfamDv:    <http://purl.obolibrary.org/obo/CfamDv_>
+prefix ChirDv:    <http://purl.obolibrary.org/obo/ChirDv_>
+prefix CporDv:    <http://purl.obolibrary.org/obo/CporDv_>
+prefix DpseDv:    <http://purl.obolibrary.org/obo/DpseDv_>
+prefix DsimDv:    <http://purl.obolibrary.org/obo/DsimDv_>
+prefix EcabDv:    <http://purl.obolibrary.org/obo/EcabDv_>
+prefix FcatDv:    <http://purl.obolibrary.org/obo/FcatDv_>
+prefix GgalDv:    <http://purl.obolibrary.org/obo/GgalDv_>
+prefix GgorDv:    <http://purl.obolibrary.org/obo/GgorDv_>
+prefix HsapDv:    <http://purl.obolibrary.org/obo/HsapDv_>
+prefix MdomDv:    <http://purl.obolibrary.org/obo/MdomDv_>
+prefix MmulDv:    <http://purl.obolibrary.org/obo/MmulDv_>
+prefix MmusDv:    <http://purl.obolibrary.org/obo/MmusDv_>
+prefix OanaDv:    <http://purl.obolibrary.org/obo/OanaDv_>
+prefix OariDv:    <http://purl.obolibrary.org/obo/OariDv_>
+prefix OcunDv:    <http://purl.obolibrary.org/obo/OcunDv_>
+prefix PpanDv:    <http://purl.obolibrary.org/obo/PpanDv_>
+prefix PtroDv:    <http://purl.obolibrary.org/obo/PtroDv_>
+prefix RnorDv:    <http://purl.obolibrary.org/obo/RnorDv_>
+prefix SsalDv:    <http://purl.obolibrary.org/obo/SsalDv_>
+prefix SscrDv:    <http://purl.obolibrary.org/obo/SscrDv_>
 
 # Make sure UBERON classes, and only UBERON classes, are on the object side
 subject==UBERON:* -> invert();


### PR DESCRIPTION
Most of the prefixes used by the taxon-specific life stage ontologies (SSLSO) are not intrinsically known by ROBOT (prefixes such as BtauDv, GgalDv, PpanDv, etc.).

As a result, when the mappings from SSLSO are transformed into cross-references for injection into the ontology (when we create the `mappings.owl` component), the SSLSO term IDs are shortened using the only suitable prefix that ROBOT knows about, the `obo:` prefix.

This means that a mapping to, say, <http://purl.obolibrary.org/obo/BtauDv_0000078> gets turned into a cross-reference to `obo:BtauDv_0000078` -- which is, strictly speaking, correct, but _not_ the format most people would expect for OBO-style cross-references (which would be `BtauDv:0000078`).

The fix is simply to make sure the prefixes are correctly declared.