### PR TITLE
Use ODK 1.5.4 in GitHub Actions workflows.

### DIFF
--- a/.github/workflows/diff.yml
+++ b/.github/workflows/diff.yml
@@ -61,7 +61,7 @@ jobs:
     needs: [branch_status]
     if: ${{ github.event.issue.pull_request }}
     runs-on: ubuntu-latest
-    container: obolibrary/odkfull:v1.5.3
+    container: obolibrary/odkfull:v1.5.4
     steps:
       - uses: khan/pull-request-comment-trigger@v1.1.0
         id: check
@@ -94,7 +94,7 @@ jobs:
     needs: [branch_status]
     if: ${{ github.event.issue.pull_request }}
     runs-on: ubuntu-latest
-    container: obolibrary/odkfull:v1.5.3
+    container: obolibrary/odkfull:v1.5.4
     steps:
       - uses: khan/pull-request-comment-trigger@v1.1.0
         id: check
@@ -122,7 +122,7 @@ jobs:
     needs: [branch_status]
     if: ${{ github.event.issue.pull_request }}
     runs-on: ubuntu-latest
-    container: obolibrary/odkfull:v1.5.3
+    container: obolibrary/odkfull:v1.5.4
     steps:
       - uses: khan/pull-request-comment-trigger@v1.1.0
         id: check
@@ -147,7 +147,7 @@ jobs:
   diff_classification:
     needs: [classify_branch, classify_main]
     runs-on: ubuntu-latest
-    container: obolibrary/odkfull:v1.5.3
+    container: obolibrary/odkfull:v1.5.4
     steps:
       - uses: khan/pull-request-comment-trigger@v1.1.0
         id: check

--- a/.github/workflows/qc.yml
+++ b/.github/workflows/qc.yml
@@ -23,7 +23,7 @@ jobs:
   ontology_qc:
     # The type of runner that the job will run on
     runs-on: ubuntu-latest
-    container: obolibrary/odkfull:v1.5.3
+    container: obolibrary/odkfull:v1.5.4
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it


### PR DESCRIPTION
This PR updates the GitHub Actions workflow files to make them use the latest 1.5.4 version of the ODK.

The bridge generation pipeline now requires SSSOM-Java 1.0.0 (this has been the case since #3443), which in turns requires the ODK 1.5.4.