### PR TITLE
Replace obsolete SSSOM/T-OWL rules.

### DIFF
--- a/src/scripts/mappings-to-xrefs.rules
+++ b/src/scripts/mappings-to-xrefs.rules
@@ -30,12 +30,12 @@ subject==UBERON:* -> invert();
 !object==UBERON:* -> stop();
 
 # Ignore any mapping to an inexistent or obsolete UBERON class.
-predicate==* -> check_object_existence();
+!exists(%{object_id}) -> stop();
 
 # Ignore any mapping where the same foreign term is mapped to more than one UBERON class.
 !cardinality==*:1 -> stop();
 
 # Create the hasDbXref annotation and annotate it with a subset of the mapping metadata
-object==UBERON:* -> annotate(%{object_id}, oboInOwl:hasDbXref, "%subject_curie",
+object==UBERON:* -> annotate(%{object_id}, oboInOwl:hasDbXref, "%{subject_id|short}",
                             /annots="mapping_justification,author_id,creator_id,mapping_provider,see_also",
                             /annots_uris="standard_map");


### PR DESCRIPTION
The `mappings-to-xrefs.rules` SSSOM/T-OWL ruleset (used to generate the `mappings.owl` component, containing xref representations of foreign mappings) is still using some deprecated, pre-1.0 SSSOM/T-OWL features:

* the `check_object_existence()` preprocessing function;
* the `%subject_curie` placeholder.

Those features will no longer be supported in a future SSSOM-Java version and should be replaced by their SSSOM/T-OWL 1.0 equivalents, which is what we do here.