### PR TITLE
Update Claude and GitHub AI automation config

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,14 +1,27 @@
 {
   "permissions": {
     "allow": [
-        "Bash",
-        "Edit",
-        "MultiEdit",
-        "NotebookEdit",
-        "FileEdit",
-        "WebFetch",
-        "WebSearch",
-        "Write"
+      "Bash",
+      "Edit",
+      "MultiEdit",
+      "NotebookEdit",
+      "FileEdit",
+      "WebFetch",
+      "WebSearch",
+      "Write"
+    ]
+  },
+  "hooks": {
+    "Stop": [
+      {
+        "hooks": [
+          {
+            "type": "agent",
+            "prompt": "You are a completion verifier for the Uberon AI agent (@dragon-ai-agent). Your job is to check whether the agent actually completed its task before allowing it to stop.\n\nIMPORTANT: First check the stop_hook_active field in $ARGUMENTS. If it is true, respond with {\"ok\": true} immediately.\n\nOtherwise, read the transcript at transcript_path from $ARGUMENTS and determine:\n\n1. What was the user's request?\n2. Did the agent produce an appropriate deliverable?\n3. If the task required ontology or repository edits, did the agent actually push work and create or update a PR?\n4. If the task required only a question, clarification, research summary, or status update, did the agent communicate that back on GitHub?\n5. If the task was a PR review, did the agent leave an actual GitHub review and or inline review comments?\n\nLook for actual tool-use evidence, not text claims. Valid evidence includes commands such as:\n- gh pr create\n- gh pr review\n- gh issue comment\n- gh pr comment\n- git push\n\nIf the agent correctly decided it should not proceed and communicated that via GitHub, that counts as complete.\n\nIf the task appears incomplete, respond with:\n{\"ok\": false, \"reason\": \"<specific description of what is missing>\"}\n\nIf the task is complete, respond with:\n{\"ok\": true}",
+            "timeout": 120
+          }
+        ]
+      }
     ]
   }
 }

--- a/.github/workflows/ai-agent.yml
+++ b/.github/workflows/ai-agent.yml
@@ -1,219 +1,341 @@
-name: Dragon AI Agent GitHub Mentions
+# AI Agent triggered by @mentions in issues/PRs
+#
+# Listens for @<agent-name> please <request> mentions from authorized users
+# and runs Claude Code to respond.
+#
+# Required secrets:
+# - AI4C_AGENT_APP_ID
+# - AI4C_AGENT_PRIVATE_KEY
+# - CLAUDE_CODE_OAUTH_TOKEN
+#
+# Configuration:
+# - .github/ai-controllers.json (list of authorized usernames)
+#
+name: AI Agent GitHub Mentions
 
 env:
-  ROBOT_VERSION: v1.9.7
+  AGENT_NAME: dragon-ai-agent
+  MODEL: claude-opus-4-7
   TOOLS_DIR: ${{ github.workspace }}/tools
+  TIMEOUT_MINUTES: 30
 
 on:
+  workflow_dispatch:
+    inputs:
+      issue_number:
+        description: "Issue or PR number to respond to"
+        required: true
+      item_type:
+        description: "Type of item (issue or pull_request)"
+        required: true
+        type: choice
+        options:
+          - issue
+          - pull_request
+      prompt:
+        description: "The request/prompt for the agent"
+        required: true
+  # `assigned` lets authorized controllers dispatch work by assigning
+  # `dragon-ai-agent` directly.
   issues:
-    types: [opened, edited]
+    types: [opened, edited, assigned]
   issue_comment:
     types: [created, edited]
   pull_request:
-    types: [opened, edited]
+    types: [opened, edited, assigned]
   pull_request_review_comment:
     types: [created, edited]
 
 jobs:
   check-mention:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: write
+      pull-requests: write
     outputs:
       result: ${{ steps.check.outputs.result }}
     steps:
+      - name: Generate ai4c-agent token
+        id: app-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.AI4C_AGENT_APP_ID }}
+          private-key: ${{ secrets.AI4C_AGENT_PRIVATE_KEY }}
+
       - name: Checkout repository
-        uses: actions/checkout@v3
-        
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+          token: ${{ steps.app-token.outputs.token }}
+
       - name: Check for qualifying mention
         id: check
         uses: actions/github-script@v6
         with:
-          github-token: ${{ secrets.PAT_FOR_PR }}  # Use PAT instead of default token
+          github-token: ${{ steps.app-token.outputs.token }}
           script: |
