### PR TITLE
Add term: ganglion cell-inner plexiform layer (UBERON:1200005)

### DIFF
--- a/src/ontology/uberon-edit.obo
+++ b/src/ontology/uberon-edit.obo
@@ -189916,9 +189916,6 @@ relationship: dc-contributor https://orcid.org/0000-0001-5858-4393
 relationship: part_of UBERON:0000029 ! lymph node
 property_value: dcterms-date "2025-11-03T00:00:00Z" xsd:dateTime
 property_value: term_tracker_item "https://github.com/obophenotype/uberon/issues/3586" xsd:anyURI
-created_by: dragon-ai-agent
-format-version: 1.2
-ontology: uberon/ganglion-cell-inner-plexiform-layer
 
 [Term]
 id: UBERON:1200005

--- a/src/ontology/uberon-edit.obo
+++ b/src/ontology/uberon-edit.obo
@@ -189916,21 +189916,6 @@ relationship: dc-contributor https://orcid.org/0000-0001-5858-4393
 relationship: part_of UBERON:0000029 ! lymph node
 property_value: dcterms-date "2025-11-03T00:00:00Z" xsd:dateTime
 property_value: term_tracker_item "https://github.com/obophenotype/uberon/issues/3586" xsd:anyURI
-
-[Term]
-id: UBERON:9900073
-name: ganglion cell-inner plexiform layer
-def: "A retinal layer complex consisting of the ganglion cell layer and the inner plexiform layer." [PMID:25208547]
-synonym: "ganglion cell and inner plexiform layer" EXACT [PMID:25208547]
-synonym: "GCIPL" RELATED OMO:0003000 [PMID:22365056]
-synonym: "macular ganglion cell-inner plexiform layer" RELATED [PMID:28283025]
-is_a: UBERON:0000481 ! multi-tissue structure
-relationship: dc-contributor https://orcid.org/0000-0001-6677-8489 ! Aleix Puig-Barbé
-relationship: has_part UBERON:0001792 ! ganglionic layer of retina
-relationship: has_part UBERON:0001795 ! inner plexiform layer of retina
-relationship: part_of UBERON:0003902 ! retinal neural layer
-property_value: dcterms-date "2026-06-03T00:00:00Z" xsd:dateTime
-property_value: term_tracker_item "https://github.com/obophenotype/uberon/issues/3729" xsd:anyURI
 created_by: dragon-ai-agent
 
 [Term]
@@ -225225,6 +225210,22 @@ def: "A region of squamous epithelium found in the tracheobronchial tree - conti
 is_a: UBERON:0006914 ! squamous epithelium
 relationship: has_part CL:4030023 ! respiratory tract hillock cell
 relationship: part_of UBERON:0007196 ! tracheobronchial tree
+
+[Term]
+id: UBERON:9900073
+name: ganglion cell-inner plexiform layer
+def: "A retinal layer complex consisting of the ganglion cell layer and the inner plexiform layer." [PMID:25208547]
+synonym: "ganglion cell and inner plexiform layer" EXACT [PMID:25208547]
+synonym: "GCIPL" RELATED OMO:0003000 [PMID:22365056]
+synonym: "macular ganglion cell-inner plexiform layer" RELATED [PMID:28283025]
+is_a: UBERON:0000481 ! multi-tissue structure
+relationship: dc-contributor https://orcid.org/0000-0001-6677-8489 ! Aleix Puig-Barbé
+relationship: has_part UBERON:0001792 ! ganglionic layer of retina
+relationship: has_part UBERON:0001795 ! inner plexiform layer of retina
+relationship: part_of UBERON:0003902 ! retinal neural layer
+property_value: dcterms-date "2026-06-03T00:00:00Z" xsd:dateTime
+property_value: term_tracker_item "https://github.com/obophenotype/uberon/issues/3729" xsd:anyURI
+created_by: dragon-ai-agent
 
 [Typedef]
 id: aboral_to

--- a/src/ontology/uberon-edit.obo
+++ b/src/ontology/uberon-edit.obo
@@ -189918,7 +189918,7 @@ property_value: dcterms-date "2025-11-03T00:00:00Z" xsd:dateTime
 property_value: term_tracker_item "https://github.com/obophenotype/uberon/issues/3586" xsd:anyURI
 
 [Term]
