### PR TITLE
Integrate ChirDv into the composite pipeline.

### DIFF
--- a/src/ontology/config/taxa.yaml
+++ b/src/ontology/config/taxa.yaml
@@ -223,3 +223,8 @@ species:
     bridging:
       - prefix: TnigDv
         name: sslso
+  - taxon_id: NCBITaxon:9925
+    label: goat
+    bridging:
+      - prefix: ChirDv
+        name: sslso


### PR DESCRIPTION
Now that SSLSO includes the ChirDv (goat life stages) component, we must make sure the bridging/composite pipeline is ready to deal with that component: that is, we must generate bridging axioms between the Uberon life stages terms and their ChirDv counterparts, and unfold them into class expressions when building Composite Metazoan.

Otherwise, the ChirDv terms would still end up in the collected/composite products (since they are bundled with SSLSO), but would not be connected to Uberon’s hierarchy.