### PR TITLE
Add terms for skull and calvarial bone marrow

### DIFF
--- a/src/ontology/uberon-edit.obo
+++ b/src/ontology/uberon-edit.obo
@@ -225245,7 +225245,7 @@ relationship: has_part CL:4030023 ! respiratory tract hillock cell
 relationship: part_of UBERON:0007196 ! tracheobronchial tree
 
 [Term]
-id: UBERON:9900001
+id: UBERON:9903758
 name: bone marrow of skull
 def: "A bone marrow that is located within the bones of the skull. In mammals, skull bone marrow is haematopoietically active and communicates directly with the dura mater through osseous skull channels, which permit the exchange of cerebrospinal fluid, central nervous system-derived antigens and immune cells; it acts as a local reservoir of myeloid cells and B cells for the meninges and the central nervous system." [PMID:30150661, PMID:34083447, PMID:35301477, PMID:37996526]
 comment: Distinguished from other bone marrow sites (for example sternal, femoral, tibial or vertebral marrow) by its direct osseous connection to the dura mater. Reported to contain lymphoid structures with germinal-centre-like features that respond to central nervous system-derived antigens (doi:10.1038/s41586-026-10951-4).
@@ -225259,14 +225259,14 @@ property_value: dcterms-date "2026-08-20T04:59:35Z" xsd:dateTime
 property_value: terminology_notes "In the neuroimmunology literature 'skull bone marrow' is generally used for calvarial marrow specifically (see 'bone marrow of calvaria'); marrow of the basicranium (UBERON:0002517) is sampled and reported as a separate compartment, as are vertebral, sternal and femoral marrow. Annotate to 'bone marrow of calvaria' where the calvaria is what was sampled." xsd:string
 
 [Term]
-id: UBERON:9900002
+id: UBERON:9903759
 name: bone marrow of calvaria
 def: "A bone marrow of skull that is located within the diploic spaces of the calvaria (skull vault). It is the principal haematopoietic compartment of the mammalian skull and is connected to the dura mater by transcalvarial channels; its immune composition differs between anterior (frontal, parietal) and posterior (interparietal, occipital) territories." [PMID:35301477, PMID:41389063]
 comment: In the mouse, lymphoid clusters containing follicular helper-like T cells, B cells and follicular dendritic cells are enriched in the marrow of the occipital and interparietal regions and are sparse in the frontal and parietal regions (doi:10.1038/s41586-026-10951-4).
 synonym: "calvarial bone marrow" EXACT []
 synonym: "calvarial marrow" EXACT []
 synonym: "skull cap bone marrow" RELATED []
-intersection_of: UBERON:9900001 ! bone marrow of skull
+intersection_of: UBERON:9903758 ! bone marrow of skull
 intersection_of: part_of UBERON:0004339 ! vault of skull
 relationship: dc-contributor https://orcid.org/0000-0002-6601-2165 ! Christopher J. Mungall
 property_value: dcterms-date "2026-08-20T04:59:35Z" xsd:dateTime

--- a/src/ontology/uberon-edit.obo
+++ b/src/ontology/uberon-edit.obo
@@ -225247,22 +225247,24 @@ relationship: part_of UBERON:0007196 ! tracheobronchial tree
 [Term]
 id: UBERON:9903758
 name: bone marrow of skull
-def: "A bone marrow that is located within the bones of the skull. In mammals, skull bone marrow is haematopoietically active and communicates directly with the dura mater through osseous skull channels, which permit the exchange of cerebrospinal fluid, central nervous system-derived antigens and immune cells; it acts as a local reservoir of myeloid cells and B cells for the meninges and the central nervous system." [PMID:30150661, PMID:34083447, PMID:35301477, PMID:37996526]
-comment: Distinguished from other bone marrow sites (for example sternal, femoral, tibial or vertebral marrow) by its direct osseous connection to the dura mater. Reported to contain lymphoid structures with germinal-centre-like features that respond to central nervous system-derived antigens (doi:10.1038/s41586-026-10951-4).
+def: "A bone marrow that is located within the bones of the skull. In mammals, skull bone marrow is haematopoietically active and communicates directly with the dura mater through osseous skull channels, which permit the exchange of cerebrospinal fluid, central nervous system-derived antigens and immune cells; it acts as a local reservoir of myeloid cells and B cells for the meninges and the central nervous system." [PMID:30150661, PMID:34083447, PMID:35301477, PMID:37996526, PMID:42618784]
+comment: Distinguished from other bone marrow sites (for example sternal, femoral, tibial or vertebral marrow) by its direct osseous connection to the dura mater. Reported to contain lymphoid structures with germinal-centre-like features that respond to central nervous system-derived antigens (PMID:42618784).
 synonym: "cranial bone marrow" RELATED []
 synonym: "skull BM" RELATED OMO:0003000 []
 synonym: "skull bone marrow" EXACT []