-id: UBERON:1200005
+id: UBERON:9900073
 name: ganglion cell-inner plexiform layer
 def: "A retinal layer complex consisting of the ganglion cell layer and the inner plexiform layer." [PMID:25208547]
 synonym: "ganglion cell and inner plexiform layer" EXACT [PMID:25208547]

--- a/src/ontology/uberon-edit.obo
+++ b/src/ontology/uberon-edit.obo
@@ -189919,6 +189919,36 @@ property_value: term_tracker_item "https://github.com/obophenotype/uberon/issues
 created_by: dragon-ai-agent
 
 [Term]
+id: UBERON:1200340
+name: collagen band
+def: "A band-shaped collection of collagen fibrils forming a distinct layer beneath an epithelium." [PMID:19295410, PMID:37022603]
+synonym: "collagenous band" EXACT [PMID:37022603]
+synonym: "subepithelial collagen band" EXACT [PMID:19295410]
+synonym: "subepithelial collagen layer" EXACT [PMID:30486642]
+synonym: "subepithelial collagenous band" EXACT [PMID:19295410]
+is_a: UBERON:0011860 ! collection of collagen fibrils
+relationship: dc-contributor https://orcid.org/0000-0001-6677-8489 ! Aleix Puig-Barbé
+property_value: dcterms-date "2026-06-03T00:00:00Z" xsd:dateTime
+property_value: term_tracker_item "https://github.com/obophenotype/uberon/issues/3727" xsd:anyURI
+created_by: dragon-ai-agent
+
+[Term]
+id: UBERON:1200341
+name: ganglion cell-inner plexiform layer
+def: "A retinal layer complex consisting of the ganglion cell layer and the inner plexiform layer." [PMID:21917932, PMID:25208547]
+synonym: "ganglion cell and inner plexiform layer" EXACT [PMID:25208547]
+synonym: "GCIPL" RELATED OMO:0003000 [PMID:22365056]
+synonym: "macular ganglion cell-inner plexiform layer" RELATED [PMID:28283025]
+is_a: UBERON:0000481 ! multi-tissue structure
+relationship: dc-contributor https://orcid.org/0000-0001-6677-8489 ! Aleix Puig-Barbé
+relationship: has_part UBERON:0001792 ! ganglionic layer of retina
+relationship: has_part UBERON:0001795 ! inner plexiform layer of retina
+relationship: part_of UBERON:0003902 ! retinal neural layer
+property_value: dcterms-date "2026-06-03T00:00:00Z" xsd:dateTime
+property_value: term_tracker_item "https://github.com/obophenotype/uberon/issues/3729" xsd:anyURI
+created_by: dragon-ai-agent
+
+[Term]
 id: UBERON:1500000
 name: scapular blade
 def: "Enlarged and broad extension of the scapula distal to the glenoid region that conforms to the contour of the ribs. Origin for the major shoulder muscles including the deltoid group." [PHENOSCAPE]
@@ -225210,22 +225240,6 @@ def: "A region of squamous epithelium found in the tracheobronchial tree - conti
 is_a: UBERON:0006914 ! squamous epithelium
 relationship: has_part CL:4030023 ! respiratory tract hillock cell
 relationship: part_of UBERON:0007196 ! tracheobronchial tree
-
-[Term]
-id: UBERON:9900073
-name: ganglion cell-inner plexiform layer
-def: "A retinal layer complex consisting of the ganglion cell layer and the inner plexiform layer." [PMID:25208547]
-synonym: "ganglion cell and inner plexiform layer" EXACT [PMID:25208547]
-synonym: "GCIPL" RELATED OMO:0003000 [PMID:22365056]
-synonym: "macular ganglion cell-inner plexiform layer" RELATED [PMID:28283025]
-is_a: UBERON:0000481 ! multi-tissue structure
-relationship: dc-contributor https://orcid.org/0000-0001-6677-8489 ! Aleix Puig-Barbé
-relationship: has_part UBERON:0001792 ! ganglionic layer of retina
-relationship: has_part UBERON:0001795 ! inner plexiform layer of retina
-relationship: part_of UBERON:0003902 ! retinal neural layer
-property_value: dcterms-date "2026-06-03T00:00:00Z" xsd:dateTime
-property_value: term_tracker_item "https://github.com/obophenotype/uberon/issues/3729" xsd:anyURI
-created_by: dragon-ai-agent
 
 [Typedef]
 id: aboral_to

