### PR TITLE
Review as ai4c-reviewer, not ai4c-agent

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -1,3 +1,14 @@
+# AI review of pull requests.
+#
+# Authenticates as the `ai4c-reviewer` GitHub App, NOT `ai4c-agent`. The two are
+# deliberately separate identities: ai4c-agent authors PRs, so having it also
+# approve them would make the approval meaningless. Reviews now come from
+# ai4c-reviewer[bot] (app id 4388239, bot user 308941448).
+#
+# Required secrets:
+# - AI4C_REVIEWER_APP_ID
+# - AI4C_REVIEWER_PRIVATE_KEY
+# - CLAUDE_CODE_OAUTH_TOKEN
 name: Claude Code Review
 
 on:
@@ -34,17 +45,34 @@ jobs:
         with:
           fetch-depth: 1
 
-      - name: Generate ai4c-agent token
-        id: ai4c-token
+      # create-github-app-token fails obscurely on an empty app-id, which reads
+      # as a token problem rather than a missing secret. Fail with the actual
+      # cause and the fix instead.
+      - name: Check reviewer app secrets are configured
+        env:
+          APP_ID: ${{ secrets.AI4C_REVIEWER_APP_ID }}
+          PRIVATE_KEY: ${{ secrets.AI4C_REVIEWER_PRIVATE_KEY }}
+        run: |
+          set -euo pipefail
+          missing=""
+          [[ -n "${APP_ID:-}" ]]      || missing="$missing AI4C_REVIEWER_APP_ID"
+          [[ -n "${PRIVATE_KEY:-}" ]] || missing="$missing AI4C_REVIEWER_PRIVATE_KEY"
+          if [[ -n "$missing" ]]; then
+            echo "::error title=ai4c-reviewer not configured::Missing secret(s):$missing. This workflow authenticates as the ai4c-reviewer GitHub App, which is separate from ai4c-agent. Install the app on this repository and add the secrets; app id is 4388239."
+            exit 1
+          fi
+
+      - name: Generate ai4c-reviewer token
+        id: reviewer-token
         uses: actions/create-github-app-token@v3
         with:
-          app-id: ${{ secrets.AI4C_AGENT_APP_ID }}
-          private-key: ${{ secrets.AI4C_AGENT_PRIVATE_KEY }}
+          app-id: ${{ secrets.AI4C_REVIEWER_APP_ID }}
+          private-key: ${{ secrets.AI4C_REVIEWER_PRIVATE_KEY }}
 
       - name: Checkout PR branch (for workflow_dispatch)
         if: github.event_name == 'workflow_dispatch'
         env:
-          GH_TOKEN: ${{ steps.ai4c-token.outputs.token }}
+          GH_TOKEN: ${{ steps.reviewer-token.outputs.token }}
         run: gh pr checkout "${{ env.PR_NUMBER }}"
 
       - name: Create tools directory
@@ -72,9 +100,11 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          github_token: ${{ steps.ai4c-token.outputs.token }}
+          github_token: ${{ steps.reviewer-token.outputs.token }}
           track_progress: ${{ github.event_name == 'pull_request' }}
-          # PRs opened by the ai4c GitHub App should still be reviewable.
+          # This lists the PR *author* to accept, not the reviewer identity:
+          # ai4c-agent opens PRs and reviewing them is the main point, so it must
+          # stay here even though the job now authenticates as ai4c-reviewer.
           allowed_bots: "claude,github-actions,ai4c-agent"
           claude_args: |
             --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr review:*),Bash(gh api:*),Bash(obo-grep.pl:*),Bash(aurelian:*),Bash(cat:*),Bash(sed:*),Bash(head:*),Bash(tail:*),Bash(wc:*),Bash(find:*),Bash(ls:*),Bash(rg:*)"


### PR DESCRIPTION
Switches `.github/workflows/claude-code-review.yml` from the `ai4c-agent` app to the separate `ai4c-reviewer` app (app id `4388239`, bot user `308941448`), matching geneontology/go-ontology#32365.

## Why

The review workflow authenticated as `ai4c-agent` — the same app that *opens* PRs in this repo. An author approving its own work isn't a review, and under required-approval branch protection it would be actively harmful: agent PRs could self-clear the gate. Reviews now come from a distinct identity.

`allowed_bots` **deliberately still lists `ai4c-agent`**. That input names the PR *author* to accept, not the reviewer identity, and reviewing the editing agent's PRs is the main reason this workflow exists. I clarified the comment there, since "the ai4c GitHub App" is now ambiguous between two apps.

## ⚠️ This is a hard cutover — setup required before merge

I checked this repo's secrets. Currently present:

```
AI4C_AGENT_APP_ID, AI4C_AGENT_PRIVATE_KEY, ANTHROPIC_API_KEY,
CLAUDE_CODE_OAUTH_TOKEN, GH_TOKEN, ID_ALLOCATION_TOKEN,
ONTOBOT_TOKEN, PAT_FOR_PR, TAVILY_API_KEY
```

No `AI4C_REVIEWER_*`. So on merge, review stops working until:

- [ ] `ai4c-reviewer` is installed on `obophenotype/uberon` with Contents **read**, Pull requests **write**, Issues **read**
- [ ] Secret `AI4C_REVIEWER_APP_ID` added (`4388239`)
- [ ] Secret `AI4C_REVIEWER_PRIVATE_KEY` added (full PEM)

(I can only see repo-level secrets — if these are configured at the `obophenotype` org level, they may already resolve and there's nothing to do.)

To make that failure legible rather than mysterious, a preflight step now checks both secrets are non-empty and fails with the actual cause, the fact that the reviewer app is separate from the agent, and the app id. `create-github-app-token` on an empty `app-id` otherwise fails in a way that reads as a token fault. Tested both branches locally: missing secrets exit 1 with the annotation, present secrets exit 0.

## Verification

- YAML parses; step order confirmed (preflight sits before token generation)
- Preflight guard executed directly under bash in both states
- No `ai4c-token` / `AI4C_AGENT_*` references remain in the file
- `actionlint` not run (not installed locally) — no Actions-schema check

## Deliberately not changed

The review prompt and criteria are untouched — this PR is only the identity switch. Two things I noticed while in here but left alone, happy to do either as a follow-up:

1. **The report is written twice.** `track_progress: true` posts the agent's final response as a tracking comment, and the prompt separately requires a checklist and summary in the `gh pr review` body. Curators get two copies that drift as the second is condensed. This was fixed in go-ontology by making the review body a three-line stub (verdict, counts, link) with the full report living in the tracking comment.
2. **`ANTHROPIC_API_KEY` isn't passed as a fallback.** It exists in this repo. Without it, an exhausted `CLAUDE_CODE_OAUTH_TOKEN` silently no-ops review on every open PR at once.

🤖 Generated with [Claude Code](https://claude.com/claude-code)