+xref: SCTID:712962003
 intersection_of: UBERON:0002371 ! bone marrow
 intersection_of: part_of UBERON:0003129 ! skull
 relationship: dc-contributor https://orcid.org/0000-0002-6601-2165 ! Christopher J. Mungall
 property_value: dcterms-date "2026-08-20T04:59:35Z" xsd:dateTime
+property_value: external_ontology_notes "SCTID:712962003 ('Structure of bone marrow of cranium') is scoped to the cranium rather than the whole skull, so it excludes mandibular marrow that this class admits; its SNOMED children cover frontal, temporal, sphenoid and nasal-orbit marrow. The FMA has no corresponding grouping class - it descends from 'Bone marrow of flat bone' (FMA:303320) straight to per-bone classes such as FMA:303380 (frontal), FMA:303382 (parietal), FMA:303388 (occipital) and FMA:303454 (temporal) - so no FMA xref is asserted here." xsd:string {external_ontology="FMA"}
 property_value: terminology_notes "In the neuroimmunology literature 'skull bone marrow' is generally used for calvarial marrow specifically (see 'bone marrow of calvaria'); marrow of the basicranium (UBERON:0002517) is sampled and reported as a separate compartment, as are vertebral, sternal and femoral marrow. Annotate to 'bone marrow of calvaria' where the calvaria is what was sampled." xsd:string
 
 [Term]
 id: UBERON:9903759
 name: bone marrow of calvaria
-def: "A bone marrow of skull that is located within the diploic spaces of the calvaria (skull vault). It is the principal haematopoietic compartment of the mammalian skull and is connected to the dura mater by transcalvarial channels; its immune composition differs between anterior (frontal, parietal) and posterior (interparietal, occipital) territories." [PMID:35301477, PMID:41389063]
-comment: In the mouse, lymphoid clusters containing follicular helper-like T cells, B cells and follicular dendritic cells are enriched in the marrow of the occipital and interparietal regions and are sparse in the frontal and parietal regions (doi:10.1038/s41586-026-10951-4).
+def: "A bone marrow of skull that is located within the diploic spaces of the calvaria (skull vault). It is the principal haematopoietic compartment of the mammalian skull and is connected to the dura mater by transcalvarial channels; its immune composition differs between anterior (frontal, parietal) and posterior (interparietal, occipital) territories." [PMID:35301477, PMID:41389063, PMID:42618784]
+comment: In the mouse, lymphoid clusters containing follicular helper-like T cells, B cells and follicular dendritic cells are enriched in the marrow of the occipital and interparietal regions and are sparse in the frontal and parietal regions (PMID:42618784).
 synonym: "calvarial bone marrow" EXACT []
 synonym: "calvarial marrow" EXACT []
 synonym: "skull cap bone marrow" RELATED []
@@ -225270,6 +225272,7 @@ intersection_of: UBERON:9903758 ! bone marrow of skull
 intersection_of: part_of UBERON:0004339 ! vault of skull
 relationship: dc-contributor https://orcid.org/0000-0002-6601-2165 ! Christopher J. Mungall
 property_value: dcterms-date "2026-08-20T04:59:35Z" xsd:dateTime
+property_value: external_ontology_notes "Neither the FMA nor SNOMED has a calvarial marrow grouping class. The FMA covers the same territory with per-bone classes: FMA:303380 (frontal), FMA:303382 (parietal), FMA:303388 (occipital) and FMA:303390 (sutural bone); these are the natural xref targets if regional calvarial marrow terms are added." xsd:string {external_ontology="FMA"}
 
 [Typedef]
 id: aboral_to

