### PR TITLE
Fix the automatic ID allocation workflow.

### DIFF
--- a/.github/workflows/allocate-definitive-ids.yml
+++ b/.github/workflows/allocate-definitive-ids.yml
@@ -14,6 +14,9 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+          fetch-depth: 0
 
       # Reallocate all temporary IDs as definitive IDs and rewrite
       # axioms accordingly; this will in effect be a no-op if there is


### PR DESCRIPTION
The automatic ID allocation workflow currently cannot be used in fully automated mode (after a PR has been merged), because it will always use the default `GITHUB_TOKEN`, which is not allowed to push to the master branch.

The workflow has a dedicated token (which _is_ allowed to push to the master branch) specifically intended for the purpose of automatic ID allocation, but for the push step to use it, the checkout step needs to be configured _not_ to persist the checkout credentials, which is what we do here.