--- a/src/ontology/uberon-edit.obo
+++ b/src/ontology/uberon-edit.obo
@@ -189917,6 +189917,24 @@ relationship: part_of UBERON:0000029 ! lymph node
 property_value: dcterms-date "2025-11-03T00:00:00Z" xsd:dateTime
 property_value: term_tracker_item "https://github.com/obophenotype/uberon/issues/3586" xsd:anyURI
 created_by: dragon-ai-agent
+format-version: 1.2
+ontology: uberon/ganglion-cell-inner-plexiform-layer
+
+[Term]
+id: UBERON:1200005
+name: ganglion cell-inner plexiform layer
+def: "A retinal layer complex consisting of the ganglion cell layer and the inner plexiform layer." [PMID:25208547]
+synonym: "ganglion cell and inner plexiform layer" EXACT [PMID:25208547]
+synonym: "GCIPL" RELATED OMO:0003000 [PMID:22365056]
+synonym: "macular ganglion cell-inner plexiform layer" RELATED [PMID:28283025]
+is_a: UBERON:0000481 ! multi-tissue structure
+relationship: dc-contributor https://orcid.org/0000-0001-6677-8489 ! Aleix Puig-Barbé
+relationship: has_part UBERON:0001792 ! ganglionic layer of retina
+relationship: has_part UBERON:0001795 ! inner plexiform layer of retina
+relationship: part_of UBERON:0003902 ! retinal neural layer
+property_value: dcterms-date "2026-06-03T00:00:00Z" xsd:dateTime
+property_value: term_tracker_item "https://github.com/obophenotype/uberon/issues/3729" xsd:anyURI
+created_by: dragon-ai-agent
 
 [Term]
 id: UBERON:1500000


### PR DESCRIPTION
## Summary

This PR adds a new term for **ganglion cell-inner plexiform layer** (UBERON:1200005) as requested in #3729.

### Term Details

- **ID**: UBERON:1200005
- **Name**: ganglion cell-inner plexiform layer
- **Definition**: A retinal layer complex consisting of the ganglion cell layer and the inner plexiform layer. [PMID:25208547]
- **Synonyms**:
  - `GCIPL` RELATED (abbreviation) [PMID:22365056]
  - `ganglion cell and inner plexiform layer` EXACT [PMID:25208547]
  - `macular ganglion cell-inner plexiform layer` RELATED [PMID:28283025]

### Logical structure

Modelled following the pattern used for `carotid artery intima-media region` (UBERON:1200002, introduced in #3630):

- `is_a` multi-tissue structure (UBERON:0000481)
- `has_part` ganglionic layer of retina (UBERON:0001792) — i.e. the GCL
- `has_part` inner plexiform layer of retina (UBERON:0001795)
- `part_of` retinal neural layer (UBERON:0003902)

### Note on parent / referenced IDs

The IDs supplied in the issue did not match the current UBERON labels:

- `UBERON:0001789` is actually *outer nuclear layer of retina*, not *neural retina layer*. The closest match by label is `UBERON:0003902` (`retinal neural layer`), which has been used as the `part_of` target.
- `UBERON:0001803` is actually *epithelium of lens*, not *inner plexiform layer of retina*. The correct ID `UBERON:0001795` was used.
- `UBERON:0001792` is *ganglionic layer of retina*; `ganglion cell layer of retina` is one of its exact synonyms — so this ID is correct.

Following the model of `carotid artery intima-media region`, the term is asserted as `is_a multi-tissue structure` (not directly as a kind of single retinal layer), with `part_of` to the broader retinal neural layer.

### Metadata

- **Contributor**: Aleix Puig-Barbé (https://orcid.org/0000-0001-6677-8489)
- **Date**: 2026-06-03
- **Term tracker**: #3729
- **Created by**: dragon-ai-agent

## Test plan

- [x] Verified existence of parent and related terms in the current ontology
- [x] Used `obo-checkout.pl`/`obo-checkin.pl` and `robot convert` to reserialise `uberon-edit.obo`
- [x] Used appropriate next free UBERON ID (highest existing was UBERON:1200004)
- [x] Included required metadata (contributor ORCID, ISO date, term tracker)
- [x] Definition references PMID:25208547
- [x] Signed commit as @dragon-ai-agent

Closes #3729

---
🤖 **Generated by @dragon-ai-agent**
- Model: `claude-opus-4-7`
- Agent harness: claude-code
- Triggered by: @aleixpuigb
- Run: [View workflow run](https://github.com/obophenotype/uberon/actions/runs/26887091011)