--- a/src/ontology/uberon-edit.obo
+++ b/src/ontology/uberon-edit.obo
@@ -225258,6 +225258,7 @@ intersection_of: part_of UBERON:0003129 ! skull
 relationship: dc-contributor https://orcid.org/0000-0002-6601-2165 ! Christopher J. Mungall
 property_value: dcterms-date "2026-08-20T04:59:35Z" xsd:dateTime
 property_value: external_ontology_notes "SCTID:712962003 ('Structure of bone marrow of cranium') is scoped to the cranium rather than the whole skull, so it excludes mandibular marrow that this class admits; its SNOMED children cover frontal, temporal, sphenoid and nasal-orbit marrow. The FMA has no corresponding grouping class - it descends from 'Bone marrow of flat bone' (FMA:303320) straight to per-bone classes such as FMA:303380 (frontal), FMA:303382 (parietal), FMA:303388 (occipital) and FMA:303454 (temporal) - so no FMA xref is asserted here." xsd:string {external_ontology="FMA"}
+property_value: term_tracker_item "https://github.com/obophenotype/uberon/pull/3758" xsd:anyURI
 property_value: terminology_notes "In the neuroimmunology literature 'skull bone marrow' is generally used for calvarial marrow specifically (see 'bone marrow of calvaria'); marrow of the basicranium (UBERON:0002517) is sampled and reported as a separate compartment, as are vertebral, sternal and femoral marrow. Annotate to 'bone marrow of calvaria' where the calvaria is what was sampled." xsd:string
 
 [Term]
@@ -225273,6 +225274,8 @@ intersection_of: part_of UBERON:0004339 ! vault of skull
 relationship: dc-contributor https://orcid.org/0000-0002-6601-2165 ! Christopher J. Mungall
 property_value: dcterms-date "2026-08-20T04:59:35Z" xsd:dateTime
 property_value: external_ontology_notes "Neither the FMA nor SNOMED has a calvarial marrow grouping class. The FMA covers the same territory with per-bone classes: FMA:303380 (frontal), FMA:303382 (parietal), FMA:303388 (occipital) and FMA:303390 (sutural bone); these are the natural xref targets if regional calvarial marrow terms are added." xsd:string {external_ontology="FMA"}
+property_value: term_tracker_item "https://github.com/obophenotype/uberon/pull/3758" xsd:anyURI
+property_value: terminology_notes "The differentia uses 'vault of skull' (UBERON:0004339), whose own comment records that the vault may not be precisely equivalent to the calvaria - sources differ on whether the temporal, ethmoid and sphenoid bones are included. That ambiguity is inherited here rather than introduced: this class is intended as the marrow of whatever 'vault of skull' covers, which is the compartment the calvarial bone marrow literature samples." xsd:string
 
 [Typedef]
 id: aboral_to

--- a/src/ontology/uberon-edit.obo
+++ b/src/ontology/uberon-edit.obo
@@ -225257,6 +225257,7 @@ intersection_of: part_of UBERON:0003129 ! skull
 created_by: ai4c-agent
 relationship: dc-contributor https://orcid.org/0000-0002-6601-2165 ! Christopher J. Mungall
 property_value: dcterms-date "2026-08-20T04:59:35Z" xsd:dateTime
+property_value: terminology_notes "In the neuroimmunology literature 'skull bone marrow' is generally used for calvarial marrow specifically (see 'bone marrow of calvaria'); marrow of the basicranium (UBERON:0002517) is sampled and reported as a separate compartment, as are vertebral, sternal and femoral marrow. Annotate to 'bone marrow of calvaria' where the calvaria is what was sampled." xsd:string
 
 [Term]
 id: UBERON:9900002

--- a/src/ontology/uberon-edit.obo
+++ b/src/ontology/uberon-edit.obo
@@ -189952,6 +189952,39 @@ property_value: term_tracker_item "https://github.com/obophenotype/uberon/issues
 created_by: dragon-ai-agent
 
 [Term]
