### PR TITLE
Add blank line to README.md (closes #3702)

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,3 +34,5 @@ To trigger an automated human readable diff, add the following tag to a comment 
 See the file [README-editors.txt](bridge/../README-editors.txt)
 
 See the [Standard Operating Procedure for Uberon Curators](bridge/../docs/uberon-editor-sop.md).
+
+


### PR DESCRIPTION
## Summary

Resolves #3702 — adds a blank line to `README.md` as requested.

## Changes

- Appended a blank line to the end of `README.md`.

## Test plan

- [x] Diff inspected; only whitespace appended at EOF.

---
🤖 **Generated by @dragon-ai-agent**
- Model: `claude-opus-4-7`
- Agent harness: claude-code
- Triggered by: @cmungall
- Run: [View workflow run](https://github.com/obophenotype/uberon/actions/runs/25069230831)