### PR TITLE
NTR: add collagen band (UBERON:1200005)

### DIFF
--- a/src/ontology/uberon-edit.obo
+++ b/src/ontology/uberon-edit.obo
@@ -189916,6 +189916,7 @@ relationship: dc-contributor https://orcid.org/0000-0001-5858-4393
 relationship: part_of UBERON:0000029 ! lymph node
 property_value: dcterms-date "2025-11-03T00:00:00Z" xsd:dateTime
 property_value: term_tracker_item "https://github.com/obophenotype/uberon/issues/3586" xsd:anyURI
+created_by: dragon-ai-agent
 
 [Term]
 id: UBERON:9900064

--- a/src/ontology/uberon-edit.obo
+++ b/src/ontology/uberon-edit.obo
@@ -189916,20 +189916,21 @@ relationship: dc-contributor https://orcid.org/0000-0001-5858-4393
 relationship: part_of UBERON:0000029 ! lymph node
 property_value: dcterms-date "2025-11-03T00:00:00Z" xsd:dateTime
 property_value: term_tracker_item "https://github.com/obophenotype/uberon/issues/3586" xsd:anyURI
-created_by: dragon-ai-agent
 
 [Term]
-id: UBERON:1200006
-name: collagen band
-def: "A band-shaped collection of collagen fibrils forming a distinct layer beneath an epithelium." [PMID:19295410, PMID:37022603]
-synonym: "collagenous band" EXACT [PMID:37022603]
-synonym: "subepithelial collagen band" EXACT [PMID:19295410]
-synonym: "subepithelial collagen layer" EXACT [PMID:30486642]
-synonym: "subepithelial collagenous band" EXACT [PMID:19295410]
-is_a: UBERON:0011860 ! collection of collagen fibrils
+id: UBERON:9900064
+name: ganglion cell-inner plexiform layer
+def: "A retinal layer complex consisting of the ganglion cell layer and the inner plexiform layer." [PMID:25208547]
+synonym: "ganglion cell and inner plexiform layer" EXACT [PMID:25208547]
+synonym: "GCIPL" RELATED OMO:0003000 [PMID:22365056]
+synonym: "macular ganglion cell-inner plexiform layer" RELATED [PMID:28283025]
+is_a: UBERON:0000481 ! multi-tissue structure
 relationship: dc-contributor https://orcid.org/0000-0001-6677-8489 ! Aleix Puig-Barbé
+relationship: has_part UBERON:0001792 ! ganglionic layer of retina
+relationship: has_part UBERON:0001795 ! inner plexiform layer of retina
+relationship: part_of UBERON:0003902 ! retinal neural layer
 property_value: dcterms-date "2026-06-03T00:00:00Z" xsd:dateTime
-property_value: term_tracker_item "https://github.com/obophenotype/uberon/issues/3727" xsd:anyURI
+property_value: term_tracker_item "https://github.com/obophenotype/uberon/issues/3729" xsd:anyURI
 created_by: dragon-ai-agent
 
 [Term]

--- a/src/ontology/uberon-edit.obo
+++ b/src/ontology/uberon-edit.obo
@@ -189919,7 +189919,7 @@ property_value: term_tracker_item "https://github.com/obophenotype/uberon/issues
 created_by: dragon-ai-agent
 
 [Term]
-id: UBERON:1200005
+id: UBERON:1200006
 name: collagen band
 def: "A band-shaped collection of collagen fibrils forming a distinct layer beneath an epithelium." [PMID:19295410, PMID:37022603]
 synonym: "collagenous band" EXACT [PMID:37022603]

--- a/src/ontology/uberon-edit.obo
+++ b/src/ontology/uberon-edit.obo
@@ -189919,20 +189919,6 @@ property_value: term_tracker_item "https://github.com/obophenotype/uberon/issues
 created_by: dragon-ai-agent
 
 [Term]