+id: UBERON:1200342
+name: bone marrow of skull
+def: "A bone marrow that is located within the bones of the skull. In mammals, skull bone marrow is haematopoietically active and communicates directly with the dura mater through osseous skull channels, which permit the exchange of cerebrospinal fluid, central nervous system-derived antigens and immune cells; it acts as a local reservoir of myeloid cells and B cells for the meninges and the central nervous system." [PMID:30150661, PMID:34083447, PMID:35301477, PMID:37996526, PMID:42618784]
+comment: Distinguished from other bone marrow sites (for example sternal, femoral, tibial or vertebral marrow) by its direct osseous connection to the dura mater. Reported to contain lymphoid structures with germinal-centre-like features that respond to central nervous system-derived antigens (PMID:42618784).
+synonym: "cranial bone marrow" RELATED []
+synonym: "skull BM" RELATED OMO:0003000 []
+synonym: "skull bone marrow" EXACT []
+xref: SCTID:712962003
+intersection_of: UBERON:0002371 ! bone marrow
+intersection_of: part_of UBERON:0003129 ! skull
+relationship: dc-contributor https://orcid.org/0000-0002-6601-2165 ! Christopher J. Mungall
+property_value: dcterms-date "2026-08-20T04:59:35Z" xsd:dateTime
+property_value: external_ontology_notes "SCTID:712962003 ('Structure of bone marrow of cranium') is scoped to the cranium rather than the whole skull, so it excludes mandibular marrow that this class admits; its SNOMED children cover frontal, temporal, sphenoid and nasal-orbit marrow. The FMA has no corresponding grouping class - it descends from 'Bone marrow of flat bone' (FMA:303320) straight to per-bone classes such as FMA:303380 (frontal), FMA:303382 (parietal), FMA:303388 (occipital) and FMA:303454 (temporal) - so no FMA xref is asserted here." xsd:string {external_ontology="FMA"}
+property_value: term_tracker_item "https://github.com/obophenotype/uberon/pull/3758" xsd:anyURI
+property_value: terminology_notes "In the neuroimmunology literature 'skull bone marrow' is generally used for calvarial marrow specifically (see 'bone marrow of calvaria'); marrow of the basicranium (UBERON:0002517) is sampled and reported as a separate compartment, as are vertebral, sternal and femoral marrow. Annotate to 'bone marrow of calvaria' where the calvaria is what was sampled." xsd:string
+
+[Term]
+id: UBERON:1200343
+name: bone marrow of calvaria
+def: "A bone marrow of skull that is located within the diploic spaces of the calvaria (skull vault). It is the principal haematopoietic compartment of the mammalian skull and is connected to the dura mater by transcalvarial channels; its immune composition differs between anterior (frontal, parietal) and posterior (interparietal, occipital) territories." [PMID:35301477, PMID:41389063, PMID:42618784]
+comment: In the mouse, lymphoid clusters containing follicular helper-like T cells, B cells and follicular dendritic cells are enriched in the marrow of the occipital and interparietal regions and are sparse in the frontal and parietal regions (PMID:42618784).
+synonym: "calvarial bone marrow" EXACT []
+synonym: "calvarial marrow" EXACT []
+synonym: "skull cap bone marrow" RELATED []
+intersection_of: UBERON:1200342 ! bone marrow of skull
+intersection_of: part_of UBERON:0004339 ! vault of skull
+relationship: dc-contributor https://orcid.org/0000-0002-6601-2165 ! Christopher J. Mungall
+property_value: dcterms-date "2026-08-20T04:59:35Z" xsd:dateTime
+property_value: external_ontology_notes "Neither the FMA nor SNOMED has a calvarial marrow grouping class. The FMA covers the same territory with per-bone classes: FMA:303380 (frontal), FMA:303382 (parietal), FMA:303388 (occipital) and FMA:303390 (sutural bone); these are the natural xref targets if regional calvarial marrow terms are added." xsd:string {external_ontology="FMA"}
+property_value: term_tracker_item "https://github.com/obophenotype/uberon/pull/3758" xsd:anyURI
+property_value: terminology_notes "The differentia uses 'vault of skull' (UBERON:0004339), whose own comment records that the vault may not be precisely equivalent to the calvaria - sources differ on whether the temporal, ethmoid and sphenoid bones are included. That ambiguity is inherited here rather than introduced: this class is intended as the marrow of whatever 'vault of skull' covers, which is the compartment the calvarial bone marrow literature samples." xsd:string
+
+[Term]
 id: UBERON:1500000
 name: scapular blade
 def: "Enlarged and broad extension of the scapula distal to the glenoid region that conforms to the contour of the ribs. Origin for the major shoulder muscles including the deltoid group." [PHENOSCAPE]
@@ -225243,39 +225276,6 @@ def: "A region of squamous epithelium found in the tracheobronchial tree - conti
 is_a: UBERON:0006914 ! squamous epithelium
 relationship: has_part CL:4030023 ! respiratory tract hillock cell
 relationship: part_of UBERON:0007196 ! tracheobronchial tree
