### PR TITLE
Support temporary IDs

### DIFF
--- a/.github/workflows/allocate-definitive-ids.yml
+++ b/.github/workflows/allocate-definitive-ids.yml
@@ -1,0 +1,34 @@
+name: Allocate definitive IDs
+
+on:
+  push:
+    branches: [ master ]
+    paths:
+      - 'src/ontology/uberon-edit.obo'
+  workflow_dispatch:
+
+jobs:
+  assign_ids:
+    runs-on: ubuntu-latest
+    container: obolibrary/odkfull:v1.6
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      # Reallocate all temporary IDs as definitive IDs and rewrite
+      # axioms accordingly; this will in effect be a no-op if there is
+      # in fact no temporary IDs to reallocate.
+      - name: Allocate definitive IDs
+        run: |
+          cd src/ontology
+          make allocate-definitive-ids
+
+      # Commit the changes; the 'push' action takes care of checking
+      # whether there are changes to commit at all, so if no IDs were
+      # reallocated, nothing will happen here.
+      - name: Commit and push changes
+        uses: actions-js/push@v1.5
+        with:
+          github_token: ${{ secrets.ID_ALLOCATION_TOKEN }}
+          message: "Replace temporary IDs by definitive IDs."
+          branch: ${{ github.ref }}

--- a/docs/id-management.md
+++ b/docs/id-management.md
@@ -1,0 +1,86 @@
+# ID management in Uberon
+
+## Temporary IDs
+
+“Temporary IDs” are an experimental mechanism to allow editors to mint
+new term IDs without worrying about potential conflicting IDs.
+
+This is primarily intended for AI agents, which are likely to open many
+PRs in parallel but have to share a single ID range (contrary to human
+editors, who all have their own range) and have no way of keeping track
+of which IDs are being used in concurrent PRs (again contrary to human
+editors, who can rely on Protégé for that).
+
+However temporary IDs are in no way restricted to AI agents, and any
+editor could use them if they so want. For example, they could be useful
+for an _external_, _occasional_ editor – someone who is not a known
+contributor to Uberon and for whom we may not necessarily want to
+allocate a dedicated ID range.
+
+### Editing the ontology with temporary IDs
+
+From an editor’s point of view, all that is needed to use temporary IDs
+is to use the `Temporary IDs` range defined in the `uberon-idranges.owl`
+file.
+
+For editors using Protégé, this means selecting said `Temporary IDs`
+range when Protégé asks you to select an ID range policy, just after
+having opened the Uberon edit file.
+
+For other editors (including AI agents), this means making sure that
+whenever a new ID is needed, it is generated within the range allocated
+to `Temporary IDs` (it should normally be `UBERON:99NNNNN`, but please
+check the contents of the `uberon-idranges.owl` file, just in case the
+range is changed in the future).
+
+### Replacing temporary IDs with definitive IDs
+
+Replacing temporary IDs with definitive IDs is done by invoking the
+`allocate-definitive-ids` target:
+
+```sh
+sh run.sh make allocate-definitive-ids
+```
+
+This will find all temporary IDs within the ontology and replace them
+with newly allocated definitive IDs picked from within the `Automation`
+range defined in the `uberon-idranges.owl` file. All axioms that were
+referring to temporary IDs will be automatically re-written so that they
+refer to the corresponding newly allocated definitive IDs.
+
+This replacement must be performed at the latest possible stage, just
+before a PR is merged. If temporary IDs in a PR are replaced by
+definitive IDs, and the PR is then left unmerged for a while, then ID
+conflicts may occur when the PR is finally merged.
+
+For convenience, a GitHub Actions workflow is available to perform the
+ID replacement step on a PR without requiring a Uberon maintainer to
+check out the PR and invoke the `allocate-definitive-ids` manually. When
+a PR containing temporary IDs has been deemed OK for merging, a
+maintainer should trigger the `allocate-definitive-ids` GitHub Actions
+workflow on the PR’s branch, wait for that workflow to terminate (it
+should take a couple of minutes at most), and then _immediately_ merge
+the PR.
+
+### Automatic replacement of temporary IDs upon pushing to master
+
+Alternatively, a PR containing temporary IDs can be merged “as is” to
+the master branch. This will then trigger an automatic ID replacement
+operation (made by the same `allocate-definitive-ids` GitHub Actions
+workflow), directly on the master branch.
+
+Compared to the approach above, where the ID replacement is done on the
+PR _prior to merging_, this approach has the following advantages:
+
+* it is entirely automated, and does not require any manual intervention
+  from a maintainer;
+* it eliminates the risk of an ID conflict still occurring between the
+  moment IDs are replaced on a PR and the moment the PR is merged.
+
+It has the inconvenient that it lets temporary IDs becoming part of the
+history of the master branch, which may make perusing the history more
+cumbersome as the history will be “polluted” by commits that do nothing
+more than rewriting IDs. With the “replace-before-merging” approach,
+such commits can be made invisible if the PR is small enough to allow
+for a “squash merge” instead of a normal merge – then only the
+definitive IDs will only ever make it to the master branch.

