### PR TITLE
Allow ai4c-agent authored PRs in Claude review workflow

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -74,7 +74,8 @@ jobs:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           github_token: ${{ steps.ai4c-token.outputs.token }}
           track_progress: ${{ github.event_name == 'pull_request' }}
-          allowed_bots: "claude,github-actions"
+          # PRs opened by the ai4c GitHub App should still be reviewable.
+          allowed_bots: "claude,github-actions,ai4c-agent"
           claude_args: |
             --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr review:*),Bash(gh api:*),Bash(obo-grep.pl:*),Bash(aurelian:*),Bash(cat:*),Bash(sed:*),Bash(head:*),Bash(tail:*),Bash(wc:*),Bash(find:*),Bash(ls:*),Bash(rg:*)"
 


### PR DESCRIPTION
## Summary
- add `ai4c-agent` to the Claude Code review workflow bot allowlist
- keep the existing human / bot gate intact for other actors

## Why
PRs opened by the ai4c GitHub App currently fail `claude-code-review.yml` with:

> Workflow initiated by non-human actor: ai4c-agent (type: Bot). Add bot to allowed_bots list or use '*' to allow all bots.

Example failing run:
- https://github.com/obophenotype/uberon/actions/runs/24921395720/job/72983444355?pr=3695

Uberon now uses the ai4c GitHub App token path to open some agent-authored PRs, so those PRs should still be reviewable by the Claude review workflow.

## Change
This is the minimal fix: extend `allowed_bots` from:
- `claude,github-actions`

to:
- `claude,github-actions,ai4c-agent`

@dragon-ai-agent
