### PR TITLE
Replace 'only in taxon' by 'in taxon' in bridges.

### DIFF
--- a/src/ontology/bridge/bridges.dispatch
+++ b/src/ontology/bridge/bridges.dispatch
@@ -34,7 +34,7 @@ file: cl-bridge-to-dhba.owl
 
 [ehdaa2-uberon]
 file: uberon-bridge-to-ehdaa2.owl
-add-axiom: (UBERON:0001062 and (BFO:0000050 some NCBITaxon:9606)) SubClassOf: RO:0002160 some NCBITaxon:9606
+add-axiom: (UBERON:0001062 and (BFO:0000050 some NCBITaxon:9606)) SubClassOf: RO:0002162 some NCBITaxon:9606
 dc-title: Uberon bridge to ehdaa2
 dc-description: Equivalence axioms between EHDAA2 and Uberon. EHDAA2 replaces EHDAA.
 dc-creator: Uberon editors
@@ -71,7 +71,7 @@ dc-title: Uberon bridge to FBbt
 dc-description: Taxonomic equivalence axioms between the Drosophila Anatomy Ontology and Uberon.
 dc-creator: Uberon editors
 dc-contributor: David Osumi-Sutherland
-add-axiom: (UBERON:0001062 and (BFO:0000050 some NCBITaxon:7227)) SubClassOf: RO:0002160 some NCBITaxon:7227
+add-axiom: (UBERON:0001062 and (BFO:0000050 some NCBITaxon:7227)) SubClassOf: RO:0002162 some NCBITaxon:7227
 
 [fbbt-cl]
 file: cl-bridge-to-fbbt.owl
@@ -90,7 +90,7 @@ dc-description: Taxonomic equivalence axioms between the FMA and Uberon.
 dc-creator: Uberon editors
 dc-contributor: Onard Mejino
 dc-contributor: Terry Hayamizu
-add-axiom: (UBERON:0001062 and (BFO:0000050 some NCBITaxon:9606)) SubClassOf: RO:0002160 some NCBITaxon:9606
+add-axiom: (UBERON:0001062 and (BFO:0000050 some NCBITaxon:9606)) SubClassOf: RO:0002162 some NCBITaxon:9606
 
 [fma-cl]
 file: cl-bridge-to-fma.owl
@@ -108,7 +108,7 @@ file: cl-bridge-to-go.owl
 
 [hao-uberon]
 file: uberon-bridge-to-hao.owl
-add-axiom: (UBERON:0001062 and (BFO:0000050 some NCBITaxon:7399)) SubClassOf: RO:0002160 some NCBITaxon:7399
+add-axiom: (UBERON:0001062 and (BFO:0000050 some NCBITaxon:7399)) SubClassOf: RO:0002162 some NCBITaxon:7399
 
 [hao-cl]
 file: cl-bridge-to-hao.owl
@@ -135,7 +135,7 @@ dc-description: Taxonomic equivalence axioms between adult mouse anatomy and Ube
 dc-creator: Uberon editors
 dc-creator: Terry Hayamizu
 dc-contributor: George Gkoutos
-add-axiom: (UBERON:0001062 and (BFO:0000050 some NCBITaxon:10090)) SubClassOf: RO:0002160 some NCBITaxon:10090
+add-axiom: (UBERON:0001062 and (BFO:0000050 some NCBITaxon:10090)) SubClassOf: RO:0002162 some NCBITaxon:10090
 
 [ma-cl]
 file: cl-bridge-to-ma.owl
@@ -200,14 +200,14 @@ file: cl-bridge-to-tads.owl
 
 [tgma-uberon]
 file: uberon-bridge-to-tgma.owl
-add-axiom: (UBERON:0001062 and (BFO:0000050 some NCBITaxon:44484)) SubClassOf: RO:0002160 some NCBITaxon:44484
+add-axiom: (UBERON:0001062 and (BFO:0000050 some NCBITaxon:44484)) SubClassOf: RO:0002162 some NCBITaxon:44484
 
 [tgma-cl]
 file: cl-bridge-to-tgma.owl
 
 [wbbt-uberon]
 file: uberon-bridge-to-wbbt.owl
-add-axiom: (UBERON:0001062 and (BFO:0000050 some NCBITaxon:6237)) SubClassOf: RO:0002160 some NCBITaxon:6237
+add-axiom: (UBERON:0001062 and (BFO:0000050 some NCBITaxon:6237)) SubClassOf: RO:0002162 some NCBITaxon:6237
 
 [wbbt-cl]
 file: cl-bridge-to-wbbt.owl
@@ -222,7 +222,7 @@ dc-description: Taxonomic equivalence axioms between XAO and Uberon.
 dc-creator: Uberon editors
 dc-contributor: Erik Segerdell
 dc-contributor: VG Ponferrada
-add-axiom: (UBERON:0001062 and (BFO:0000050 some NCBITaxon:8353)) SubClassOf: RO:0002160 some NCBITaxon:8353
+add-axiom: (UBERON:0001062 and (BFO:0000050 some NCBITaxon:8353)) SubClassOf: RO:0002162 some NCBITaxon:8353
 
 [xao-cl]
 file: cl-bridge-to-xao.owl
@@ -240,7 +240,7 @@ dc-creator: Uberon editors
 dc-contributor: Veri Van Slyke
 dc-contributor: Yvonne Bradford
 dc-contributor: Melissa Haendel
-add-axiom: (UBERON:0001062 and (BFO:0000050 some NCBITaxon:7954)) SubClassOf: RO:0002160 some NCBITaxon:7954
+add-axiom: (UBERON:0001062 and (BFO:0000050 some NCBITaxon:7954)) SubClassOf: RO:0002162 some NCBITaxon:7954
 
 [zfa-cl]
 file: cl-bridge-to-zfa.owl


### PR DESCRIPTION
The bridging axioms in the bridges to taxon-specific ontologies normally use RO:0002162 ('in taxon'), but some bridges also include a custom bridging axiom between Uberon’s 'anatomical entity' and the corresponding term in the foreign ontology. Those custom axioms are set forth in the `src/ontology/bridges/bridges.dispatch` file, and they currently use (for historical reasons) RO:0002160 ('only in taxon').

The RO:0002160 property is obsolete (or [about to be](https://github.com/oborel/obo-relations/pull/892)), so this PR replaces it with RO:0002162 (as for all other bridging axioms).