### PR TITLE
Fixes #3521 Removes incorrect partonomy for 'ovarian cortex'

### DIFF
--- a/src/ontology/uberon-edit.obo
+++ b/src/ontology/uberon-edit.obo
@@ -154347,7 +154347,7 @@ relationship: part_of UBERON:0001756 ! middle ear
 [Term]
 id: UBERON:0013191
 name: ovarian cortex
-def: "The layer of the ovarian stroma lying immediately beneath the tunica albuginea, composed of connective tissue cells and fibers, among which are scattered primary and secondary (antral) follicles in various stages of development; the cortex varies in thickness according to the age of the individual, becoming thinner with advancing years; included in the follicles are the cumulus oophorus, membrana granulosa (and the granulosa cells inside it), corona radiata, zona pellucida, and primary oocyte; the zona pellucida, theca of follicle, antrum and liquor folliculi are also contained in the follicle; also in the cortex is the corpus luteum derived from the follicles." [MGI:anna]
+def: "The layer of the ovary lying immediately beneath the tunica albuginea, composed of connective tissue cells and fibers, among which are scattered primary and secondary (antral) follicles in various stages of development; the cortex varies in thickness according to the age of the individual, becoming thinner with advancing years; included in the follicles are the cumulus oophorus, membrana granulosa (and the granulosa cells inside it), corona radiata, zona pellucida, and primary oocyte; the zona pellucida, theca of follicle, antrum and liquor folliculi are also contained in the follicle; also in the cortex is the corpus luteum derived from the follicles." [MGI:anna, PMID:17999378, PMID:22666170, PMID:32716007, PMID:36191605, PMID:36721914, PMID:41256733]
 subset: pheno_slim
 synonym: "cortex of ovary" EXACT [FMA:18613]
 synonym: "cortex ovarii (zona parenchymatosa)" EXACT [FMA:18613]
@@ -154357,7 +154357,6 @@ xref: NCIT:C33243
 xref: UMLS:C0227878 {source="ncithesaurus:Ovarian_Cortex"}
 intersection_of: UBERON:0001851 ! cortex
 intersection_of: part_of UBERON:0000992 ! ovary
-relationship: part_of UBERON:0006960 ! ovary stroma
 
 [Term]
 id: UBERON:0013192


### PR DESCRIPTION
Fixes #3521 Removes incorrect partonomy for 'ovarian cortex'