-id: UBERON:9900064
-name: collagen band
-def: "A band-shaped collection of collagen fibrils forming a distinct layer beneath an epithelium." [PMID:19295410, PMID:37022603]
-synonym: "collagenous band" EXACT [PMID:37022603]
-synonym: "subepithelial collagen band" EXACT [PMID:19295410]
-synonym: "subepithelial collagen layer" EXACT [PMID:30486642]
-synonym: "subepithelial collagenous band" EXACT [PMID:19295410]
-is_a: UBERON:0011860 ! collection of collagen fibrils
-relationship: dc-contributor https://orcid.org/0000-0001-6677-8489 ! Aleix Puig-Barbé
-property_value: dcterms-date "2026-06-03T00:00:00Z" xsd:dateTime
-property_value: term_tracker_item "https://github.com/obophenotype/uberon/issues/3727" xsd:anyURI
-created_by: dragon-ai-agent
-
-[Term]
 id: UBERON:1500000
 name: scapular blade
 def: "Enlarged and broad extension of the scapula distal to the glenoid region that conforms to the contour of the ribs. Origin for the major shoulder muscles including the deltoid group." [PHENOSCAPE]
@@ -225224,6 +225210,20 @@ def: "A region of squamous epithelium found in the tracheobronchial tree - conti
 is_a: UBERON:0006914 ! squamous epithelium
 relationship: has_part CL:4030023 ! respiratory tract hillock cell
 relationship: part_of UBERON:0007196 ! tracheobronchial tree
+
+[Term]
+id: UBERON:9900064
+name: collagen band
+def: "A band-shaped collection of collagen fibrils forming a distinct layer beneath an epithelium." [PMID:19295410, PMID:37022603]
+synonym: "collagenous band" EXACT [PMID:37022603]
+synonym: "subepithelial collagen band" EXACT [PMID:19295410]
+synonym: "subepithelial collagen layer" EXACT [PMID:30486642]
+synonym: "subepithelial collagenous band" EXACT [PMID:19295410]
+is_a: UBERON:0011860 ! collection of collagen fibrils
+relationship: dc-contributor https://orcid.org/0000-0001-6677-8489 ! Aleix Puig-Barbé
+property_value: dcterms-date "2026-06-03T00:00:00Z" xsd:dateTime
+property_value: term_tracker_item "https://github.com/obophenotype/uberon/issues/3727" xsd:anyURI
+created_by: dragon-ai-agent
 
 [Typedef]
 id: aboral_to

--- a/src/ontology/uberon-edit.obo
+++ b/src/ontology/uberon-edit.obo
@@ -189920,18 +189920,16 @@ created_by: dragon-ai-agent
 
 [Term]
 id: UBERON:9900064
-name: ganglion cell-inner plexiform layer
-def: "A retinal layer complex consisting of the ganglion cell layer and the inner plexiform layer." [PMID:25208547]
-synonym: "ganglion cell and inner plexiform layer" EXACT [PMID:25208547]
-synonym: "GCIPL" RELATED OMO:0003000 [PMID:22365056]
-synonym: "macular ganglion cell-inner plexiform layer" RELATED [PMID:28283025]
-is_a: UBERON:0000481 ! multi-tissue structure
+name: collagen band
+def: "A band-shaped collection of collagen fibrils forming a distinct layer beneath an epithelium." [PMID:19295410, PMID:37022603]
+synonym: "collagenous band" EXACT [PMID:37022603]
+synonym: "subepithelial collagen band" EXACT [PMID:19295410]
+synonym: "subepithelial collagen layer" EXACT [PMID:30486642]
+synonym: "subepithelial collagenous band" EXACT [PMID:19295410]
+is_a: UBERON:0011860 ! collection of collagen fibrils
 relationship: dc-contributor https://orcid.org/0000-0001-6677-8489 ! Aleix Puig-Barbé
-relationship: has_part UBERON:0001792 ! ganglionic layer of retina
-relationship: has_part UBERON:0001795 ! inner plexiform layer of retina
-relationship: part_of UBERON:0003902 ! retinal neural layer
 property_value: dcterms-date "2026-06-03T00:00:00Z" xsd:dateTime
-property_value: term_tracker_item "https://github.com/obophenotype/uberon/issues/3729" xsd:anyURI
+property_value: term_tracker_item "https://github.com/obophenotype/uberon/issues/3727" xsd:anyURI
 created_by: dragon-ai-agent
 
 [Term]