-
-[Term]
-id: UBERON:9903758
-name: bone marrow of skull
-def: "A bone marrow that is located within the bones of the skull. In mammals, skull bone marrow is haematopoietically active and communicates directly with the dura mater through osseous skull channels, which permit the exchange of cerebrospinal fluid, central nervous system-derived antigens and immune cells; it acts as a local reservoir of myeloid cells and B cells for the meninges and the central nervous system." [PMID:30150661, PMID:34083447, PMID:35301477, PMID:37996526, PMID:42618784]
-comment: Distinguished from other bone marrow sites (for example sternal, femoral, tibial or vertebral marrow) by its direct osseous connection to the dura mater. Reported to contain lymphoid structures with germinal-centre-like features that respond to central nervous system-derived antigens (PMID:42618784).
-synonym: "cranial bone marrow" RELATED []
-synonym: "skull BM" RELATED OMO:0003000 []
-synonym: "skull bone marrow" EXACT []
-xref: SCTID:712962003
-intersection_of: UBERON:0002371 ! bone marrow
-intersection_of: part_of UBERON:0003129 ! skull
-relationship: dc-contributor https://orcid.org/0000-0002-6601-2165 ! Christopher J. Mungall
-property_value: dcterms-date "2026-08-20T04:59:35Z" xsd:dateTime
-property_value: external_ontology_notes "SCTID:712962003 ('Structure of bone marrow of cranium') is scoped to the cranium rather than the whole skull, so it excludes mandibular marrow that this class admits; its SNOMED children cover frontal, temporal, sphenoid and nasal-orbit marrow. The FMA has no corresponding grouping class - it descends from 'Bone marrow of flat bone' (FMA:303320) straight to per-bone classes such as FMA:303380 (frontal), FMA:303382 (parietal), FMA:303388 (occipital) and FMA:303454 (temporal) - so no FMA xref is asserted here." xsd:string {external_ontology="FMA"}
-property_value: term_tracker_item "https://github.com/obophenotype/uberon/pull/3758" xsd:anyURI
-property_value: terminology_notes "In the neuroimmunology literature 'skull bone marrow' is generally used for calvarial marrow specifically (see 'bone marrow of calvaria'); marrow of the basicranium (UBERON:0002517) is sampled and reported as a separate compartment, as are vertebral, sternal and femoral marrow. Annotate to 'bone marrow of calvaria' where the calvaria is what was sampled." xsd:string
-
-[Term]
-id: UBERON:9903759
-name: bone marrow of calvaria
-def: "A bone marrow of skull that is located within the diploic spaces of the calvaria (skull vault). It is the principal haematopoietic compartment of the mammalian skull and is connected to the dura mater by transcalvarial channels; its immune composition differs between anterior (frontal, parietal) and posterior (interparietal, occipital) territories." [PMID:35301477, PMID:41389063, PMID:42618784]
-comment: In the mouse, lymphoid clusters containing follicular helper-like T cells, B cells and follicular dendritic cells are enriched in the marrow of the occipital and interparietal regions and are sparse in the frontal and parietal regions (PMID:42618784).
-synonym: "calvarial bone marrow" EXACT []
-synonym: "calvarial marrow" EXACT []
-synonym: "skull cap bone marrow" RELATED []
-intersection_of: UBERON:9903758 ! bone marrow of skull
-intersection_of: part_of UBERON:0004339 ! vault of skull
-relationship: dc-contributor https://orcid.org/0000-0002-6601-2165 ! Christopher J. Mungall
-property_value: dcterms-date "2026-08-20T04:59:35Z" xsd:dateTime
-property_value: external_ontology_notes "Neither the FMA nor SNOMED has a calvarial marrow grouping class. The FMA covers the same territory with per-bone classes: FMA:303380 (frontal), FMA:303382 (parietal), FMA:303388 (occipital) and FMA:303390 (sutural bone); these are the natural xref targets if regional calvarial marrow terms are added." xsd:string {external_ontology="FMA"}
-property_value: term_tracker_item "https://github.com/obophenotype/uberon/pull/3758" xsd:anyURI
-property_value: terminology_notes "The differentia uses 'vault of skull' (UBERON:0004339), whose own comment records that the vault may not be precisely equivalent to the calvaria - sources differ on whether the temporal, ethmoid and sphenoid bones are included. That ambiguity is inherited here rather than introduced: this class is intended as the marrow of whatever 'vault of skull' covers, which is the compartment the calvarial bone marrow literature samples." xsd:string
 
 [Typedef]
 id: aboral_to

