### PR TITLE
Update the Uberon ROBOT plugin.

### DIFF
--- a/src/ontology/Makefile
+++ b/src/ontology/Makefile
@@ -10,7 +10,7 @@
 # More information: https://github.com/INCATools/ontology-development-kit/
 
 # Fingerprint of the configuration file when this Makefile was last generated
-CONFIG_HASH=                5425c3609d8b1a973d180c3fbdda577a3e57e8397534270b629edd2f1f6025de
+CONFIG_HASH=                d7d2fbd10b9c58b6b92511fbfc29c15ffae9e8f3e880ed5d27d8ba3e4137d84b
 
 
 # ----------------------------------------
@@ -183,7 +183,7 @@ $(ROBOT_PLUGINS_DIRECTORY)/%.jar:
 # Specific rules for supplementary plugins defined in configuration
 
 $(ROBOT_PLUGINS_DIRECTORY)/uberon.jar:
-	curl -L -o $@ https://github.com/gouttegd/uberon-robot-plugin/releases/download/uberon-robot-plugin-0.3.2/uberon.jar
+	curl -L -o $@ https://github.com/obophenotype/uberon-robot-plugin/releases/download/uberon-robot-plugin-0.4.0/uberon.jar
 
 
 # ----------------------------------------

--- a/src/ontology/uberon-odk.yaml
+++ b/src/ontology/uberon-odk.yaml
@@ -135,7 +135,7 @@ robot_java_args: '-Xmx20G'
 robot_plugins:
   plugins:
     - name: uberon
-      mirror_from: https://github.com/gouttegd/uberon-robot-plugin/releases/download/uberon-robot-plugin-0.3.2/uberon.jar
+      mirror_from: https://github.com/obophenotype/uberon-robot-plugin/releases/download/uberon-robot-plugin-0.4.0/uberon.jar
 robot_report:
   release_reports: False
   fail_on: ERROR


### PR DESCRIPTION
The Uberon plugin has been moved from my personal GitHub space (https://github.com/gouttegd/) to the “obophenotype” organisation (https://github.com/obophenotype/). So in this PR we update the location we are downloading the plugin from, and get the latest version.