-            // Load allowed users from config
-            const fs = require('fs');
+            const fs = require("fs");
+
             let allowedUsers = [];
             try {
-              const configContent = fs.readFileSync('.github/ai-controllers.json', 'utf8');
+              const configContent = fs.readFileSync(".github/ai-controllers.json", "utf8");
               allowedUsers = JSON.parse(configContent);
             } catch (error) {
-              console.log('Error loading allowed users:', error);
-              allowedUsers = ['cmungall']; // Fallback
+              console.log("Error loading allowed users:", error);
+              allowedUsers = ["cmungall"];
             }
-            
-            // Get content and user from event payload directly to avoid API calls when possible
-            let content = '';
-            let userLogin = '';
-            let itemType = '';
+
+            const agentName = process.env.AGENT_NAME || "dragon-ai-agent";
+
+            if (context.eventName === "workflow_dispatch") {
+              const inputs = context.payload.inputs;
+              const itemType = inputs.item_type;
+              const itemNumber = parseInt(inputs.issue_number, 10);
+              const prompt = inputs.prompt;
+              const combined = `${prompt}`.toLowerCase();
+              const skipOdk = combined.includes("skip_odk") || combined.includes("quick question");
+
+              return {
+                qualifiedMention: true,
+                itemType,
+                itemNumber,
+                user: context.actor,
+                prompt,
+                branchName: `${agentName}-${itemType}-${itemNumber}-run${context.runNumber}`,
+                useOdkContainer: !skipOdk,
+                skipOdkNote: skipOdk
+                  ? "NOTE: This is NOT running in the ODK container (SKIP_ODK or quick question was specified), so ODK tools like ROBOT may be unavailable."
+                  : "",
+              };
+            }
+
+            let content = "";
+            let userLogin = "";
+            let itemType = "";
             let itemNumber = 0;