--- a/src/ontology/uberon-edit.obo
+++ b/src/ontology/uberon-edit.obo
@@ -225250,11 +225250,10 @@ name: bone marrow of skull
 def: "A bone marrow that is located within the bones of the skull. In mammals, skull bone marrow is haematopoietically active and communicates directly with the dura mater through osseous skull channels, which permit the exchange of cerebrospinal fluid, central nervous system-derived antigens and immune cells; it acts as a local reservoir of myeloid cells and B cells for the meninges and the central nervous system." [PMID:30150661, PMID:34083447, PMID:35301477, PMID:37996526]
 comment: Distinguished from other bone marrow sites (for example sternal, femoral, tibial or vertebral marrow) by its direct osseous connection to the dura mater. Reported to contain lymphoid structures with germinal-centre-like features that respond to central nervous system-derived antigens (doi:10.1038/s41586-026-10951-4).
 synonym: "cranial bone marrow" RELATED []
-synonym: "skull bone marrow" EXACT []
 synonym: "skull BM" RELATED OMO:0003000 []
+synonym: "skull bone marrow" EXACT []
 intersection_of: UBERON:0002371 ! bone marrow
 intersection_of: part_of UBERON:0003129 ! skull
-created_by: ai4c-agent
 relationship: dc-contributor https://orcid.org/0000-0002-6601-2165 ! Christopher J. Mungall
 property_value: dcterms-date "2026-08-20T04:59:35Z" xsd:dateTime
 property_value: terminology_notes "In the neuroimmunology literature 'skull bone marrow' is generally used for calvarial marrow specifically (see 'bone marrow of calvaria'); marrow of the basicranium (UBERON:0002517) is sampled and reported as a separate compartment, as are vertebral, sternal and femoral marrow. Annotate to 'bone marrow of calvaria' where the calvaria is what was sampled." xsd:string
@@ -225269,7 +225268,6 @@ synonym: "calvarial marrow" EXACT []
 synonym: "skull cap bone marrow" RELATED []
 intersection_of: UBERON:9900001 ! bone marrow of skull
 intersection_of: part_of UBERON:0004339 ! vault of skull
-created_by: ai4c-agent
 relationship: dc-contributor https://orcid.org/0000-0002-6601-2165 ! Christopher J. Mungall
 property_value: dcterms-date "2026-08-20T04:59:35Z" xsd:dateTime
 

--- a/src/ontology/uberon-edit.obo
+++ b/src/ontology/uberon-edit.obo
@@ -225244,6 +225244,34 @@ is_a: UBERON:0006914 ! squamous epithelium
 relationship: has_part CL:4030023 ! respiratory tract hillock cell
 relationship: part_of UBERON:0007196 ! tracheobronchial tree
 
+[Term]
+id: UBERON:9900001
+name: bone marrow of skull
+def: "A bone marrow that is located within the bones of the skull. In mammals, skull bone marrow is haematopoietically active and communicates directly with the dura mater through osseous skull channels, which permit the exchange of cerebrospinal fluid, central nervous system-derived antigens and immune cells; it acts as a local reservoir of myeloid cells and B cells for the meninges and the central nervous system." [PMID:30150661, PMID:34083447, PMID:35301477, PMID:37996526]
+comment: Distinguished from other bone marrow sites (for example sternal, femoral, tibial or vertebral marrow) by its direct osseous connection to the dura mater. Reported to contain lymphoid structures with germinal-centre-like features that respond to central nervous system-derived antigens (doi:10.1038/s41586-026-10951-4).
+synonym: "cranial bone marrow" RELATED []
+synonym: "skull bone marrow" EXACT []
+synonym: "skull BM" RELATED OMO:0003000 []
+intersection_of: UBERON:0002371 ! bone marrow
+intersection_of: part_of UBERON:0003129 ! skull
+created_by: ai4c-agent
+relationship: dc-contributor https://orcid.org/0000-0002-6601-2165 ! Christopher J. Mungall
+property_value: dcterms-date "2026-08-20T04:59:35Z" xsd:dateTime
+
+[Term]
+id: UBERON:9900002
+name: bone marrow of calvaria
+def: "A bone marrow of skull that is located within the diploic spaces of the calvaria (skull vault). It is the principal haematopoietic compartment of the mammalian skull and is connected to the dura mater by transcalvarial channels; its immune composition differs between anterior (frontal, parietal) and posterior (interparietal, occipital) territories." [PMID:35301477, PMID:41389063]
+comment: In the mouse, lymphoid clusters containing follicular helper-like T cells, B cells and follicular dendritic cells are enriched in the marrow of the occipital and interparietal regions and are sparse in the frontal and parietal regions (doi:10.1038/s41586-026-10951-4).
+synonym: "calvarial bone marrow" EXACT []
+synonym: "calvarial marrow" EXACT []
+synonym: "skull cap bone marrow" RELATED []
+intersection_of: UBERON:9900001 ! bone marrow of skull
+intersection_of: part_of UBERON:0004339 ! vault of skull
+created_by: ai4c-agent
+relationship: dc-contributor https://orcid.org/0000-0002-6601-2165 ! Christopher J. Mungall
+property_value: dcterms-date "2026-08-20T04:59:35Z" xsd:dateTime
+
 [Typedef]
 id: aboral_to
 name: aboral to


