### PR TITLE
Include seeAlso annotations in mapping-derived xrefs.

### DIFF
--- a/src/scripts/mappings-to-xrefs.rules
+++ b/src/scripts/mappings-to-xrefs.rules
@@ -36,8 +36,6 @@ predicate==* -> check_object_existence();
 !cardinality==*:1 -> stop();
 
 # Create the hasDbXref annotation and annotate it with a subset of the mapping metadata
-object==UBERON:* -> annotate_object(oboInOwl:hasDbXref, "%subject_curie",
-                                    "direct:mapping_justification,
-                                            author_id,
-                                            creator_id,
-                                            mapping_provider");
+object==UBERON:* -> annotate(%{object_id}, oboInOwl:hasDbXref, "%subject_curie",
+                            /annots="mapping_justification,author_id,creator_id,mapping_provider,see_also",
+                            /annots_uris="standard_map");


### PR DESCRIPTION
When generating the cross-references from the SSSOM-maintained mappings, annotate them with any seeAlso annotations that may be associated with the mappings.

The intention is that, if a mapping editor has a reference to back up a mapping statement, that reference can be stored in the SSSOM `see_also` field, and once there it should be preserved when the mapping is transformed into a classic cross-reference.

(This is the same thing as the [corresponding CL PR](https://github.com/obophenotype/cell-ontology/pull/3022)).