### PR TITLE
Use ODK 1.6 in diff.yml workflow.

### DIFF
--- a/.github/workflows/diff.yml
+++ b/.github/workflows/diff.yml
@@ -61,7 +61,7 @@ jobs:
     needs: [branch_status]
     if: ${{ github.event.issue.pull_request }}
     runs-on: ubuntu-latest
-    container: obolibrary/odkfull:v1.5.4
+    container: obolibrary/odkfull:v1.6
     steps:
       - uses: khan/pull-request-comment-trigger@v1.1.0
         id: check
@@ -94,7 +94,7 @@ jobs:
     needs: [branch_status]
     if: ${{ github.event.issue.pull_request }}
     runs-on: ubuntu-latest
-    container: obolibrary/odkfull:v1.5.4
+    container: obolibrary/odkfull:v1.6
     steps:
       - uses: khan/pull-request-comment-trigger@v1.1.0
         id: check
@@ -122,7 +122,7 @@ jobs:
     needs: [branch_status]
     if: ${{ github.event.issue.pull_request }}
     runs-on: ubuntu-latest
-    container: obolibrary/odkfull:v1.5.4
+    container: obolibrary/odkfull:v1.6
     steps:
       - uses: khan/pull-request-comment-trigger@v1.1.0
         id: check
@@ -147,7 +147,7 @@ jobs:
   diff_classification:
     needs: [classify_branch, classify_main]
     runs-on: ubuntu-latest
-    container: obolibrary/odkfull:v1.5.4
+    container: obolibrary/odkfull:v1.6
     steps:
       - uses: khan/pull-request-comment-trigger@v1.1.0
         id: check


### PR DESCRIPTION
The `diff.yml` workflow, which powers the “gogoeditdiff” feature, is still using the ODK image version 1.5.4. This leads to a systematic failure, because at least one of the rules invoked by this workflow (`make uberon-base.owl`) is dependent upon the new ROBOT option `--include-subproperties`, which is not available in the version of ROBOT provided with ODK 1.5.4.

We update the workflow to ensure it uses version 1.6 of the ODK.

closes #3575