-            
-            if (context.eventName === 'issues') {
-              content = context.payload.issue.body || '';
-              userLogin = context.payload.issue.user.login;
-              itemType = 'issue';
+            let commentId = null;
+            let reactionTarget = "issue";
+
+            if (context.eventName === "issues") {
+              content = context.payload.issue.body || "";
+              userLogin = context.payload.action === "assigned"
+                ? (context.payload.sender?.login || context.payload.issue.user.login)
+                : context.payload.issue.user.login;
+              itemType = "issue";
               itemNumber = context.payload.issue.number;
-            } else if (context.eventName === 'pull_request') {
-              content = context.payload.pull_request.body || '';
-              userLogin = context.payload.pull_request.user.login;
-              itemType = 'pull_request';
+            } else if (context.eventName === "pull_request") {
+              content = context.payload.pull_request.body || "";
+              userLogin = context.payload.action === "assigned"
+                ? (context.payload.sender?.login || context.payload.pull_request.user.login)
+                : context.payload.pull_request.user.login;
+              itemType = "pull_request";
               itemNumber = context.payload.pull_request.number;
-            } else if (context.eventName === 'issue_comment') {
-              content = context.payload.comment.body || '';
+            } else if (context.eventName === "issue_comment") {
+              content = context.payload.comment.body || "";
               userLogin = context.payload.comment.user.login;
-              itemType = 'issue';
+              itemType = context.payload.issue.pull_request ? "pull_request" : "issue";
               itemNumber = context.payload.issue.number;
-            } else if (context.eventName === 'pull_request_review_comment') {
-              content = context.payload.comment.body || '';
+              commentId = context.payload.comment.id;
+              reactionTarget = "issue_comment";
+            } else if (context.eventName === "pull_request_review_comment") {
+              content = context.payload.comment.body || "";
               userLogin = context.payload.comment.user.login;
-              itemType = 'pull_request';
+              itemType = "pull_request";
               itemNumber = context.payload.pull_request.number;
+              commentId = context.payload.comment.id;
+              reactionTarget = "pull_request_review_comment";
             }
-            
-            // Check if user is allowed and mention exists
+
             const isAllowed = allowedUsers.includes(userLogin);
-            const mentionRegex = /@dragon-ai-agent\s+please\s+(.*)/i;
+            const mentionRegex = new RegExp(`@${agentName}\\s+please\\s+([\\s\\S]*)`, "i");
             const mentionMatch = content.match(mentionRegex);
-            
-            const qualifiedMention = isAllowed && mentionMatch !== null;
-            const prompt = qualifiedMention ? mentionMatch[1].trim() : '';
-            
-            console.log(`User: ${userLogin}, Allowed: ${isAllowed}, Has mention: ${mentionMatch !== null}`);
-            
+            const isAgentAssignment =
+              (context.eventName === "issues" || context.eventName === "pull_request") &&
+              context.payload.action === "assigned" &&
+              context.payload.assignee?.login === agentName;
+            const qualifiedMention =
+              (isAllowed && mentionMatch !== null) || (isAllowed && isAgentAssignment);
+            const prompt = mentionMatch !== null
+              ? mentionMatch[1].trim()
+              : (isAgentAssignment
+                ? "You were assigned to this item. Read the full GitHub context, identify the next concrete action, and carry it through."
+                : "");
+
+            console.log(
+              `User: ${userLogin}, Allowed: ${isAllowed}, Has mention: ${mentionMatch !== null}, ` +
+              `Agent assignment: ${isAgentAssignment}`
+            );
+
+            if (!qualifiedMention) {
+              return { qualifiedMention: false };
+            }
+
+            try {
+              if (reactionTarget === "issue_comment") {
+                await github.rest.reactions.createForIssueComment({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  comment_id: commentId,
+                  content: "eyes",
+                });
+              } else if (reactionTarget === "pull_request_review_comment") {
+                await github.rest.reactions.createForPullRequestReviewComment({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  comment_id: commentId,
+                  content: "eyes",
+                });
+              } else {
+                await github.rest.reactions.createForIssue({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: itemNumber,
+                  content: "eyes",
+                });
+              }
+            } catch (error) {
+              console.log("Could not add reaction:", error.message);
+            }
+
+            try {
+              const runUrl = `https://github.com/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
+              const commentBody = `🤖 Working on it...\n\nFollow along: [View workflow run](${runUrl})\n\n*— @${agentName}*`;
+
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: itemNumber,
+                body: commentBody,
+              });
+            } catch (error) {
+              console.log("Could not post comment:", error.message);
+            }
+
+            const baseBody =
+              context.payload.issue?.body ||
+              context.payload.pull_request?.body ||
+              "";
+            const combined = `${baseBody}\n${content}`.toLowerCase();
+            const skipOdk = combined.includes("skip_odk") || combined.includes("quick question");
+
             return {
-              qualifiedMention,
+              qualifiedMention: true,
               itemType,
               itemNumber,
-              prompt,
               user: userLogin,
-              controllers: allowedUsers.map(u => '@' + u).join(', ')
+              prompt,
+              branchName: `${agentName}-${itemType}-${itemNumber}-run${context.runNumber}`,
+              useOdkContainer: !skipOdk,
+              skipOdkNote: skipOdk
+                ? "NOTE: This is NOT running in the ODK container (SKIP_ODK or quick question was specified), so ODK tools like ROBOT may be unavailable."
+                : "",
             };
 
   respond-to-mention:
     needs: check-mention
     if: fromJSON(needs.check-mention.outputs.result).qualifiedMention == true
+    timeout-minutes: 30
     permissions:
       contents: write
-      pull-requests: write
       issues: write
+      pull-requests: write
+      id-token: write
     runs-on: ubuntu-latest
+    container: ${{ fromJSON(needs.check-mention.outputs.result).useOdkContainer && 'obolibrary/odkfull:latest' || null }}
     steps:
+      - name: Generate ai4c-agent token
+        id: app-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.AI4C_AGENT_APP_ID }}
+          private-key: ${{ secrets.AI4C_AGENT_PRIVATE_KEY }}
+
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 1
-          token: ${{ secrets.PAT_FOR_PR }}  # Use PAT for checkout to allow committing later
+          token: ${{ steps.app-token.outputs.token }}
 
       - name: Configure Git
         run: |
-          git config --global user.name "Dragon-AI Agent"
-          git config --global user.email "dragon-ai-agent[bot]@users.noreply.github.com"
-      
+          git config --global user.name "${{ env.AGENT_NAME }}[bot]"
+          git config --global user.email "${{ env.AGENT_NAME }}[bot]@users.noreply.github.com"
+
       - name: Create tools directory
-        run: mkdir -p ${{ env.TOOLS_DIR }}
-
-      - name: Setup Node.js
-        uses: actions/setup-node@v3
-        with:
-          node-version: '18'
-
-      - name: install claude
-        run: |
-          npm install -g @anthropic-ai/claude-code
-
-      - name: Cache ROBOT JAR files
-        uses: actions/cache@v3
-        with:
-          path: ~/.jar-cache
-          key: ${{ runner.os }}-robot-${{ env.ROBOT_VERSION }}
-          restore-keys: ${{ runner.os }}-robot-
-  
-      - name: Download ROBOT JAR if not cached
-        run: |
-          mkdir -p ~/.jar-cache
-          if [ ! -f ~/.jar-cache/robot.jar ]; then
-            curl -L https://github.com/ontodev/robot/releases/download/${{ env.ROBOT_VERSION }}/robot.jar -o ~/.jar-cache/robot.jar
-          fi
-      
-      - name: Download ROBOT command line wrapper
-        run: |
-          cp ~/.jar-cache/robot.jar ${{ env.TOOLS_DIR }}/robot.jar
-          curl -L https://raw.githubusercontent.com/ontodev/robot/${{ env.ROBOT_VERSION }}/bin/robot -o ${{ env.TOOLS_DIR }}/robot
-          chmod +x ${{ env.TOOLS_DIR }}/robot
-          ${{ env.TOOLS_DIR }}/robot --help
+        run: mkdir -p "${{ env.TOOLS_DIR }}"
 
       - name: Add tools to PATH
-        run: |
-          echo "${{ env.TOOLS_DIR }}" >> $GITHUB_PATH
-          ls -alt ${{ github.workspace }}
-          ls -alt ${{ env.TOOLS_DIR }}
+        run: echo "${{ env.TOOLS_DIR }}" >> "$GITHUB_PATH"
 
       - name: Add obo-scripts to PATH
         run: |
-          git clone https://github.com/cmungall/obo-scripts.git ${{ env.TOOLS_DIR }}/obo-scripts
-          echo "${{ env.TOOLS_DIR }}/obo-scripts" >> $GITHUB_PATH
-
-      - name: Set up environment
-        run: |
-          echo "BRANCH_NAME=dragon_ai_agent_${{ fromJSON(needs.check-mention.outputs.result).itemNumber }}" >> $GITHUB_ENV
-          # Safely write prompt to file
-          mkdir -p /tmp/claude-input
-          echo "${{ fromJSON(needs.check-mention.outputs.result).prompt }}" > /tmp/claude-input/prompt.txt
-          
-      - name: Set up Anthropic API key and GitHub token
-        env:
-          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
-          GH_TOKEN: ${{ secrets.PAT_FOR_PR }}  # Kept PAT as requested
-        run: |
-          echo "ANTHROPIC_API_KEY=$ANTHROPIC_API_KEY" >> $GITHUB_ENV
-          echo "GH_TOKEN=$GH_TOKEN" >> $GITHUB_ENV
-          echo "LOGFIRE_SEND_TO_LOGFIRE=false" >> $GITHUB_ENV
+          git clone --depth 1 https://github.com/cmungall/obo-scripts.git "${{ env.TOOLS_DIR }}/obo-scripts"
+          echo "${{ env.TOOLS_DIR }}/obo-scripts" >> "$GITHUB_PATH"
 
       - name: Install uv
         uses: astral-sh/setup-uv@v5
-          
-      - name: Install python tools
+
+      - name: Install Python tools
         run: |
           uv venv
-          source .venv/bin/activate
+          . .venv/bin/activate
           uv pip install aurelian jinja2-cli "wrapt>=1.17.2"
-        
-      - name: Create structured Claude prompt
-        run: |
-          cat > /tmp/claude-input/claude_prompt.txt << EOL
-          You are @dragon-ai-agent.
-          You're responding to a request from or relayed by @${{ fromJSON(needs.check-mention.outputs.result).user }} on GitHub ${{ fromJSON(needs.check-mention.outputs.result).itemType }} #${{ fromJSON(needs.check-mention.outputs.result).itemNumber }}.
-          You only respond to requests from the following authorized controllers: ${{ fromJSON(needs.check-mention.outputs.result).controllers }}.
+          echo "${{ github.workspace }}/.venv/bin" >> "$GITHUB_PATH"
 
-          You should use \`gh\` to communicate with the user via the GitHub issue/ticket.
-          If instructed to modify files, you should make changes on a branch and submit a PR, communicating clearly and in
-          detail on the PR.
+      - name: Export GitHub token for gh CLI
+        run: echo "GH_TOKEN=${{ steps.app-token.outputs.token }}" >> "$GITHUB_ENV"
 
-          Always end by informing the user what you did (or were not able to do) with a message, either on an issue or a PR,
-          as appropriate.
-          
-          The request is below, enclosed in triple backticks:
-          \`\`\`
-          $(cat /tmp/claude-input/prompt.txt)
-          \`\`\`
+      - name: Run Claude Code
+        uses: anthropics/claude-code-action@v1
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          github_token: ${{ steps.app-token.outputs.token }}
+          allowed_bots: "claude,github-actions"
+          show_full_output: true
+          claude_args: |
+            --allowedTools "Bash,Read,Write,Edit,Glob,Grep,LS,MultiEdit,NotebookEdit,TodoRead,TodoWrite,WebFetch,WebSearch"
+            --model "${{ env.MODEL }}"
+          prompt: |
+            You are @${{ env.AGENT_NAME }}, responding to a request from @${{ fromJSON(needs.check-mention.outputs.result).user }} on GitHub ${{ fromJSON(needs.check-mention.outputs.result).itemType }} #${{ fromJSON(needs.check-mention.outputs.result).itemNumber }}.
 
-          However, you should use `gh` to read the complete context of the request, and look at any linked issues or PRs
-          that provide additional context.
+            Follow the repository instructions in `CLAUDE.md`.
 
-          EOL
-      
-      
-      - name: Run Claude Code in headless mode
-        id: claude-response
-        run: |
-          obo-grep.pl --help
-          obo-checkin.pl --help
+            ${{ fromJSON(needs.check-mention.outputs.result).skipOdkNote }}
 
-          export PATH="${{ env.TOOLS_DIR }}:$PATH"
-          # Python env
-          source .venv/bin/activate
+            THE REQUEST:
+            ```
+            ${{ fromJSON(needs.check-mention.outputs.result).prompt }}
+            ```
 
-          # Run Claude with proper permissions
-          claude -p "$(cat /tmp/claude-input/claude_prompt.txt)" \
-            --permission-mode bypassPermissions \
-            --output-format stream-json \
-            --verbose 
-          
+            GETTING CONTEXT:
+            Use `gh` to read the full context. Examples:
+            - `gh issue view ${{ fromJSON(needs.check-mention.outputs.result).itemNumber }} --json title,body,comments`
+            - `gh pr view ${{ fromJSON(needs.check-mention.outputs.result).itemNumber }} --json title,body,comments,reviews`
+            - Check for linked issues or PRs mentioned in the body
+
+            MAKING CHANGES:
+            If you need to modify files:
+            1. Create a branch: `git checkout -b ${{ fromJSON(needs.check-mention.outputs.result).branchName }}`
+               (unless requested to update an existing branch or PR, in which case check out and work on that branch)
+            2. Make your changes and commit with descriptive messages
+            3. Push the branch: `git push -u origin ${{ fromJSON(needs.check-mention.outputs.result).branchName }}`
+            4. Create a PR using `gh pr create` with a clear title and description
+
+            COMMUNICATING:
+            - Use `gh` CLI directly to interact with the user on GitHub
+            - Use `gh issue comment` or `gh pr comment` to post updates
+            - Always inform the user what you did (or could not do)
+            - If you created a PR, reference it in your comment on the original issue or PR
+            - If the request is ambiguous, ask a clarifying question via `gh`
+
+            SIGNATURE:
+            Always include the following signature block in commit messages and GitHub comments:
+            ```
+            ---
+            🤖 **Generated by @${{ env.AGENT_NAME }}**
+            - Model: `${{ env.MODEL }}`
+            - Agent harness: claude-code
+            - Triggered by: @${{ fromJSON(needs.check-mention.outputs.result).user }}
+            - Run: [View workflow run](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }})
+            ```

--- a/.github/workflows/ai-agent.yml
+++ b/.github/workflows/ai-agent.yml
@@ -58,20 +58,20 @@ jobs:
     steps:
       - name: Generate ai4c-agent token
         id: app-token
-        uses: actions/create-github-app-token@v1
+        uses: actions/create-github-app-token@v3
         with:
           app-id: ${{ secrets.AI4C_AGENT_APP_ID }}
           private-key: ${{ secrets.AI4C_AGENT_PRIVATE_KEY }}
 
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 1
           token: ${{ steps.app-token.outputs.token }}
 
       - name: Check for qualifying mention
         id: check
-        uses: actions/github-script@v6
+        uses: actions/github-script@v8
         with:
           github-token: ${{ steps.app-token.outputs.token }}
           script: |
@@ -246,13 +246,13 @@ jobs:
     steps:
       - name: Generate ai4c-agent token
         id: app-token
-        uses: actions/create-github-app-token@v1
+        uses: actions/create-github-app-token@v3
         with:
           app-id: ${{ secrets.AI4C_AGENT_APP_ID }}
           private-key: ${{ secrets.AI4C_AGENT_PRIVATE_KEY }}
 
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 1
           token: ${{ steps.app-token.outputs.token }}

--- a/.github/workflows/ai-agent.yml
+++ b/.github/workflows/ai-agent.yml
@@ -42,7 +42,7 @@ on:
   issue_comment:
     types: [created, edited]
   pull_request:
-    types: [opened, edited, assigned]
+    types: [opened, edited, assigned, synchronize]
   pull_request_review_comment:
     types: [created, edited]
 

--- a/.github/workflows/ai-agent.yml
+++ b/.github/workflows/ai-agent.yml
@@ -150,13 +150,22 @@ jobs:
             const isAllowed = allowedUsers.includes(userLogin);
             const mentionRegex = new RegExp(`@${agentName}\\s+please\\s+([\\s\\S]*)`, "i");
             const mentionMatch = content.match(mentionRegex);
+            // On synchronize we want this workflow to revalidate on push without
+            // re-dispatching the agent from a stale PR body mention.
+            const shouldHonorBodyMention =
+              (context.eventName === "issues" && ["opened", "edited"].includes(context.payload.action)) ||
+              (context.eventName === "pull_request" && ["opened", "edited"].includes(context.payload.action)) ||
+              context.eventName === "issue_comment" ||
+              context.eventName === "pull_request_review_comment";
             const isAgentAssignment =
               (context.eventName === "issues" || context.eventName === "pull_request") &&
               context.payload.action === "assigned" &&
               context.payload.assignee?.login === agentName;
+            const hasQualifiedBodyMention =
+              isAllowed && shouldHonorBodyMention && mentionMatch !== null;
             const qualifiedMention =
-              (isAllowed && mentionMatch !== null) || (isAllowed && isAgentAssignment);
-            const prompt = mentionMatch !== null
+              hasQualifiedBodyMention || (isAllowed && isAgentAssignment);
+            const prompt = hasQualifiedBodyMention
               ? mentionMatch[1].trim()
               : (isAgentAssignment
                 ? "You were assigned to this item. Read the full GitHub context, identify the next concrete action, and carry it through."
@@ -164,6 +173,7 @@ jobs:
 
             console.log(
               `User: ${userLogin}, Allowed: ${isAllowed}, Has mention: ${mentionMatch !== null}, ` +
+              `Honor body mention: ${shouldHonorBodyMention}, ` +
               `Agent assignment: ${isAgentAssignment}`
             );
 
@@ -242,7 +252,7 @@ jobs:
       pull-requests: write
       id-token: write
     runs-on: ubuntu-latest
-    container: ${{ fromJSON(needs.check-mention.outputs.result).useOdkContainer && 'obolibrary/odkfull:latest' || null }}
+    container: ${{ fromJSON(needs.check-mention.outputs.result).useOdkContainer && 'obolibrary/odkfull:v1.6' || null }}
     steps:
       - name: Generate ai4c-agent token
         id: app-token
@@ -274,7 +284,7 @@ jobs:
           echo "${{ env.TOOLS_DIR }}/obo-scripts" >> "$GITHUB_PATH"
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@v7
 
       - name: Install Python tools
         run: |

--- a/.github/workflows/allocate-definitive-ids.yml
+++ b/.github/workflows/allocate-definitive-ids.yml
@@ -13,7 +13,7 @@ jobs:
     container: obolibrary/odkfull:v1.6
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           persist-credentials: false
           fetch-depth: 0

--- a/.github/workflows/auto-pr-ontobot.yml
+++ b/.github/workflows/auto-pr-ontobot.yml
@@ -13,7 +13,7 @@ jobs:
     steps:
       - name: Check if issue body contains 'Hey ontobot'
         id: check-body
-        uses: actions/github-script@v6
+        uses: actions/github-script@v8
         with:
           script: |
             const issue = await github.rest.issues.get({
@@ -45,7 +45,7 @@ jobs:
 
       - name: Return issue number
         id: gh-script-issue
-        uses: actions/github-script@v6
+        uses: actions/github-script@v8
         with:
           github-token: ${{ secrets.ONTOBOT_TOKEN }}
           script: |
@@ -55,7 +55,7 @@ jobs:
       
       - name: Return repository name
         id: gh-script-repo
-        uses: actions/github-script@v6
+        uses: actions/github-script@v8
         with:
           github-token: ${{ secrets.ONTOBOT_TOKEN }}
           script: |

--- a/.github/workflows/check-modified-inferences.yml
+++ b/.github/workflows/check-modified-inferences.yml
@@ -24,13 +24,13 @@ jobs:
       is_large_scale: ${{ steps.analysis.outputs.is_large_scale }}
     steps:
       - name: Checkout the head of the PR branch
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: ${{ github.head_ref }}
           path: head
 
       - name: Checkout the base of the PR branch
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: ${{ github.base_ref }}
           path: base

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -1,0 +1,124 @@
+name: Claude Code Review
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: "PR number to review"
+        required: true
+        type: number
+
+concurrency:
+  group: claude-review-${{ github.event.pull_request.number || github.event.inputs.pr_number }}
+  cancel-in-progress: true
+
+jobs:
+  claude-review:
+    if: github.event_name == 'workflow_dispatch' || github.event.pull_request.draft == false
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+      issues: read
+      id-token: write
+
+    env:
+      PR_NUMBER: ${{ github.event.pull_request.number || github.event.inputs.pr_number }}
+      TOOLS_DIR: ${{ github.workspace }}/tools
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 1
+
+      - name: Generate ai4c-agent token
+        id: ai4c-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.AI4C_AGENT_APP_ID }}
+          private-key: ${{ secrets.AI4C_AGENT_PRIVATE_KEY }}
+
+      - name: Checkout PR branch (for workflow_dispatch)
+        if: github.event_name == 'workflow_dispatch'
+        env:
+          GH_TOKEN: ${{ steps.ai4c-token.outputs.token }}
+        run: gh pr checkout "${{ env.PR_NUMBER }}"
+
+      - name: Create tools directory
+        run: mkdir -p "${{ env.TOOLS_DIR }}"
+
+      - name: Add tools to PATH
+        run: echo "${{ env.TOOLS_DIR }}" >> "$GITHUB_PATH"
+
+      - name: Add obo-scripts to PATH
+        run: |
+          git clone --depth 1 https://github.com/cmungall/obo-scripts.git "${{ env.TOOLS_DIR }}/obo-scripts"
+          echo "${{ env.TOOLS_DIR }}/obo-scripts" >> "$GITHUB_PATH"
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
+
+      - name: Install Python tools
+        run: |
+          uv venv
+          . .venv/bin/activate
+          uv pip install aurelian "wrapt>=1.17.2"
+          echo "${{ github.workspace }}/.venv/bin" >> "$GITHUB_PATH"
+
+      - name: Run Claude Code Review
+        uses: anthropics/claude-code-action@v1
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          github_token: ${{ steps.ai4c-token.outputs.token }}
+          track_progress: ${{ github.event_name == 'pull_request' }}
+          allowed_bots: "claude,github-actions"
+          claude_args: |
+            --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr review:*),Bash(gh api:*),Bash(obo-grep.pl:*),Bash(aurelian:*),Bash(cat:*),Bash(sed:*),Bash(head:*),Bash(tail:*),Bash(wc:*),Bash(find:*),Bash(ls:*),Bash(rg:*)"
+
+          prompt: |
+            REPO: ${{ github.repository }}
+            PR NUMBER: ${{ env.PR_NUMBER }}
+
+            Review this pull request for the Uberon ontology repository.
+
+            Follow the repository instructions in `CLAUDE.md`.
+
+            When you need to inspect ontology content in `src/ontology/uberon-edit.obo`, use only:
+            - `obo-grep.pl -r 'id: UBERON:NNNNNNN' src/ontology/uberon-edit.obo`
+            - `obo-grep.pl -r 'UBERON:NNNNNNN' src/ontology/uberon-edit.obo`
+
+            Focus on:
+            - Hierarchy and proposed parents being anatomically and logically consistent
+            - Definitions, xrefs, and PMIDs being real and adequately supportive
+            - Obsolete-term handling and replacement or consider tags being safe
+            - OBO and ODK conventions being preserved
+            - Workflow, auth, and repo-configuration regressions when the PR touches `.github` or `.claude`
+
+            Be constructive and specific. For each issue found, indicate severity:
+            - 🔴 CRITICAL: Must fix before merge
+            - 🟡 IMPORTANT: Should fix before merge
+            - 🔵 SUGGESTION: Optional improvement
+
+            Prefer inline comments for concrete file-level issues. Use the overall review summary to explain the main risks and the merge recommendation.
+
+            After reviewing, set the GitHub PR review status:
+
+            If there are any 🔴 CRITICAL or 🟡 IMPORTANT issues, submit a REQUEST_CHANGES review:
+            ```
+            gh pr review ${{ env.PR_NUMBER }} --request-changes --body "<your review summary>"
+            ```
+
+            If there are only 🔵 SUGGESTIONs or no issues, submit an APPROVE review:
+            ```
+            gh pr review ${{ env.PR_NUMBER }} --approve --body "<your review summary>"
+            ```
+
+            Always include a checklist at the top of your review:
+            - [ ] Hierarchy and parents are consistent
+            - [ ] Definitions and supporting references look adequate
+            - [ ] Obsolete or replacement handling is safe
+            - [ ] OBO and ODK conventions appear preserved
+            - [ ] No obvious CI, auth, or workflow regression

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -36,7 +36,7 @@ jobs:
 
       - name: Generate ai4c-agent token
         id: ai4c-token
-        uses: actions/create-github-app-token@v1
+        uses: actions/create-github-app-token@v3
         with:
           app-id: ${{ secrets.AI4C_AGENT_APP_ID }}
           private-key: ${{ secrets.AI4C_AGENT_PRIVATE_KEY }}

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -26,7 +26,7 @@ jobs:
     # If you do not check out your code, Copilot will do this for you.
     steps:
     - name: Checkout code
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
 
     - name: Create tools directory
       run: mkdir -p ${{ github.workspace }}/tools

--- a/.github/workflows/diff.yml
+++ b/.github/workflows/diff.yml
@@ -25,12 +25,12 @@ jobs:
       # Checks-out current branch
       - uses: xt0rted/pull-request-comment-branch@v2
         id: comment-branch
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         if: steps.check.outputs.triggered == 'true'
         with:
           ref: ${{ steps.comment-branch.outputs.head_ref }}
       # Checks-out master branch under "master" directory
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         if: steps.check.outputs.triggered == 'true'
         with:
           ref: ${{ steps.comment-branch.outputs.head_ref }}
@@ -71,12 +71,12 @@ jobs:
           GITHUB_TOKEN: '${{ secrets.GITHUB_TOKEN }}'
       - uses: xt0rted/pull-request-comment-branch@v2
         id: comment-branch
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         if: steps.check.outputs.triggered == 'true'
         with:
           ref: ${{ steps.comment-branch.outputs.head_ref }}
           path: branch
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         if: steps.check.outputs.triggered == 'true'
         with:
           ref: master
@@ -104,7 +104,7 @@ jobs:
           GITHUB_TOKEN: '${{ secrets.GITHUB_TOKEN }}'
       - uses: xt0rted/pull-request-comment-branch@v2
         id: comment-branch
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         if: steps.check.outputs.triggered == 'true'
         with:
           ref: ${{ steps.comment-branch.outputs.head_ref }}
@@ -130,7 +130,7 @@ jobs:
           trigger: '#gogoeditdiff'
         env:
           GITHUB_TOKEN: '${{ secrets.GITHUB_TOKEN }}'
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         if: steps.check.outputs.triggered == 'true'
         with:
           ref: master
@@ -155,7 +155,7 @@ jobs:
           trigger: '#gogoeditdiff'
         env:  
           GITHUB_TOKEN: '${{ secrets.GITHUB_TOKEN }}'
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         if: steps.check.outputs.triggered == 'true'
       - name: Download classified ontology main branch
         if: steps.check.outputs.triggered == 'true'
@@ -188,7 +188,7 @@ jobs:
           trigger: '#gogoeditdiff'
         env:
           GITHUB_TOKEN: '${{ secrets.GITHUB_TOKEN }}'
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         if: steps.check.outputs.triggered == 'true'
       - name: Download reasoned diff
         if: steps.check.outputs.triggered == 'true'
@@ -205,7 +205,7 @@ jobs:
           file: "../../comment.md"
           identifier: "REASONED"
           github_token: ${{secrets.GITHUB_TOKEN}}
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         if: steps.check.outputs.triggered == 'true'
       - name: Download edit diff
         if: steps.check.outputs.triggered == 'true'
@@ -222,6 +222,5 @@ jobs:
           file: "../../edit-comment.md"
           identifier: "UNREASONED"
           github_token: ${{secrets.GITHUB_TOKEN}}
-
 
 

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout main
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Deploy docs
         uses: mhausenblas/mkdocs-deploy-gh-pages@master
@@ -24,4 +24,3 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           CONFIG_FILE: mkdocs.yaml
-

--- a/.github/workflows/post-release-diff.yml
+++ b/.github/workflows/post-release-diff.yml
@@ -15,7 +15,7 @@ jobs:
   post_diff:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Prepare release diff comment
         env:
             GITHUB_SHA: ${{ github.sha }}

--- a/.github/workflows/qc.yml
+++ b/.github/workflows/qc.yml
@@ -27,7 +27,7 @@ jobs:
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Run ontology QC checks
         id: check


### PR DESCRIPTION
## Summary
- replace the legacy `ai-agent` workflow with a GitHub App + Claude Code OAuth based setup
- add a `claude-code-review` workflow for PR review automation
- allow `dragon-ai-agent` to be summoned by assignment, following the dismech pattern
- add a Stop hook in `.claude/settings.json` so automated runs are checked for actual GitHub-side deliverables before stopping

## Notes
- this keeps the existing `.github/ai-controllers.json` allowlist unchanged
- workflow and JSON syntax were validated locally
- the new automation still needs the `ai4c-agent` app installed on this repo and the matching secrets configured

## Required repo setup
- `AI4C_AGENT_APP_ID`
- `AI4C_AGENT_PRIVATE_KEY`
- `CLAUDE_CODE_OAUTH_TOKEN`

@dragon-ai-agent