--- a/mkdocs.yaml
+++ b/mkdocs.yaml
@@ -92,6 +92,7 @@ nav:
       - Uberon Release: uberon-release.md
       - Standard Operating Procedure for Uberon Curators: uberon-editor-sop.md
       - Onboarding a new curator: onboarding.md
+      - Managing term IDs: id-management.md
   - References:
       - Wiki: https://github.com/obophenotype/uberon/wiki
       - Uberon Manual: https://github.com/obophenotype/uberon/wiki/Manual

--- a/src/ontology/uberon-idranges.owl
+++ b/src/ontology/uberon-idranges.owl
@@ -270,3 +270,15 @@ Datatype: idrange:41
         allocatedto: "Arwa Ibrahim"
     EquivalentTo:
         xsd:integer[>= 8920000, < 8930000]
+
+Datatype: idrange:42
+    Annotations:
+        allocatedto: "Temporary IDs"
+    EquivalentTo:
+        xsd:integer[>= 9900000, < 10000000]
+
+Datatype: idrange:43
+    Annotations:
+        allocatedto: "Automation"
+    EquivalentTo:
+        xsd:integer[>= 1200000, < 1300000]

--- a/src/ontology/uberon-idranges.owl
+++ b/src/ontology/uberon-idranges.owl
@@ -1,4 +1,3 @@
-## ID Ranges File
 Prefix: idrange: <http://purl.obolibrary.org/obo/uberon/idrange/>
 Prefix: allocatedto: <http://purl.obolibrary.org/obo/IAO_0000597>
 Prefix: iddigits: <http://purl.obolibrary.org/obo/IAO_0000596>
@@ -17,260 +16,257 @@ AnnotationProperty: allocatedto:
 
 AnnotationProperty: idprefix:
 
-AnnotationProperty: iddigits: 
+AnnotationProperty: iddigits:
 
-AnnotationProperty: idsfor: 
+AnnotationProperty: idsfor:
 
-AnnotationProperty: comment: 
+AnnotationProperty: comment:
 
 Datatype: idrange:1
     Annotations:
         allocatedto: "Chris Mungall"
     EquivalentTo:
-        xsd:integer[> 1 , <= 499999]
+        xsd:integer[>= 2, < 500000]
 
 Datatype: idrange:2
     Annotations:
         allocatedto: "TBD"
     EquivalentTo:
-        xsd:integer[> 500000 , <= 999999]
+        xsd:integer[>= 500001, < 1000000]
 
 Datatype: idrange:3
     Annotations:
         allocatedto: "Erik Segerdell"
     EquivalentTo:
-        xsd:integer[> 1000000 , <= 1099999]
-
-Datatype: idrange:12
-    Annotations:
-        allocatedto: "David Osumi-Sutherland"
-    EquivalentTo:
-        xsd:integer[> 1100000 , <= 1199999]
+        xsd:integer[>= 1000001, < 1100000]
 
 Datatype: idrange:4
     Annotations:
         allocatedto: "Melissa Haendel"
     EquivalentTo:
-        xsd:integer[> 1500000 , <= 1999999]
+        xsd:integer[>= 1500001, < 2000000]
 
 Datatype: idrange:5
     Annotations:
         allocatedto: "Terms uplifted from TAO",
         comment: "Classes unique to TAO were migrated to this block, but there is no implicit taxonomic constraint here"
     EquivalentTo:
-        xsd:integer[> 2000000 , <= 2999999]
+        xsd:integer[>= 2000001, < 3000000]
 
 Datatype: idrange:6
     Annotations:
         allocatedto: "Terms uplifted from AAO",
         comment: "Classes unique to AAO were migrated to this block, but there is no implicit taxonomic constraint here"
     EquivalentTo:
-        xsd:integer[> 3000000 , <= 3999999]
+        xsd:integer[>= 3000001, < 4000000]
 
 Datatype: idrange:7
     Annotations:
         allocatedto: "Terms uplifted from VSAO",
         comment: "Classes unique to VSAO were migrated to this block, but there is no implicit taxonomic constraint here"
     EquivalentTo:
-        xsd:integer[> 4000000 , <= 4000182]
+        xsd:integer[>= 4000001, < 4000183]
 
 Datatype: idrange:8
     Annotations:
         allocatedto: "Nizar Ibrahim"
     EquivalentTo:
-        xsd:integer[> 4100000 , <= 4199999]
+        xsd:integer[>= 4100001, < 4200000]
 
 Datatype: idrange:9
     Annotations:
         allocatedto: "Alex Dececchi"
     EquivalentTo:
-        xsd:integer[> 4200000 , <= 4299999]
+        xsd:integer[>= 4200001, < 4300000]
 
 Datatype: idrange:10
     Annotations:
         allocatedto: "Wasila Dahdul"
     EquivalentTo:
-        xsd:integer[> 4300000 , <= 4399999]
+        xsd:integer[>= 4300001, < 4400000]
 
 Datatype: idrange:11
     Annotations:
         allocatedto: "Chris Mungall (ext editing)"
     EquivalentTo:
-        xsd:integer[> 4400000 , <= 4499999]
+        xsd:integer[>= 4400001, < 4500000]
+
+Datatype: idrange:12
+    Annotations:
+        allocatedto: "David Osumi-Sutherland"
+    EquivalentTo:
+        xsd:integer[>= 1100001, < 1200000]
 
 Datatype: idrange:13
     Annotations:
         allocatedto: "Robert Druzinsky"
     EquivalentTo:
-        xsd:integer[> 5000000 , <= 5499999]
+        xsd:integer[>= 5000001, < 5500000]
 
 Datatype: idrange:14
     Annotations:
         allocatedto: "Trish Whetzel"
     EquivalentTo:
-        xsd:integer[> 5500000 , <= 5599999]
+        xsd:integer[>= 5500001, < 5600000]
 
 Datatype: idrange:15
     Annotations:
         allocatedto: "Insect Anatomy"
     EquivalentTo:
-        xsd:integer[> 6000000 , <= 6099999]
+        xsd:integer[>= 6000001, < 6100000]
 
 Datatype: idrange:16
     Annotations:
         allocatedto: "Nico Matentzoglu"
     EquivalentTo:
-        xsd:integer[> 7000000 , <= 7499999]
+        xsd:integer[>= 7000001, < 7500000]
 
 Datatype: idrange:17
     Annotations:
         allocatedto: "Ramona Walls"
     EquivalentTo:
-        xsd:integer[> 7500000 , <= 7999999]
+        xsd:integer[>= 7500001, < 8000000]
 
 Datatype: idrange:18
     Annotations:
         allocatedto: "Nicole Vasilevsky"
     EquivalentTo:
-        xsd:integer[> 8000000 , <= 8199999]
+        xsd:integer[>= 8000001, < 8200000]
 
 Datatype: idrange:19
     Annotations:
         allocatedto: "Anne Thessen"
     EquivalentTo:
-        xsd:integer[> 8200000 , <= 8299999]
+        xsd:integer[>= 8200001, < 8300000]
 
 Datatype: idrange:20
     Annotations:
         allocatedto: "Bonita Lam"
     EquivalentTo:
-        xsd:integer[> 8300000, <= 8305000]
+        xsd:integer[>= 8300001, < 8305001]
 
 Datatype: idrange:21
     Annotations:
         allocatedto: "Sebastian Koehler"
     EquivalentTo:
-        xsd:integer[> 8305001, <= 8309999]
+        xsd:integer[>= 8305002, < 8310000]
 
 Datatype: idrange:22
     Annotations:
         allocatedto: "InterLex"
     EquivalentTo:
-        xsd:integer[> 8310000, <= 8399999]
+        xsd:integer[>= 8310001, < 8400000]
 
 Datatype: idrange:23
     Annotations:
         allocatedto: "Maria Keays"
     EquivalentTo:
-        xsd:integer[> 8400000, <= 8409999]
+        xsd:integer[>= 8400001, < 8410000]
 
 Datatype: idrange:24
     Annotations:
         allocatedto: "Paola Roncaglia"
     EquivalentTo:
-        xsd:integer[> 8410000, <= 8419999]
+        xsd:integer[>= 8410001, < 8420000]
 
 Datatype: idrange:25
     Annotations:
         allocatedto: "Ray Stefancsik"
     EquivalentTo:
-        xsd:integer[> 8420000, <= 8429999]
+        xsd:integer[>= 8420001, < 8430000]
 
 Datatype: idrange:26
     Annotations:
         allocatedto: "Joshua Fortriede"
     EquivalentTo:
-        xsd:integer[> 8430000, <= 8439999]
+        xsd:integer[>= 8430001, < 8440000]
 
 Datatype: idrange:27
     Annotations:
         allocatedto: "Shawn Tan"
     EquivalentTo:
-        xsd:integer[> 8440000, <= 8449999]
+        xsd:integer[>= 8440001, < 8450000]
 
 Datatype: idrange:28
     Annotations:
         allocatedto: "Damien Goutte-Gattat"
     EquivalentTo:
-        xsd:integer[> 8450000, <= 8459999]
+        xsd:integer[>= 8450001, < 8460000]
 
 Datatype: idrange:29
     Annotations:
         allocatedto: "Ellen Quardokus"
     EquivalentTo:
-        xsd:integer[> 8460000, <= 8469999]
+        xsd:integer[>= 8460001, < 8470000]
 
 Datatype: idrange:30
     Annotations:
         allocatedto: "ad hoc EBI editor"
     EquivalentTo:
-        xsd:integer[> 8470000, <= 8479999]
+        xsd:integer[>= 8470001, < 8480000]
 
 Datatype: idrange:31
     Annotations:
         allocatedto: "Paula Duek"
     EquivalentTo:
-        xsd:integer[> 8480000, <= 8489999]
-
+        xsd:integer[>= 8480001, < 8490000]
 
 Datatype: idrange:32
     Annotations:
         allocatedto: "Bill Duncan"
     EquivalentTo:
-        xsd:integer[> 8490000, <= 8499999]
-
+        xsd:integer[>= 8490001, < 8500000]
 
 Datatype: idrange:33
     Annotations:
         allocatedto: "Helena Machado"
     EquivalentTo:
-        xsd:integer[> 8500000, <= 8599999]
-        
+        xsd:integer[>= 8500001, < 8600000]
 
 Datatype: idrange:34
     Annotations:
         allocatedto: "Aleix Puig"
     EquivalentTo:
-        xsd:integer[>= 8600000, <= 8609999]
+        xsd:integer[>= 8600000, < 8610000]
 
 Datatype: idrange:35
     Annotations:
         allocatedto: "Jim Balhoff"
     EquivalentTo:
-        xsd:integer[>= 4500000, <= 4509999]
+        xsd:integer[>= 4500000, < 4510000]
 
