### PR TITLE
Prune non-relevant taxa from taxon-specific subsets.

### DIFF
--- a/src/ontology/Makefile
+++ b/src/ontology/Makefile
@@ -10,7 +10,7 @@
 # More information: https://github.com/INCATools/ontology-development-kit/
 
 # Fingerprint of the configuration file when this Makefile was last generated
-CONFIG_HASH=                91414c1a5f963a19baa027e134f3e31fdf6ee4b115f70a6cdeec15180d073d89
+CONFIG_HASH=                d12abab42ccf603187deaa68c3c631ab20a1469ceffe0d5e4092d71c12b9dbf3
 
 
 # ----------------------------------------
@@ -183,7 +183,7 @@ $(ROBOT_PLUGINS_DIRECTORY)/%.jar:
 # Specific rules for supplementary plugins defined in configuration
 
 $(ROBOT_PLUGINS_DIRECTORY)/uberon.jar:
-	curl -L -o $@ https://github.com/obophenotype/uberon-robot-plugin/releases/download/uberon-robot-plugin-0.5.0/uberon.jar
+	curl -L -o $@ https://github.com/obophenotype/uberon-robot-plugin/releases/download/uberon-robot-plugin-0.5.1/uberon.jar
 
 
 # ----------------------------------------

--- a/src/ontology/uberon-odk.yaml
+++ b/src/ontology/uberon-odk.yaml
@@ -137,7 +137,7 @@ robot_java_args: '-Xmx20G'
 robot_plugins:
   plugins:
     - name: uberon
-      mirror_from: https://github.com/obophenotype/uberon-robot-plugin/releases/download/uberon-robot-plugin-0.5.0/uberon.jar
+      mirror_from: https://github.com/obophenotype/uberon-robot-plugin/releases/download/uberon-robot-plugin-0.5.1/uberon.jar
 robot_report:
   release_reports: False
   fail_on: ERROR

--- a/src/ontology/uberon.Makefile
+++ b/src/ontology/uberon.Makefile
@@ -892,6 +892,7 @@ subsets/%-view.owl subsets/%-tags.ofn: $(POSTPROCESS_SRC) | all_robot_plugins
 		                              --taxon $(TAXON_ID_$*) \
 		                              --strategy $(TAXON_SUBSET_STRATEGY) \
 		                              --reasoner ELK \
+		                              --prune-taxa \
 		                              $(foreach root,$(TAXON_SUBSET_ROOTS),--root $(root)) \
 		                              --prefix 'uberon: http://purl.obolibrary.org/obo/uberon/core#' \
 		                              --subset-name uberon:$*_subset \


### PR DESCRIPTION
The method that generates the taxon-specific subsets (or "views") leaves the entire NCBITaxon:* tree untouched. For example, a taxon-specific subset still contains the same NCBITaxon:* tree than the entire Uberon ontology.

As a result, general class axioms (GCAs) that are completely irrelevant to the taxon for which the subset is generated are still present in the subset.

This PR updates the pipeline that creates the taxon-specific subsets so that the NCBITaxon:* is pruned of all the non-relevant taxa (all the taxa that are neither ancestors nor descendants of the taxon for which the subset is generated).

Partially fixes #3748