### PR TITLE
Add workflows section to ODK YAML config and rm qc

### DIFF
--- a/src/ontology/uberon-odk.yaml
+++ b/src/ontology/uberon-odk.yaml
@@ -172,3 +172,5 @@ components:
     - filename: vasculature_class.owl
     - filename: hra_depiction_3d_images.owl
       source: https://raw.githubusercontent.com/hubmapconsortium/ccf-validation-tools/master/owl/hra_uberon_3d_images.owl
+workflows:
+ - docs


### PR DESCRIPTION
Add workflows section to ODK config, overriding the defaults and effectively removing the qc workflow from ODK management.