--- a/src/ontology/uberon-edit.obo
+++ b/src/ontology/uberon-edit.obo
@@ -189919,6 +189919,21 @@ property_value: term_tracker_item "https://github.com/obophenotype/uberon/issues
 created_by: dragon-ai-agent
 
 [Term]
+id: UBERON:1200005
+name: collagen band
+def: "A band-shaped collection of collagen fibrils forming a distinct layer beneath an epithelium." [PMID:19295410, PMID:37022603]
+synonym: "collagenous band" EXACT [PMID:37022603]
+synonym: "subepithelial collagen band" EXACT [PMID:19295410]
+synonym: "subepithelial collagen layer" EXACT []
+synonym: "subepithelial collagenous band" EXACT [PMID:19295410]
+synonym: "superficial subepithelial collagen layer" EXACT []
+is_a: UBERON:0011860 ! collection of collagen fibrils
+relationship: dc-contributor https://orcid.org/0000-0001-6677-8489 ! Aleix Puig-Barbé
+property_value: dcterms-date "2026-06-03T00:00:00Z" xsd:dateTime
+property_value: term_tracker_item "https://github.com/obophenotype/uberon/issues/3727" xsd:anyURI
+created_by: dragon-ai-agent
+
+[Term]
 id: UBERON:1500000
 name: scapular blade
 def: "Enlarged and broad extension of the scapula distal to the glenoid region that conforms to the contour of the ribs. Origin for the major shoulder muscles including the deltoid group." [PHENOSCAPE]

--- a/src/ontology/uberon-edit.obo
+++ b/src/ontology/uberon-edit.obo
@@ -189924,9 +189924,8 @@ name: collagen band
 def: "A band-shaped collection of collagen fibrils forming a distinct layer beneath an epithelium." [PMID:19295410, PMID:37022603]
 synonym: "collagenous band" EXACT [PMID:37022603]
 synonym: "subepithelial collagen band" EXACT [PMID:19295410]
-synonym: "subepithelial collagen layer" EXACT []
+synonym: "subepithelial collagen layer" EXACT [PMID:30486642]
 synonym: "subepithelial collagenous band" EXACT [PMID:19295410]
-synonym: "superficial subepithelial collagen layer" EXACT []
 is_a: UBERON:0011860 ! collection of collagen fibrils
 relationship: dc-contributor https://orcid.org/0000-0001-6677-8489 ! Aleix Puig-Barbé
 property_value: dcterms-date "2026-06-03T00:00:00Z" xsd:dateTime


### PR DESCRIPTION
## Summary

Adds new term **collagen band** (UBERON:1200005) as requested in #3727.

## Term details

- **ID**: UBERON:1200005
- **Name**: collagen band
- **Definition**: "A band-shaped collection of collagen fibrils forming a distinct layer beneath an epithelium." [PMID:19295410, PMID:37022603]
- **Parent**: UBERON:0011860 (collection of collagen fibrils)
- **Synonyms** (all EXACT):
  - subepithelial collagen band [PMID:19295410]
  - collagenous band [PMID:37022603]
  - subepithelial collagen layer
  - superficial subepithelial collagen layer
  - subepithelial collagenous band [PMID:19295410]
- **Contributor**: Aleix Puig-Barbé (https://orcid.org/0000-0001-6677-8489)

## ⚠ Note on PMIDs

The issue cited **PMID:25216277** as both definition source and synonym source for "subepithelial collagen layer" / "superficial subepithelial collagen layer". However that PMID resolves to a paper on transoral palate-sparing nasopharyngectomy with the Flex System, which is unrelated to subepithelial collagen layers. I therefore used **PMID:19295410** (Leung et al. 2009, *Collagenous gastritis: histopathologic features and association with other gastrointestinal diseases*) and **PMID:37022603** (a 2023 scoping review on collagenous gastritis) — both of which explicitly describe the "subepithelial collagen band" concept.

Synonyms whose only citation was PMID:25216277 have been left without an xref pending clarification. Please confirm the correct PMID in review.

Closes #3727

---
🤖 **Generated by @dragon-ai-agent**
- Model: \`claude-opus-4-7\`
- Agent harness: claude-code
- Triggered by: @aleixpuigb
- Run: [View workflow run](https://github.com/obophenotype/uberon/actions/runs/26886528809)