### PR DESCRIPTION
## Why

Reviewing Park, Abramishvili, Davanzo et al., ["Functional role of skull lymphoid structures in CNS immunosurveillance"](https://doi.org/10.1038/s41586-026-10951-4) (*Nature*, 19 Aug 2026, PMID:42618784) turned up a gap that is bigger than the paper: **UBERON has no representation of skull bone marrow at all.**

The only bone-marrow-by-site terms in the edit file are `red bone marrow of sternum` (UBERON:8410080) and `red bone marrow of iliac crest`. Skull marrow has been an active subject since Herisson et al. described transcalvarial vascular channels in 2018, and nearly every paper in the field is built on a skull-vs-other-site comparison. We could express one side of that comparison and not the other.

## What this adds

Two terms, following the existing by-site pattern:

| ID | Name | Logical definition | xref |
|---|---|---|---|
| UBERON:1200342 | bone marrow of skull | `bone marrow` and `part_of` some `skull` (UBERON:0003129) | SCTID:712962003 |
| UBERON:1200343 | bone marrow of calvaria | `bone marrow of skull` and `part_of` some `vault of skull` (UBERON:0004339) | — |

Synonyms: *skull bone marrow*, *cranial bone marrow*, *skull BM* on the first; *calvarial bone marrow*, *calvarial marrow* on the second.

IDs come from `idrange:44`, `1200000–1300000`, allocated in `uberon-idranges.owl` to **"Automation"** — the block already holding UBERON:1200000–1200341. `1200342`/`1200343` are the next free values, verified unused across the repo and unclaimed by any open PR.

## Citations — all six verified against PubMed

Every PMID in the two definitions, checked via PubMed `esummary` and confirmed to resolve to the paper cited:

| PMID | Title | Journal | Supports |
|---|---|---|---|
| 30150661 | Direct vascular channels connect skull bone marrow and the brain surface enabling myeloid cell migration (Herisson et al.) | Nat Neurosci 2018 | osseous channels between skull marrow and brain surface |
| 34083447 | Skull and vertebral bone marrow are myeloid cell reservoirs for the meninges and CNS parenchyma (Cugurra et al.) | Science 2021 | skull marrow as a local myeloid reservoir for meninges/CNS |
| 35301477 | Cerebrospinal fluid regulates skull bone marrow niches via direct access through dural channels (Mazzitelli et al.) | Nat Neurosci 2022 | CSF access to skull marrow via dural channels |
| 37996526 | Skull bone marrow channels as immune gateways to the central nervous system (Mazzitelli et al.) | Nat Neurosci 2023 | review; the "communicates directly with the dura mater through osseous skull channels" clause |
| 41389063 | Functional Specialization of the Calvarial Bone Marrow (Koh & Adams) | Physiology 2026 | review; diploic location and regional heterogeneity of calvarial marrow |
| 42618784 | Functional role of skull lymphoid structures in CNS immunosurveillance (Park et al.) | Nature 2026 | the source paper; lymphoid structures and their regional distribution |

Note for anyone re-checking: **Europe PMC has no record of PMID:42618784**; PubMed does. A verification path that queries only Europe PMC will report it missing.

## Cross-ontology situation

- **SNOMED has the grouping class.** `SCTID:712962003` "Structure of bone marrow of cranium", xrefed on `bone marrow of skull`. Not exact — SNOMED scopes it to the cranium, so it excludes the mandibular marrow this class admits. Its parent `SCTID:421320006` is already xrefed on `bone marrow`, and its children cover frontal, temporal, sphenoid and nasal-orbit marrow. Recorded in `external_ontology_notes` rather than left implicit.
- **FMA has no counterpart for either term, but does have the per-bone classes.** FMA descends from `Bone marrow of flat bone` (FMA:303320) straight to individual bones — `FMA:303380` frontal, `FMA:303382` parietal, `FMA:303388` occipital, `FMA:303390` sutural, `FMA:303454` temporal — with no skull-level or calvaria-level grouper in between. So no FMA xref is assertable here, and both stanzas say so. Those per-bone classes are the ready xref targets if the regional calvarial marrow terms below are ever added.
- Worth noting separately: `red bone marrow of sternum` (UBERON:8410080) has no FMA xref either, though `FMA:303392` "Bone marrow of sternum" exists. Pre-existing, out of scope here.

## Modelling decisions worth a reviewer's eye

- **`bone marrow of calvaria` takes `bone marrow of skull` as its genus**, not `bone marrow` directly. UBERON asserts `skull has_part cranium` but never `cranium part_of skull`, so `vault of skull → neurocranium → cranium` dead-ends without reaching `skull`, and defining it as `bone marrow` + `part_of vault of skull` would leave the subsumption unentailed. CI's logical-definition check confirms the intended entailment; `ai4c-reviewer` independently verified the chain. The alternative fix is adding the missing `cranium part_of skull` upstream, which may be the better call.
- **Genus is `bone marrow`, not `red bone marrow`**, even though calvarial marrow is haematopoietically active in mouse and human. Fatty conversion is age- and site-dependent; a `red bone marrow of calvaria` child can follow if needed.
- **`bone marrow of skull` carries a `terminology_notes` warning.** Extended Data Fig. 1b of the paper plots *Skull*, *Skull Base*, *Vertebrae*, *Sternum*, *Femur* and *Dura* as separate sampled tissues — so this literature's "skull bone marrow" is the narrower calvarial compartment, and basicranial marrow is deliberately excluded from it. The note says so and points at `basicranium` (UBERON:0002517).
- **`bone marrow of calvaria` carries a calvaria-vs-vault caveat.** `vault of skull` records that the vault may not be precisely equivalent to the calvaria; the new class documents that it inherits that ambiguity and means the marrow of whatever `vault of skull` covers.

## Status

- [x] ~~**IDs need minting from a real allocated range.**~~ Done in `2158446`. The terms were originally in the `9900000–10000000` "Temporary IDs" block, which contains nothing merged and which every open NTR branch mints from. They now sit in the **Automation** range (`idrange:44`, 1200000–1300000) alongside the seven terms already merged there.
- [x] ~~**IDs collide with other open PRs.**~~ Fixed in `969e476`, then made moot by the move above. The branch originally used `UBERON:9900001`/`9900002`, claimed by **#3622, #3623, #3693, #3698, #3699, #3700, #3739** and **#3622, #3623, #3698, #3700** respectively.
- [x] ~~**Not reserialised or reasoned.**~~ `robot convert` normalisation clean and idempotent, re-checked after every push; `ontology_qc` green.
- [x] ~~**Cited by DOI, not PMID.**~~ Fixed in `76abce5` — PMID:42618784. All six citations tabulated above.
- [x] ~~**No `term_tracker_item`; calvaria/vault ambiguity unacknowledged.**~~ Both addressed in `29c9d19` per `ai4c-reviewer`'s suggestions.

**Note for maintainers:** `CLAUDE.md` line 54 says *"New terms start UBERON:99xxxxx"*, which points at the temporary block rather than the Automation range. That instruction is what sent this PR to `99xxxxx` in the first place, and will send every future agent run to the same place.

## Related gaps found, deliberately left alone

- **`tertiary lymphoid structure`** — zero hits for "tertiary lymphoid", "ectopic lymphoid" or "lymphoid aggregate". Wanted by tumour immunology, iBALT and meningeal lymphoid aggregate work; deserves its own NTR.
- **`diploe`** — FMA:76630 exists and HP:0030312 already depends on the concept. The `bone marrow of calvaria` definition refers to "diploic spaces" with nothing to point at.
- **`skull–meninges connection`** — well replicated, but blocked on whether it is modelled as a bony canal or a vessel, and there is no `diploic vein` term to anchor against.
- **`skull bone marrow lymphoid structure`** — the paper's headline entity, deliberately *not* added. Described as germinal-centre-*like* throughout; human evidence is a reanalysis of a single dataset.
- **Regional calvarial marrow terms**, now with FMA xref targets in hand, plus **`bone marrow of basicranium`** and the rest of the by-site series (femur `FMA:303348`, tibia `FMA:303360`, vertebra `FMA:303412`).

Full review: https://claude.ai/code/artifact/8ec95325-9943-42f9-8d7d-93bc03a20caf