-        Datatype: idrange:36
+Datatype: idrange:36
     Annotations:
         allocatedto: "Jasmine Belfiore"
     EquivalentTo:
-        xsd:integer[>= 8700000, <= 8799999]
+        xsd:integer[>= 8700000, < 8800000]
 
-        Datatype: idrange:37
+Datatype: idrange:37
     Annotations:
         allocatedto: "Alida Avola"
     EquivalentTo:
-        xsd:integer[>= 8800000, <= 8849999]
+        xsd:integer[>= 8800000, < 8850000]
 
-        Datatype: idrange:38
+Datatype: idrange:38
     Annotations:
         allocatedto: "Caroline Eastwood"
     EquivalentTo:
-        xsd:integer[>= 8850000, <= 8899999]
+        xsd:integer[>= 8850000, < 8900000]
 
-        Datatype: idrange:39
+Datatype: idrange:39
     Annotations:
         allocatedto: "Tiago Lubiana"
     EquivalentTo:
-        xsd:integer[>= 8900000, <= 8909999]
+        xsd:integer[>= 8900000, < 8910000]
 
 Datatype: idrange:40
     Annotations:
         allocatedto: "NDI Cloud"
     EquivalentTo:
-        xsd:integer[>= 8910000, <= 8919999]
+        xsd:integer[>= 8910000, < 8920000]
 
-        Datatype: idrange:41
+Datatype: idrange:41
     Annotations:
         allocatedto: "Arwa Ibrahim"
     EquivalentTo:
-        xsd:integer[>= 8920000, <= 8929999]
+        xsd:integer[>= 8920000, < 8930000]

--- a/src/ontology/uberon.Makefile
+++ b/src/ontology/uberon.Makefile
@@ -1397,6 +1397,16 @@ release-diff:
 # UTILITY COMMANDS
 # ----------------------------------------
 
+# Allocating definitive IDs
+# ----------------------------------------#
+.PHONY: allocate-definitive-ids
+allocate-definitive-ids: | all_robot_plugins
+	$(ROBOT) kgcl:mint -i $(SRC) \
+		           --temp-id-prefix http://purl.obolibrary.org/obo/UBERON_99 \
+		           --id-range-name Automation \
+		 convert -f obo --check false -o $(SRC)
+
+
 # Spellchecking
 # ----------------------------------------
 


### PR DESCRIPTION
This PR implements the idea proposed in #3564 for allowing AI agents (or in fact any editor, AI or not) to use “temporary” term IDs that are later replaced by definitive IDs.

It allocates two new ID ranges:

* the `Temporary IDs` range (UBERON:99NNNNN): any ID picked within that range is treated as a temporary ID, slated for later replacement by a definitive ID;
* the `Automation` range (UBERON:12NNNNN): this is a “normal” ID range (IDs picked within that range are not treated differently from any other ID), but is reserved for automated process – notably, for the process that replaces temporary IDs by definitive ones.

It also adds a new GitHub Action workflow, `allocate-definitive-ids.yml`, which finds all temporary IDs (all IDs in the `UBERON:99NNNNN` range) in the -edit file and replaces them by newly allocated IDs from the `Automation` range. That workflow can be used in two different ways, corresponding to the two options outlined at the end of the #3564 ticket:

(A) Manual trigger: When a PR contains temporary IDs, a Uberon maintainer should manually trigger the `allocate-definitive-ids.yml` workflow on the PR’s underlying branch, _just before_ merging the PR into the master branch. This will automatically add a commit to the PR, in which temporary IDs are replaced by definitive ones. The PR should then be merged _as soon as possible_ once that commit has been added.

(B) Automatic trigger: If a PR containing temporary IDs is merged into the master branch (with the temporary IDs still present), the `allocate-definitive-ids.yml` workflow will automatically be triggered and push a new commit to replace the temporary IDs by definitive ones, directly on the master branch. This can act as a “fall-back” action to ensure that temporary IDs are never left in the master branch, in case a Uberon maintainer forgets to manually trigger the ID replacement workflow on a PR.