### PR TITLE
Avoid persisting Dragon checkout credentials

### DIFF
--- a/.github/workflows/ai-agent.yml
+++ b/.github/workflows/ai-agent.yml
@@ -60,6 +60,7 @@ jobs:
         with:
           fetch-depth: 1
           token: ${{ secrets.PAT_FOR_PR }}
+          persist-credentials: false
 
       - name: Check for qualifying mention
         id: check
@@ -250,6 +251,7 @@ jobs:
         with:
           fetch-depth: 1
           token: ${{ secrets.PAT_FOR_PR }}
+          persist-credentials: false
 
       - name: Configure Git
         run: |
@@ -277,11 +279,15 @@ jobs:
           uv pip install aurelian jinja2-cli "wrapt>=1.17.2"
           echo "${{ github.workspace }}/.venv/bin" >> "$GITHUB_PATH"
 
-      - name: Export GitHub token for gh CLI
-        run: echo "GH_TOKEN=${{ secrets.PAT_FOR_PR }}" >> "$GITHUB_ENV"
+      - name: Configure GitHub authentication
+        env:
+          GH_TOKEN: ${{ secrets.PAT_FOR_PR }}
+        run: gh auth setup-git --hostname github.com --force
 
       - name: Run Claude Code
         uses: anthropics/claude-code-action@v1
+        env:
+          GH_TOKEN: ${{ secrets.PAT_FOR_PR }}
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           github_token: ${{ secrets.PAT_FOR_PR }}


### PR DESCRIPTION
## Summary

- opt both AI-agent checkout steps out of persisted credentials
- configure Git to authenticate through the `gh` credential helper
- scope `GH_TOKEN` to the Claude step instead of writing it to `GITHUB_ENV`

## Why

The checkout credential was previously available through Git configuration and could be captured when an agent inspected `.git/config`. This avoids that accidental exposure path while preserving intelligent `gh` usage and authenticated `git push`.

## Security boundary

The agent still receives `PAT_FOR_PR` as `GH_TOKEN` and as the Claude action `github_token` input, so it retains the requested GitHub capabilities. This change prevents persistence-based accidental disclosure; it does not sandbox an agent with arbitrary shell access.

## Validation

- `yq eval '.' .github/workflows/ai-agent.yml`
- `yamllint -d relaxed .github/workflows/ai-agent.yml` (existing line-length warnings only)
- `actionlint .github/workflows/ai-agent.yml`
- `git diff --check`