### PR TITLE
Fix typos in uberon-edit.obo via codespell (follow-up to #3759)

### DIFF
--- a/.codespellrc
+++ b/.codespellrc
@@ -16,32 +16,102 @@
 #   - src/patterns/definitions.owl (generated from src/patterns/data/**/*.tsv)
 #   - LICENSE (fixed legal wording; do not rewrite even if it has typos)
 #   - .git-meta (author-workflow scratch for commit / PR message drafts)
-#   - src/ontology/uberon-edit.obo -- the ontology edit file. Its contents
-#     will be spell-checked in a separate curator-reviewed PR; skipped here
-#     so that this infrastructure PR does not conflate infrastructure setup
-#     with curator-judgement calls on ~200 biological / anatomical terms.
-skip = .git,.git-meta,.gitignore,.gitattributes,.codespellrc,LICENSE,*.pdf,*.svg,*.graffle,*.tmp*,*.LOG,attic,bulk_ntr_workflow,experimental,ext-mappings,mappings,modules,reports,resources,source-ontologies,subsets,depictions.owl,external-disjoints.owl,homology.owl,homology-relations.owl,musculoskeletal.obo,musculoskeletal.owl,project.owl,reasoner_axioms.owl,rules.owl,ssso-merged-uberon.owl,uberon-base.owl,uberon-simple-rel.obo,uberon-taxmod-amniote.obo,uberon-with-isa.obo,uberon.obo,imports,taxmods,diffs,languages,odk-workflows,ubermacros.el,uberon-edit.obo,uberon-bridge-to-*.owl,cl-bridge-to-*.owl,definitions.owl
+skip = .git,.git-meta,.gitignore,.gitattributes,.codespellrc,LICENSE,*.pdf,*.svg,*.graffle,*.tmp*,*.LOG,attic,bulk_ntr_workflow,experimental,ext-mappings,mappings,modules,reports,resources,source-ontologies,subsets,depictions.owl,external-disjoints.owl,homology.owl,homology-relations.owl,musculoskeletal.obo,musculoskeletal.owl,project.owl,reasoner_axioms.owl,rules.owl,ssso-merged-uberon.owl,uberon-base.owl,uberon-simple-rel.obo,uberon-taxmod-amniote.obo,uberon-with-isa.obo,uberon.obo,imports,taxmods,diffs,languages,odk-workflows,ubermacros.el,uberon-bridge-to-*.owl,cl-bridge-to-*.owl,definitions.owl
 check-hidden = true
-# Protect:
-#   - URLs (short host substrings like bu.edu would otherwise flag "bu")
-#   - camelCase / PascalCase identifiers (Prolog vars in *.pro scripts,
-#     code identifiers)
-#   - Cross-reference values after `PREFIX:` (BAMS:MEnt, BM:Tel-OLT etc.
-#     -- external IDs must not be "corrected")
+# Protect URLs, camelCase/PascalCase identifiers, and PREFIX:CODE cross-references
+# (e.g. BAMS:MEnt, BM:Tel-OLT — external IDs must not be "corrected")
 ignore-regex = https?://\S+|\b[a-z]+[A-Z]\w*\b|\b[A-Z][a-z]+[A-Z]\w*\b|\b[A-Z]{2,}:[\w-]+
-# Domain vocabulary that codespell flags as typos but is legitimate here:
-#   Anatomical / Latin terms recurring in non-uberon-edit content
-#   (bridge/external-disjoints.obo, src/patterns/data/**/*.tsv, etc.):
-#     mater      - dura/pia/arachnoid mater (meninges)
-#     vas        - vas deferens etc.
-#     processus  - Latin "process"
-#     regio      - anatomical region (Latin)
-#     collum     - Latin "neck"
-#   Ontology terminology:
-#     disjointness - "disjointness axiom" (OWL/OBO term)
-#   Curated-data / code noise:
-#     anc          - Prolog predicate name in *.pro scripts
-#     nd           - Prolog predicate (nd/4 in src/scripts/namediff.pro) and
-#                    GO evidence code "ND" (No Data) in uberon.references
-#     heterogenous, homogenous - accepted variants
-ignore-words-list = mater,vas,processus,regio,collum,disjointness,anc,nd,heterogenous,homogenous
+# Domain vocabulary that codespell flags as typos but is legitimate here.
+# Each entry has an inline comment explaining why it is protected.
+ignore-words-list =
+  # dura/pia/arachnoid mater (meninges)
+  mater,
+  # vas deferens etc. (Latin "vessel")
+  vas,
+  # Latin "process" — anatomical processes (processus mastoideus etc.)
+  processus,
+  # anatomical region (Latin regio — regio temporalis etc.)
+  regio,
+  # Latin "neck" — collum femoris, collum mallei, etc.
+  collum,
+  # "disjointness axiom" — OWL/OBO ontology terminology
+  disjointness,
+  # Prolog predicate name in src/scripts/*.pro
+  anc,
+  # ANS (Autonomic Nervous System) abbreviation in comments
+  ans,
+  # Prolog predicate (nd/4) and GO evidence code "ND" (No Data)
+  nd,
+  # accepted variant spellings used in ontology definitions
+  heterogenous,
+  homogenous,
+  # discus intervertebralis (FMA:TA Latin synonym) — not "discuss"
+  discus,
+  # crus horizontale striae diagonalis (FMA:TA) — not "horizontal"
+  horizontale,
+  # s. durae matris (Latin genitive of mater) — not "matrix"
+  matris,
+  # pyramides renales (FMA:TA Latin plural) — not "pyramids"
+  pyramides,
+  # solum anterius (Latin "floor/base") — not "solemn"
+  solum,
+  # in statu nascendi (Latin phrase "in state of being born") — not "status/statue"
+  statu,
+  # stilus columellare (Latin form) — not "stylus"
+  stilus,
+  # citation tag split mid-word: "activit[MP:0009965]y" — not "activist"
+  activit,
+  # undertail covert (ornithological feather term) — not "convert/covet"
+  covert,
+  # interpolar part of spinal trigeminal nucleus — not "interpolator"
+  interpolar,
+  # mane (synonym for pelage / hair coat) — not "main/many"
+  mane,
+  # anatomical landmark on mastoid process (UBERON:7500127, curator-confirmed) — not "option"
+  otion,
+  # thermoregulatory panting in taxon_notes — not "painting"
+  panting,
+  # "ductus remains pervious" (medical: patent/open) — not "previous"
+  pervious,
+  # "not preformed in cartilage" (embryology) — not "performed"
+  preformed,
+  # sweat gland of eyelid / eyelid stye (hordeolum) — not "style"
+  stye,
+  # anatomical trough at base of papillae — not "through"
+  trough,
+  # "auxillery nerve" RELATED syn of axillary nerve — codespell would wrongly fix to "auxiliary"
+  auxillery,
+  # "cementary gland" RELATED from BTO:0002738 (cement-secreting gland) — not "cemetery"
+  cementary,
+  # "collumn dentis" EXACT from ncithesaurus:Collum_Dentis — not "column"
+  collumn,
+  # "scala medias" EXACT from BIRNLEX:2562 — not "media/mediums"
+  medias,
+  # "sement" RELATED (archaic synonym for copulatory plug)
+  sement,
+  # "vermillion" RELATED alternate spelling of lip vermilion
+  vermillion,
+  # "branche ventrale de l'urohyal" (French synonym, PSPUB source)
+  branche,
+  # "Sciences de la vie" (French: "life sciences") in citation title
+  vie,
+  # Apical Ectodermal Ridge (AER, e.g. "aer pectoral fin")
+  aer,
+  # ALLS: ferret visual cortex region abbreviation
+  alls,
+  # Van der Loos (proper name in citations)
+  loos,
+  # P.R. Manger (neuroscientist, proper name in citations)
+  manger,
+  # OLT: olfactory trigone abbreviation (BIRNLEX)
+  olt,
+  # ONL: outer nuclear layer abbreviation
+  onl,
+  # OT: oxytocin/vasopressin; "Ot" = otion landmark abbreviation
+  ot,
+  # TE: author initial (e.g. "Spencer TE") in citations
+  te,
+  # UE: utriculo-endolymphatic valve abbreviation
+  ue,
+  # UES: upper esophageal sphincter abbreviation
+  ues

--- a/src/ontology/uberon-edit.obo
+++ b/src/ontology/uberon-edit.obo
@@ -1643,7 +1643,7 @@ is_a: UBERON:0000479 ! tissue
 relationship: has_part GO:0070451 ! cell hair
 relationship: part_of UBERON:0001846 ! internal ear
 property_value: curator_notes "this refers to the inner ear structure, not the macula of the retina. We follow ZFA in including a grouping class for the macula of utricle and sacule" xsd:string
-property_value: external_definition "Patches of thickened, pseudostratified epithelium of the inner ear, consisting of regular arrays of sensory hair cells interspersed with supporting cells. Each patch has its own charcteristic shape and polarity pattern. (See Anatomical Atlas entry for sensory patches of the ear by T. Whitfield.)[TAO]" xsd:string {date_retrieved="2012-08-14", external_class="TAO:0000386", ontology="TAO", source="ZFIN:curator"}
+property_value: external_definition "Patches of thickened, pseudostratified epithelium of the inner ear, consisting of regular arrays of sensory hair cells interspersed with supporting cells. Each patch has its own characteristic shape and polarity pattern. (See Anatomical Atlas entry for sensory patches of the ear by T. Whitfield.)[TAO]" xsd:string {date_retrieved="2012-08-14", external_class="TAO:0000386", ontology="TAO", source="ZFIN:curator"}
 property_value: has_relational_adjective "macular" xsd:string
 
 [Term]
@@ -4383,7 +4383,7 @@ name: body wall
 def: "The external portion of an animal body derived from ectoderm and mesoderm layers that encloses the body cavity." [MP:0003385]
 subset: pheno_slim
 synonym: "trunk wall" NARROW [FMA:10427]
-synonym: "wall fo trunk" EXACT [FMA:10427]
+synonym: "wall of trunk" EXACT [FMA:10427]
 synonym: "wall of trunk" NARROW [FMA:10427]
 xref: BTO:0000139
 xref: EMAPA:32761
@@ -4897,9 +4897,9 @@ synonym: "ophthalmic division [Va]" EXACT [FMA:52621]
 synonym: "ophthalmic division of fifth cranial nerve" EXACT [FMA:52621]
 synonym: "ophthalmic division of trigeminal nerve (V1)" EXACT [FMA:52621]
 synonym: "ophthalmic division of trigeminal nerve (Va)" EXACT [FMA:52621]
+synonym: "ophthalmic nerve" EXACT [Wikipedia:Ophthalmic_nerve]
 synonym: "ophthalmic nerve [V1]" EXACT [FMA:52621]
 synonym: "ophthalmic nerve [Va]" EXACT [FMA:52621]
-synonym: "opthalmic nerve" EXACT [Wikipedia:Ophthalmic_nerve]
 synonym: "profundal nerve" RELATED [http://orcid.org/0000-0002-6601-2165]
 synonym: "profundus" RELATED [http://palaeos.com/vertebrates/glossary/glossaryPo.html]
 synonym: "profundus nerve" RELATED [http://palaeos.com/vertebrates/glossary/glossaryPo.html]
@@ -6383,7 +6383,7 @@ disjoint_from: UBERON:0002708 {source="lexical"} ! posterior periventricular nuc
 id: UBERON:0000435
 name: lateral tuberal nucleus
 def: "Nerve cell nuclei situated ventrally in the intermediate hypothalamic region, mainly in the lateral hypothalamic area." [BTO:0002481]
-comment: The lateral tuberal nucleus is specific to humans and higher primates, however, this term is sometimes used loosely. If using for rodents, please use tuberal nucleus (sensu Rodentia) instead. If refering to the nucleus lateralis tuberis of fish, please use nucleus lateralis tuberis system (sensu Teleostei) {xref="PMID:29976824", xref="PMID:29976812", xref="DOI:10.1016/0016-6480(71)90165-1", xref="PMID:1362279"}
+comment: The lateral tuberal nucleus is specific to humans and higher primates, however, this term is sometimes used loosely. If using for rodents, please use tuberal nucleus (sensu Rodentia) instead. If referring to the nucleus lateralis tuberis of fish, please use nucleus lateralis tuberis system (sensu Teleostei) {xref="PMID:29976824", xref="PMID:29976812", xref="DOI:10.1016/0016-6480(71)90165-1", xref="PMID:1362279"}
 synonym: "lateral tuberal hypothalamic nuclei" EXACT [FMA:62336]
 synonym: "lateral tuberal nuclear complex" EXACT [BIRNLEX:1206]
 synonym: "lateral tuberal nuclei" EXACT [FMA:62336]
@@ -7546,7 +7546,7 @@ property_value: external_definition "Unilaminar epithelium that consists of a si
 [Term]
 id: UBERON:0000488
 name: atypical epithelium
-def: "Epithelium that consists of epithelial cells not arranged in one ore more layers." [http://orcid.org/0000-0001-9114-8737]
+def: "Epithelium that consists of epithelial cells not arranged in one or more layers." [http://orcid.org/0000-0001-9114-8737]
 subset: vertebrate_core
 synonym: "atypical epithelia" RELATED OMO:0003004 [ZFA:0001493]
 synonym: "heterogenous epithelium" EXACT []
@@ -8484,7 +8484,7 @@ relationship: part_of UBERON:0002104 ! visual system
 property_value: editor_note "Do not classify under 'cranial nerve', as this is not a true nerve - should be classified as evaginated sensory afferent[ISBN:0471888893]" xsd:string
 property_value: external_definition "A collection of nerve cells that project visual information from the eyes to the brain. (Source: BioGlossary, www.Biology-Text.com)[TAO]" xsd:string {date_retrieved="2012-08-14", external_class="TAO:0000435", ontology="TAO", source="ZFIN:curator"}
 property_value: external_definition "Fibrous, somatic sensory element covered by a fibrous connective-tissue sheath and is continuous with the layer of nerve cells on the inner surface of the eye.[AAO]" xsd:string {date_retrieved="2012-06-20", external_class="AAO:0010345", ontology="AAO", source="AAO:EJS"}
-property_value: external_ontology_notes "(relaion to eye): MA, XAO, AAO and BTO consider this part of the eye. This is in contrast to GO, FMA, EHDAA2 (FMA has a class 'intra-ocular part of optic nerve' which represents the region of overlap). Relation to brain: part of diencephalon in EHDAA2, ZFA. In NIF, has the optic nerve root as part, which is a feature part of the diencphalon" xsd:string {external_ontology="MA"}
+property_value: external_ontology_notes "(relation to eye): MA, XAO, AAO and BTO consider this part of the eye. This is in contrast to GO, FMA, EHDAA2 (FMA has a class 'intra-ocular part of optic nerve' which represents the region of overlap). Relation to brain: part of diencephalon in EHDAA2, ZFA. In NIF, has the optic nerve root as part, which is a feature part of the diencphalon" xsd:string {external_ontology="MA"}
 property_value: homology_notes "(...) an essentially similar sequence of events occurs during the embryonic development of the vertebrate eye. The eye initially develops as a single median evagination of the diencephalon that soon bifurcates to form the paired optic vesicles. As each optic vesicle grows towards the body surface, its proximal part narrows as the optic stalk, and its distal part invaginates to form a two-layered optic cup (reference 1); The (optic) stalk persists as the optic nerve (reference 2).[well established][VHOG]" xsd:string {date_retrieved="2012-09-17", external_class="VHOG:0000543", ontology="VHOG", source="ISBN:978-0030223693 Liem KF, Bemis WE, Walker WF, Grande L, Functional Anatomy of the Vertebrates: An Evolutionary Perspective (2001) p.429, http://medical-dictionary.thefreedictionary.com/optic+stalk", source="http://bgee.unil.ch/"}
 
 [Term]
@@ -9140,7 +9140,7 @@ relationship: part_of UBERON:0010409 {source="MA"} ! ocular surface region
 relationship: part_of UBERON:0012430 {source="FMA-isa"} ! tunica fibrosa of eyeball
 property_value: depiction "http://upload.wikimedia.org/wikipedia/commons/1/1e/Schematic_diagram_of_the_human_eye_en.svg" xsd:anyURI
 property_value: has_relational_adjective "corneal" xsd:string
-property_value: taxon_notes "Compared to terrestial animals, the cornea of zebrafish is relatively flat. It consists of nonpigmented, stratified squamous nonkeratinizing epithelial cells, attached to a thick basement membrane that is considered to be analogous to the Bowman's membrane in mammals. In fish, and aquatic vertebrates in general, the cornea plays no role in focusing light, since it has virtually the same refractive index as water" xsd:string
+property_value: taxon_notes "Compared to terrestrial animals, the cornea of zebrafish is relatively flat. It consists of nonpigmented, stratified squamous nonkeratinizing epithelial cells, attached to a thick basement membrane that is considered to be analogous to the Bowman's membrane in mammals. In fish, and aquatic vertebrates in general, the cornea plays no role in focusing light, since it has virtually the same refractive index as water" xsd:string
 
 [Term]
 id: UBERON:0000965
@@ -9540,7 +9540,7 @@ relationship: distally_connected_to UBERON:0002387 ! pes
 relationship: part_of UBERON:0002103 ! hindlimb
 relationship: proximally_connected_to UBERON:0001464 ! hip
 property_value: homology_notes "Most anatomists now agree that the three proximal bones of the tetrapod limbs are homologous to the two or three proximal elements of the paired fin skeleton of other sarcopterygians, that is the humerus-femur, radius-tibia, and ulna-fibula.[well established][VHOG]" xsd:string {date_retrieved="2012-09-17", external_class="VHOG:0000345", ontology="VHOG", source="ISBN:978-0198540472 Janvier P, Early vertebrates (1996) p.268", source="http://bgee.unil.ch/"}
-property_value: terminology_notes "The term leg can mean: [1] an appendage on which an animal walks [2] the entire hindlimb of a tetrapod [3] the segment of a human leg between knee and ankle (cf FMA) [4] the region of a hindlimb include the stylopod and zeugopod, but excluding the autopod. We define this class as [4], and thus 'leg' is compltely analagous to 'arm'. For [1], see the class 'locomotive weight-bearing appendage'. For [2] we use 'hindlimb'. For" xsd:string {source="3"}
+property_value: terminology_notes "The term leg can mean: [1] an appendage on which an animal walks [2] the entire hindlimb of a tetrapod [3] the segment of a human leg between knee and ankle (cf FMA) [4] the region of a hindlimb include the stylopod and zeugopod, but excluding the autopod. We define this class as [4], and thus 'leg' is completely analogous to 'arm'. For [1], see the class 'locomotive weight-bearing appendage'. For [2] we use 'hindlimb'. For" xsd:string {source="3"}
 
 [Term]
 id: UBERON:0000979
@@ -10497,7 +10497,7 @@ xref: Wikipedia:Trachea
 is_a: UBERON:0003103 ! compound organ
 relationship: channel_for UBERON:0034874 ! air in respiratory system
 relationship: part_of UBERON:0001004 ! respiratory system
-property_value: curator_notes "This class generically groups trachea and analagous structures throughout metazoa. Consider renaming, as the term could be taken to mean lumen of tracheal system (e.g. in SNOMED). As a grouping class this is quite vague, as it is not clear where the airway begins and ends" xsd:string
+property_value: curator_notes "This class generically groups trachea and analogous structures throughout metazoa. Consider renaming, as the term could be taken to mean lumen of tracheal system (e.g. in SNOMED). As a grouping class this is quite vague, as it is not clear where the airway begins and ends" xsd:string
 
 [Term]
 id: UBERON:0001006
@@ -12825,7 +12825,7 @@ xref: XAO:0003078
 intersection_of: UBERON:0015010 ! sacral vertebra endochondral element
 intersection_of: composed_primarily_of UBERON:0002481 ! bone tissue
 relationship: develops_from UBERON:0010745 ! sacral vertebra cartilage element
-property_value: external_definition "Enlarged vertebra with transverse processes (diapophyses), and ocassionally ribs, that are modified and elaborated for support of the pelvic girdle.[AAO]" xsd:string {date_retrieved="2012-06-20", external_class="AAO:0000552", ontology="AAO", source="AAO:Duellman_and_Trueb_1994"}
+property_value: external_definition "Enlarged vertebra with transverse processes (diapophyses), and occasionally ribs, that are modified and elaborated for support of the pelvic girdle.[AAO]" xsd:string {date_retrieved="2012-06-20", external_class="AAO:0000552", ontology="AAO", source="AAO:Duellman_and_Trueb_1994"}
 
 [Term]
 id: UBERON:0001095
@@ -17611,7 +17611,7 @@ relationship: develops_from UBERON:0010718 ! pubic cartilage element
 relationship: in_lateral_side_of UBERON:0007832 ! pelvic girdle skeleton
 relationship: part_of UBERON:0001272 {source="FMA"} ! innominate bone
 relationship: part_of UBERON:0007832 {source="VSAO"} ! pelvic girdle skeleton
-property_value: external_definition "Paired, cartilaginous (ocassionally calcified) elements that form the ventral portion of the pelvic girdle. Each is located ventral to the acetabulum between the anteroventral margin of the ischium and the posteroventral margin of the illium. When the element calcifies or ossifies, its articulation with adjacent elements is difficult to distinguish. Both pubes are synchondrotically fused to one another.[AAO]" xsd:string {date_retrieved="2012-06-20", external_class="AAO:0000861", ontology="AAO", source="AAO:LAP"}
+property_value: external_definition "Paired, cartilaginous (occasionally calcified) elements that form the ventral portion of the pelvic girdle. Each is located ventral to the acetabulum between the anteroventral margin of the ischium and the posteroventral margin of the illium. When the element calcifies or ossifies, its articulation with adjacent elements is difficult to distinguish. Both pubes are synchondrotically fused to one another.[AAO]" xsd:string {date_retrieved="2012-06-20", external_class="AAO:0000861", ontology="AAO", source="AAO:LAP"}
 property_value: external_ontology_notes "isa bone zone in FMA" xsd:string {external_ontology="FMA"}
 
 [Term]
@@ -19165,7 +19165,7 @@ subset: uberon_slim
 synonym: "gland of urethra" EXACT [OBOL:automatic]
 synonym: "urethra gland" EXACT []
 synonym: "urethra gland (male or female)" EXACT []
-synonym: "urethral mucuous gland" EXACT []
+synonym: "urethral mucous gland" EXACT []
 xref: EMAPA:37784 {source="MA:th"}
 xref: FMA:19683
 xref: MA:0001688
@@ -21675,7 +21675,7 @@ property_value: homology_notes "Most anatomists now agree that the three proxima
 id: UBERON:0001441
 name: hindlimb skeleton
 def: "Subdivision of skeleton consisting of all skeletal elements in an hindlimb region." [https://orcid.org/0000-0002-6601-2165]
-comment: TOOD - find a home for: FMA:24140
+comment: TODO - find a home for: FMA:24140
 subset: uberon_slim
 synonym: "bones of lower limb" EXACT []
 synonym: "free lower limb skeleton" EXACT [FMA:24144]
@@ -22119,7 +22119,7 @@ synonym: "distal tarsal 3 bone" EXACT SYSTEMATIC [UBERON:cjm]
 synonym: "ectocuneiforme" EXACT [VSAO:0005054]
 synonym: "external cuneiform" EXACT [Wikipedia:Lateral_cuneiform_bone]
 synonym: "external cuneiform bone of foot" EXACT []
-synonym: "foor distal carpal bone 3" RELATED []
+synonym: "foot distal carpal bone 3" RELATED []
 synonym: "lateral cuneiform" EXACT []
 synonym: "lateral cuneiform bone" EXACT [FMA:24520]
 synonym: "os cuneiforme laterale" EXACT OMO:0003011 [NominaAnatomicaVeterinaria:2005]
@@ -23376,7 +23376,7 @@ intersection_of: UBERON:0006508 ! interosseous muscle of autopod
 intersection_of: part_of UBERON:0002398 ! manus
 relationship: has_muscle_insertion UBERON:0002234 ! proximal phalanx of manus
 relationship: has_muscle_origin UBERON:0002374 ! metacarpal bone
-property_value: external_definition "The interosseous muscles are flexor muscles of the manus that help support and flex the metacarpophalangeal joints. In some species the muscles are known as the suspensory ligaments. The muscles are found under the deep digital flexor tendon and originate from the base of each metacarpal bone. From its origin each muscle runs a short way down until it divides into two tendons that continue down and insert onto the base of its corresponding proximal phalanx. Each tendon has a sesamoid imbedded within it, that lie over the metacarpophalangeal joint. A small tendon, sometimes known as an extensor branch, continues to proceed from the base of each proximal phalanx and connects to the common extensor tendon. It has a small role to play in the extension of each phalanx. The main innervation of this muscle is via a branch of the ulnaris nerve[MURDOCH:1022]." xsd:string {source="MURDOCH:1022"}
+property_value: external_definition "The interosseous muscles are flexor muscles of the manus that help support and flex the metacarpophalangeal joints. In some species the muscles are known as the suspensory ligaments. The muscles are found under the deep digital flexor tendon and originate from the base of each metacarpal bone. From its origin each muscle runs a short way down until it divides into two tendons that continue down and insert onto the base of its corresponding proximal phalanx. Each tendon has a sesamoid embedded within it, that lie over the metacarpophalangeal joint. A small tendon, sometimes known as an extensor branch, continues to proceed from the base of each proximal phalanx and connects to the common extensor tendon. It has a small role to play in the extension of each phalanx. The main innervation of this muscle is via a branch of the ulnaris nerve[MURDOCH:1022]." xsd:string {source="MURDOCH:1022"}
 
 [Term]
 id: UBERON:0001503
@@ -26116,7 +26116,7 @@ name: ophthalmic artery
 def: "The ophthalmic artery is a branch of the internal carotid artery which supplies branches to supply the eye and other structures in the orbit. It enters the orbit together with the Optic nerve through the Optic foramen/canal. [WP,modified]." [Wikipedia:Ophthalmic_artery]
 subset: uberon_slim
 synonym: "arteria ophthalmica" RELATED OMO:0003011 [Wikipedia:Ophthalmic_artery]
-synonym: "opthalmic artery" RELATED [Wikipedia:Ophthalmic_artery]
+synonym: "ophthalmic artery" RELATED [Wikipedia:Ophthalmic_artery]
 xref: AAO:0010497
 xref: EHDAA2:0001300
 xref: EHDAA:7363
@@ -26908,7 +26908,7 @@ relationship: has_developmental_contribution_from UBERON:0005239 {source="Wikipe
 property_value: depiction "https://upload.wikimedia.org/wikipedia/commons/9/99/Gray778_Trigeminal.png" xsd:anyURI
 property_value: external_definition "Nerve consists of motor and sensory components. Ganglion cells of the sensory component form the proximal part of the trigeminal (Gasserian) ganglion. From the ganglion 3 major rami innervate jaws, snout, and buccal roof.[AAO]" xsd:string {date_retrieved="2012-06-20", external_class="AAO:0010470", ontology="AAO", source="AAO:EJS"}
 property_value: homology_notes "We conclude this section by listing some of the many synapomorphies of craniates, including (...) (5) cranial nerves (...) (reference 1); Phylogenetically, the cranial nerves are thought to have evolved from dorsal and ventral nerves of a few anterior spinal nerves that became incorporated into the braincase. Dorsal and ventral nerves fuse in the trunk but not in the head, and they produce two series: dorsal cranial nerves (V, VII, IX, and X) and ventral cranial nerves (III, IV, VI, and XIII) (reference 2).[well established][VHOG]" xsd:string {date_retrieved="2012-09-17", external_class="VHOG:0000704", ontology="VHOG", source="ISBN:978-0030223693 Liem KF, Bemis WE, Walker WF, Grande L, Functional Anatomy of the Vertebrates: An Evolutionary Perspective (2001) p.43, ISBN:978-0072528305 Kardong KV, Vertebrates: Comparative Anatomy, Function, Evolution (2006) p.625", source="http://bgee.unil.ch/"}
-property_value: taxon_notes "the ophthalmic usually usually merges with the other two. In some vertebrates, the ophthalmic emerges from the brain separately[Kardong] The trigeminal nerve has 3 branches in mammals - similar branches are present in nonmammalian vertebrates, but in some a separate profundus nerve that corresponds to opthalmic branch in mammls" xsd:string {source="ISBN:0471888893"}
+property_value: taxon_notes "the ophthalmic usually usually merges with the other two. In some vertebrates, the ophthalmic emerges from the brain separately[Kardong] The trigeminal nerve has 3 branches in mammals - similar branches are present in nonmammalian vertebrates, but in some a separate profundus nerve that corresponds to ophthalmic branch in mammls" xsd:string {source="ISBN:0471888893"}
 
 [Term]
 id: UBERON:0001646
@@ -29130,7 +29130,7 @@ property_value: depiction "http://upload.wikimedia.org/wikipedia/commons/3/30/Gr
 [Term]
 id: UBERON:0001718
 name: mesencephalic nucleus of trigeminal nerve
-def: "Elongated nucleus located in the midbrain tegmentum that receives proprioceptive input from both teh extraocular and the masticatory muscles. Contrary to the general rule, the cell bodies that give rise to these sensory fibers are located within the mesencephalic nucleus rather than in a peripheral ganglion. Some of the sensory fibers in the mesencephalic root give off collaterals to the trigeminal motor nucleus, thereby providing the anatomic basis for the monosynaptic jaw reflex. (Heimer, L. The Human Brain and Spinal Cord, 2nd ed. 1996, page 248)." [BIRNLEX:1010]
+def: "Elongated nucleus located in the midbrain tegmentum that receives proprioceptive input from both the extraocular and the masticatory muscles. Contrary to the general rule, the cell bodies that give rise to these sensory fibers are located within the mesencephalic nucleus rather than in a peripheral ganglion. Some of the sensory fibers in the mesencephalic root give off collaterals to the trigeminal motor nucleus, thereby providing the anatomic basis for the monosynaptic jaw reflex. (Heimer, L. The Human Brain and Spinal Cord, 2nd ed. 1996, page 248)." [BIRNLEX:1010]
 subset: pheno_slim
 subset: uberon_slim
 subset: vertebrate_core
@@ -29464,7 +29464,7 @@ property_value: development_notes "arise by inductive interactions between epith
 property_value: external_definition "A chemoreceptive organ.[AAO]" xsd:string {date_retrieved="2012-06-20", external_class="AAO:0010573", ontology="AAO", source="AAO:EJS"}
 property_value: external_definition "One of a number of receptor cell nests located in the epithelium of the papillae of the tongue and in the soft palate, epiglottis, and pharynx that mediate the sense of taste. [TFD][VHOG]" xsd:string {date_retrieved="2012-09-17", external_class="VHOG:0000130", ontology="VHOG", source="http://bgee.unil.ch/", source="http://medical-dictionary.thefreedictionary.com/taste+bud"}
 property_value: homology_notes "Experients in amphibia have shown that an intrinsic feature of the pharyngeal endoderm is its ability to generate taste buds and this capacity must have been acquired by the endoderm at the origin of the vertebrates.[well established][VHOG]" xsd:string {date_retrieved="2012-09-17", external_class="VHOG:0000130", ontology="VHOG", source="DOI:10.1046/j.1469-7580.2001.19910133.x Graham A. The development and evolution of the pharyngeal arches. J Anat (2001)", source="http://bgee.unil.ch/"}
-property_value: taxon_notes "In humans, saste buds may be found on the tongue, soft palatte, epiglottis and upper pharynx. In other species they may be found in more unusual places, such as the trunk, or on the barbels or fins of fish." xsd:string
+property_value: taxon_notes "In humans, saste buds may be found on the tongue, soft palate, epiglottis and upper pharynx. In other species they may be found in more unusual places, such as the trunk, or on the barbels or fins of fish." xsd:string
 
 [Term]
 id: UBERON:0001728
@@ -31185,7 +31185,7 @@ property_value: depiction "http://upload.wikimedia.org/wikipedia/commons/1/1e/Sc
 property_value: external_definition "A small pit in the center of the macula lutea, the area of clearest vision, where the retinal layers are spread aside, and light falls directly on the cones. [TFD][VHOG]" xsd:string {date_retrieved="2012-09-17", external_class="VHOG:0001572", ontology="VHOG", source="http://bgee.unil.ch/", source="http://medical-dictionary.thefreedictionary.com/fovea"}
 property_value: function_notes "high acuity vision" xsd:string
 property_value: has_relational_adjective "foveal" xsd:string
-property_value: homology_notes "Definition of fovea centralis should be considered here as 'an area centralis at the visual axis' (reference 1). There is an uncertaincy of the relation, because: 1.-The fovea first appeared in evolution in the temporal retina of fishes. Then, in birds, the nasal fovea and bifoveal system with nasal and temporal foveas developed. The fovea disappeared in primitive mammals, and reappeared in primates. A residue of the fovea is conserved in the visual streak, and the disappearance and reappearance of the fovea, in primitive mammals and primates respectively, correlates with degeneration and restoration of cone pigment genes in photoreceptors (reference 2). 2.-Many retinal features (foveas, trichromacy, midget pathways and associated cell types) appear specific to primates. This has led to investigations in parallel with other mammalian models such as cat or rabbit. Correlation of the results often proves to be difficult, since an evolutionary scenario with transitions between the mammalian models is largely lacking (reference 3).[uncertain][VHOG]" xsd:string {date_retrieved="2012-09-17", external_class="VHOG:0001572", ontology="VHOG", source="DOI:10.1017/S095252380623342X Ahnelt PK, Schubert C, Kübber-Heiss A, Schiviz A, Anger E, Independent variation of retinal S and M cone photoreceptor topographies: A survey of four families of mammals. Visual neuroscience (2006), http://www.ncbi.nlm.nih.gov/pubmed/11193946 Azuma N, Molecular cell biology on morphogenesis of the fovea and evolution of the central vision. Nihon Ganka Gakkai Zasshi (2000), DOI:10.1016/S1350-9462(00)00012-4 Ahnelt PK, Kolb H, The mammalian photoreceptor mosaic-adaptive design. Progress in Retinal and Eye Research (2000)", source="http://bgee.unil.ch/"}
+property_value: homology_notes "Definition of fovea centralis should be considered here as 'an area centralis at the visual axis' (reference 1). There is an uncertainty of the relation, because: 1.-The fovea first appeared in evolution in the temporal retina of fishes. Then, in birds, the nasal fovea and bifoveal system with nasal and temporal foveas developed. The fovea disappeared in primitive mammals, and reappeared in primates. A residue of the fovea is conserved in the visual streak, and the disappearance and reappearance of the fovea, in primitive mammals and primates respectively, correlates with degeneration and restoration of cone pigment genes in photoreceptors (reference 2). 2.-Many retinal features (foveas, trichromacy, midget pathways and associated cell types) appear specific to primates. This has led to investigations in parallel with other mammalian models such as cat or rabbit. Correlation of the results often proves to be difficult, since an evolutionary scenario with transitions between the mammalian models is largely lacking (reference 3).[uncertain][VHOG]" xsd:string {date_retrieved="2012-09-17", external_class="VHOG:0001572", ontology="VHOG", source="DOI:10.1017/S095252380623342X Ahnelt PK, Schubert C, Kübber-Heiss A, Schiviz A, Anger E, Independent variation of retinal S and M cone photoreceptor topographies: A survey of four families of mammals. Visual neuroscience (2006), http://www.ncbi.nlm.nih.gov/pubmed/11193946 Azuma N, Molecular cell biology on morphogenesis of the fovea and evolution of the central vision. Nihon Ganka Gakkai Zasshi (2000), DOI:10.1016/S1350-9462(00)00012-4 Ahnelt PK, Kolb H, The mammalian photoreceptor mosaic-adaptive design. Progress in Retinal and Eye Research (2000)", source="http://bgee.unil.ch/"}
 property_value: taxon_notes "The fovea is also a pit in the surface of the retinas of many types of fish, reptiles, and birds. Among mammals, it is found only in simian primates. The retinal fovea takes slightly different forms in different types of animals. For example, in primates, cone photoreceptors line the base of the foveal pit, the cells that elsewhere in the retina form more superficial layers having been displaced away from the foveal region during late fetal and early postnatal life. Other foveae may show only a reduced thickness in the inner cell layers, rather than an almost complete absence" xsd:string
 
 [Term]
@@ -31555,7 +31555,7 @@ relationship: has_quality PATO:0001548 ! quality of a liquid
 relationship: part_of UBERON:0001766 {notes="FMA def states A and P", notes="located_in in EHDAA2", source="VHOG"} ! anterior chamber of eyeball
 property_value: depiction "http://upload.wikimedia.org/wikipedia/commons/1/1e/Schematic_diagram_of_the_human_eye_en.svg" xsd:anyURI
 property_value: external_definition "The fluid produced by the ciliary process in the eye and occupying the anterior and posterior chambers. It provides nourishment for the lens and cornea and maintains the ocular pressure, and hence the optical integrity of the eyeball. [TFD][VHOG]" xsd:string {date_retrieved="2012-09-17", external_class="VHOG:0000548", ontology="VHOG", source="http://bgee.unil.ch/", source="http://medical-dictionary.thefreedictionary.com/aqueous+humour"}
-property_value: external_ontology_notes "FMA says A+P chambers, and MA states A chamber. ZFA states A chamber and tha it is produced primarily by dorsal ciliary epithelial cells.To be investigated across taxa." xsd:string {external_ontology="FMA"}
+property_value: external_ontology_notes "FMA says A+P chambers, and MA states A chamber. ZFA states A chamber and that it is produced primarily by dorsal ciliary epithelial cells.To be investigated across taxa." xsd:string {external_ontology="FMA"}
 property_value: homology_notes "(...) we reach the inescapable conclusion that the last common ancestor of jawless and jawed vertebrates already possessed an eye that was comparable to that of extant lampreys and gnathostomes. Accordingly, a vertebrate camera-like eye must have been present by the time that lampreys and gnathostomes diverged, around 500 Mya (reference 1); Although the eye varies greatly in adaptative details among vertebrates, its basic structure is the same in all. The human eye is representative of the design typical for a tetrapod. (...) A watery aqueous humor fills the spaces in the eye in front of the lens (...) (reference 2).[well established][VHOG]" xsd:string {date_retrieved="2012-09-17", external_class="VHOG:0000548", ontology="VHOG", source="DOI:10.1038/nrn2283 Lamb TD, Collin SP and Pugh EN Jr, Evolution of the vertebrate eye: opsins, photoreceptors, retina and eye cup. Nature Reviews Neuroscience (2007), ISBN:978-0030223693 Liem KF, Bemis WE, Walker WF, Grande L, Functional Anatomy of the Vertebrates: An Evolutionary Perspective (2001) p.424 and p.426 and p.429 and Figure 12-24", source="http://bgee.unil.ch/"}
 
 [Term]
@@ -33657,7 +33657,7 @@ property_value: homology_notes "All nuclei of the mammalian basal ganglia are al
 id: UBERON:0001875
 name: globus pallidus
 def: "Subcortical nucleus, functionally part of the basal ganglia, which consists of two segments the external (or lateral) and internal (or medial) separated by the medial medullary lamina in primates. In rodents, The globus pallidus lateral is separated from the medial segment by the fibers of the internal capsule/cerebral peduncle." [BIRNLEX:1234]
-comment: BTO and MA are inconsistent w.r.t striatum and pallidum being non-overlapping as in ABA. Note that we have pallidum as part_of basal gangion, so we can make the direct link to basal ganglion. ISBN:1588900649 says: ... a derivative of the diencephalon, seperates as a result of growing fibers of theinternal capsule and is finally displaced into telencephalon. only a small medial remnannt remains, the entopeduncular nucleus. The globus pallidus should be regarded as part of the subthalamus
+comment: BTO and MA are inconsistent w.r.t striatum and pallidum being non-overlapping as in ABA. Note that we have pallidum as part_of basal gangion, so we can make the direct link to basal ganglion. ISBN:1588900649 says: ... a derivative of the diencephalon, separates as a result of growing fibers of theinternal capsule and is finally displaced into telencephalon. only a small medial remnannt remains, the entopeduncular nucleus. The globus pallidus should be regarded as part of the subthalamus
 subset: efo_slim
 subset: pheno_slim
 subset: uberon_slim
@@ -35234,7 +35234,7 @@ property_value: depiction "http://upload.wikimedia.org/wikipedia/commons/6/64/Il
 property_value: editor_note "Originally this was classified as a female reproductive structure, as it was in the MP in 2011" xsd:string
 property_value: external_definition "Any of the milk-producing apocrine glands typically occurring in pairs in female mammals and consisting of lobes containing clusters of alveoli with a system of ducts to convey the milk to an external nipple or teat. [TFD][VHOG]" xsd:string {date_retrieved="2012-09-17", external_class="VHOG:0000398", ontology="VHOG", source="http://bgee.unil.ch/", source="http://medical-dictionary.thefreedictionary.com/mammary+gland"}
 property_value: external_ontology_notes "The BTO class represents the combination of nipple plus lobe" xsd:string
-property_value: external_ontology_notes "The FMA class represents an individule lobe. The nipple is not a part" xsd:string
+property_value: external_ontology_notes "The FMA class represents an individual lobe. The nipple is not a part" xsd:string
 property_value: external_ontology_notes "The MA class represents a composite structure, including the nipple, fat, connective tissue, smooth muscle as parts" xsd:string
 property_value: has_relational_adjective "mammary" xsd:string
 property_value: homology_notes "The detailed similarities of mammary glands in living monotremes, marsupials, and eutherians argue for a monophyletic origin of these glands, perhaps by the combination of parts of preexisting sebaceous and sweat glands.[well established][VHOG]" xsd:string {date_retrieved="2012-09-17", external_class="VHOG:0000398", ontology="VHOG", source="ISBN:978-0072528305 Kardong KV, Vertebrates: Comparative Anatomy, Function, Evolution (2006) p.224", source="http://bgee.unil.ch/"}
@@ -40721,7 +40721,7 @@ property_value: depiction "http://upload.wikimedia.org/wikipedia/commons/7/7c/Ap
 property_value: external_definition "Skeletal subdivision consisting of all the skeletal elements in the pectoral and pelvic appendage complexes.[VSAO]" xsd:string {date_retrieved="2012-08-14", external_class="VSAO:0000076", ontology="VSAO", source="PSPUB:0000170", source="https://orcid.org/0000-0002-6601-2165"}
 property_value: external_definition "Skeletal system that consists of the paired fins (pectoral or pelvic fins).[TAO]" xsd:string {date_retrieved="2012-08-14", external_class="TAO:0000027", ontology="TAO", source="TAO:wd"}
 property_value: external_definition "The pectoral and pelvic girdles, which articulate with the axial skeleton, together with their associated limbs, the forelimbs and hind limbs, form the appendicular skeleton.[AAO]" xsd:string {date_retrieved="2012-06-20", external_class="AAO:0000747", ontology="AAO", source="AAO:LAP"}
-property_value: external_ontology_notes "ontologies differ in whether they treat the term appendicular skeleton as being the entire set of bones in the limbs, or whether the fore and hind limbs/fins are treated as seperate appendicular skeletons. Here we follow FMA, and treat the appendicular skeleton as the sum total of skeletal elements in the organism (this is evidenced by the fact that in FMA, skeleton of left/right upper/lower limb is part_of a appendicular skeleton, and subtypes of 'subdivision of appendicular skeleton'). We have separate classes such as 'skeleton of limb', and 'skeleton of hindlimb' for the 4 parts of the appendicular skeleton. In future the ZFA/TAO classes may be moved." xsd:string {external_ontology="FMA"}
+property_value: external_ontology_notes "ontologies differ in whether they treat the term appendicular skeleton as being the entire set of bones in the limbs, or whether the fore and hind limbs/fins are treated as separate appendicular skeletons. Here we follow FMA, and treat the appendicular skeleton as the sum total of skeletal elements in the organism (this is evidenced by the fact that in FMA, skeleton of left/right upper/lower limb is part_of a appendicular skeleton, and subtypes of 'subdivision of appendicular skeleton'). We have separate classes such as 'skeleton of limb', and 'skeleton of hindlimb' for the 4 parts of the appendicular skeleton. In future the ZFA/TAO classes may be moved." xsd:string {external_ontology="FMA"}
 property_value: seeAlso "https://github.com/obophenotype/uberon/wiki/Appendages-and-the-appendicular-skeleton" xsd:anyURI
 
 [Term]
@@ -41633,7 +41633,7 @@ property_value: taxon_notes "In some elasmobranchs, the left ovary does not matu
 id: UBERON:0002120
 name: pronephros
 alt_id: UBERON:0005794
-def: "In mammals, the pronephros is the first of the three embryonic kidneys to be established and exists only transiently. In lower vertebrates such as fish and amphibia, the pronephros is the fully functional embryonic kidney and is indispensible for larval life[GO]." [GO:0048793, Wikipedia:Pronephros]
+def: "In mammals, the pronephros is the first of the three embryonic kidneys to be established and exists only transiently. In lower vertebrates such as fish and amphibia, the pronephros is the fully functional embryonic kidney and is indispensable for larval life[GO]." [GO:0048793, Wikipedia:Pronephros]
 comment: Once the more complex mesonephros forms the pronephros undergoes apoptosis in amphibians. In fishes the nephron degenerates but the organ remains and becomes a component of the immune system[Wikipedia:Pronephros]. // TODO - check developmental relationships. Note that we previously include the ZFA/XAO terms under the more specific 'pronephric kidney', but these are now merged. TODO GCI: relationship: capable_of GO:0030104
 subset: efo_slim
 subset: organ_slim
@@ -42657,7 +42657,7 @@ xref: Wikipedia:Superior_cerebellar_peduncle
 is_a: UBERON:0007416 ! cerebellar peduncle
 property_value: depiction "http://upload.wikimedia.org/wikipedia/commons/9/97/Gray704.png" xsd:anyURI
 property_value: editor_note "we follow NIF in dividing this into 3 parts. This allows for consistency with ABA" xsd:string
-property_value: external_ontology_notes "we make the TAO class disjoint for now as it's not clear if this is the analagous structure" xsd:string {external_ontology="TAO"}
+property_value: external_ontology_notes "we make the TAO class disjoint for now as it's not clear if this is the analogous structure" xsd:string {external_ontology="TAO"}
 
 [Term]
 id: UBERON:0002151
@@ -42812,7 +42812,7 @@ relationship: mutually_spatially_disjoint_with UBERON:0002870 {source="ABA"} ! d
 relationship: mutually_spatially_disjoint_with UBERON:0002871 {source="ABA"} ! hypoglossal nucleus
 relationship: mutually_spatially_disjoint_with UBERON:0002872 {source="ABA"} ! inferior salivatory nucleus
 relationship: mutually_spatially_disjoint_with UBERON:0002877 {source="ABA"} ! parasolitary nucleus
-property_value: external_ontology_notes "in ABA this is disjoint from MDR, but we relax this here to accomodate FMA" xsd:string {external_ontology="ABA"}
+property_value: external_ontology_notes "in ABA this is disjoint from MDR, but we relax this here to accommodate FMA" xsd:string {external_ontology="ABA"}
 
 [Term]
 id: UBERON:0002155
@@ -43291,7 +43291,7 @@ relationship: contributes_to_morphology_of UBERON:0002167 ! right lung
 [Term]
 id: UBERON:0002171
 name: lower lobe of right lung
-def: "The lobe of the right lung that is furtherst from the head." [https://orcid.org/0000-0002-6601-2165]
+def: "The lobe of the right lung that is furthest from the head." [https://orcid.org/0000-0002-6601-2165]
 subset: pheno_slim
 synonym: "inferior lobe of right lung" EXACT [FMA:7337]
 synonym: "lobus inferior (pulmo dexter)" EXACT OMO:0003011 [FMA:7337, FMA:TA]
@@ -43977,7 +43977,7 @@ relationship: in_taxon NCBITaxon:7742 {source="PMID:19084529"} ! Vertebrata <ver
 relationship: part_of UBERON:0000007 ! pituitary gland
 property_value: depiction "http://upload.wikimedia.org/wikipedia/commons/f/fb/Gray1181.png" xsd:anyURI
 property_value: external_definition "Region of the pituitary gland derived from the buccal protrusion consisting of three regions.[AAO]" xsd:string {date_retrieved="2012-06-20", external_class="AAO:0010540", ontology="AAO", source="AAO:BJB"}
-property_value: external_definition "The anterior lobe of the hypophysis (pituitary gland). This lobe contains cells that produce prolactin, growth hormone, thyroid-stimulating hormone, follicle-stimulating hormone and proopiomelanocortin. In contrast to mamalian vertebrates, the adenohypophysis remains in a subepithelial position and there exists no equivalent of Rathke's pouch in zebrafish. Herzog et al, 2004.[TAO]" xsd:string {date_retrieved="2012-08-14", external_class="TAO:0001282", ontology="TAO", source="ZFIN:curator"}
+property_value: external_definition "The anterior lobe of the hypophysis (pituitary gland). This lobe contains cells that produce prolactin, growth hormone, thyroid-stimulating hormone, follicle-stimulating hormone and proopiomelanocortin. In contrast to mammalian vertebrates, the adenohypophysis remains in a subepithelial position and there exists no equivalent of Rathke's pouch in zebrafish. Herzog et al, 2004.[TAO]" xsd:string {date_retrieved="2012-08-14", external_class="TAO:0001282", ontology="TAO", source="ZFIN:curator"}
 property_value: homology_notes "It (the hypophysis) develops embryonically in all vertebrates from two ectodermal evaginations that meet and unite. An infundibulum grows ventrally from the diencephalon of the brain, and Rathke's pouch extends dorsally from the roof of the developing mouth, or stomodaeum. The infundibulum remains connected to the floor of the diencephalon, which becomes the hypothalamus, and gives rise to the part of the gland known as the neurohypophysis. (...) Rathke's pouch loses its connection with the stomodaeum in most adult vertebrates and gives rise to the rest of the gland, the adenohypophysis. (...) A well-developed hypophyseal system with functional connections to the hypothalamus is unique to craniates.[well established][VHOG]" xsd:string {date_retrieved="2012-09-17", external_class="VHOG:0000141", ontology="VHOG", source="ISBN:978-0030223693 Liem KF, Bemis WE, Walker WF, Grande L, Functional Anatomy of the Vertebrates: An Evolutionary Perspective (2001) p.510 and Figure 15-5", source="http://bgee.unil.ch/"}
 property_value: taxon_notes "In contrast to mammalian vertebrates, the adenohypophysis remains in a subepithelial position and there exists no equivalent of Rathke's pouch in zebrafish" xsd:string {source="ZFA"}
 property_value: taxon_notes "While in most basal fish and tetrapods the adenohypophyseal anlagen invaginates to form Rathke's pouch, in teleost fish the adenohypophyseal placode does not invaginate but rather maintains its initial organization forming a solid structure in the head[NCBIBook:NBK53175]." xsd:string
@@ -45109,7 +45109,7 @@ xref: SCTID:368046006
 xref: Wikipedia:Floating_rib
 is_a: UBERON:0002238 ! false rib
 property_value: depiction "http://upload.wikimedia.org/wikipedia/commons/f/f7/Skeleton_woman_back.png" xsd:anyURI
-property_value: terminology_notes "We synonymize 'free rib' with 'floating rib' - this case it referes to caudal ribs, but you can have free ribs (i.e. non-attached ventrally) in other places . Should we just synonymize this with 'floating rib'? see Primate Anatomy: An Introduction by Friderun Ankel-Simons pg. 275" xsd:string
+property_value: terminology_notes "We synonymize 'free rib' with 'floating rib' - this case it refers to caudal ribs, but you can have free ribs (i.e. non-attached ventrally) in other places . Should we just synonymize this with 'floating rib'? see Primate Anatomy: An Introduction by Friderun Ankel-Simons pg. 275" xsd:string
 
 [Term]
 id: UBERON:0002240
@@ -45520,7 +45520,7 @@ relationship: part_of UBERON:0000004 ! nose
 relationship: part_of UBERON:0009954 ! vomeronasal system
 property_value: depiction "http://upload.wikimedia.org/wikipedia/commons/8/84/Gray51.png" xsd:anyURI
 property_value: external_definition "An organ thought to supplement the olfactory system in receiving pheromonic communication. The sensory part of the organ is in two long, thin sacs, situated on either side of the nasal septum at its base. [TFD][VHOG]" xsd:string {date_retrieved="2012-09-17", external_class="VHOG:0000665", ontology="VHOG", source="http://bgee.unil.ch/", source="http://medical-dictionary.thefreedictionary.com/vomeronasal+organ"}
-property_value: homology_notes "(...) the vomeronasal organ is known only in some tetrapods. It is absent in most turtles, crocodiles, birds, some bats, and aquatic mammals. In amphibians, it is in a recessed area off the main nasal cavity. (...) In mammals possesing this organ, it is an isolated area of olfactory membrane within the nasal cavity that is usually connected to the mouth via the nasopalatine duct (reference 1); The opinions concerning the presence and functioning of the vomeronasal organ in humans are controversial. The vomeronasal cavities appear early in human foetuses. (...) Historical examination of the nasal septum revealed the presence of vomeronasal cavities in approximately 70% of adults. In contrast to the situation in other mammals, the organ is not supported by a rigid tube of bone or cartilage (reference 2); (...) the best evidence for the homology of the human VNO to that of other primates (and of mammals in general) is ontogenetic in nature, based on a common embryonic origin from a thickening (vomeronasal primordium) on the medial aspect of each olfactory pit (reference 3); (...) suggesting that lungfish possess a region homologous to the accessory olfactory bulb of tetrapods. Based on these results, it seems appropriate to refer to the recess epithelium as a primordium of the vomeronasal organ (reference 4). [debated][VHOG]" xsd:string {date_retrieved="2012-09-17", external_class="VHOG:0000665", ontology="VHOG", source="ISBN:978-0072528305 Kardong KV, Vertebrates: Comparative Anatomy, Function, Evolution (2006) p.669 (ref.1), http://www.ncbi.nlm.nih.gov/pubmed/9866877 Doving KB, Trotier D, Review: Structure and function of the vomeronasal organ. The Journal of Experimental Biology (1998) (ref.2), DOI:10.1046/j.1469-7580.2001.19810077.x Smith TD, Siegel MI, Bonar CJ, Bhatnagar KP, Mooney MP, Burrows AM, Smith MA, Maico LM, The existence of the vomeronasal organ in postnatal chimpanzees and evidence for its homology with that of humans. J Anat (2001) (ref.3) , DOI:10.1002/ar.22415 Nakamuta S, Nakamuta N, Taniguchi K, Taniguchi K, Histological and ultrastructural characteristics of the primordial vomeronasal organ in lungfish. Anat Rec (Hoboken) (2012) (ref.4)", source="http://bgee.unil.ch/"}
+property_value: homology_notes "(...) the vomeronasal organ is known only in some tetrapods. It is absent in most turtles, crocodiles, birds, some bats, and aquatic mammals. In amphibians, it is in a recessed area off the main nasal cavity. (...) In mammals possessing this organ, it is an isolated area of olfactory membrane within the nasal cavity that is usually connected to the mouth via the nasopalatine duct (reference 1); The opinions concerning the presence and functioning of the vomeronasal organ in humans are controversial. The vomeronasal cavities appear early in human foetuses. (...) Historical examination of the nasal septum revealed the presence of vomeronasal cavities in approximately 70% of adults. In contrast to the situation in other mammals, the organ is not supported by a rigid tube of bone or cartilage (reference 2); (...) the best evidence for the homology of the human VNO to that of other primates (and of mammals in general) is ontogenetic in nature, based on a common embryonic origin from a thickening (vomeronasal primordium) on the medial aspect of each olfactory pit (reference 3); (...) suggesting that lungfish possess a region homologous to the accessory olfactory bulb of tetrapods. Based on these results, it seems appropriate to refer to the recess epithelium as a primordium of the vomeronasal organ (reference 4). [debated][VHOG]" xsd:string {date_retrieved="2012-09-17", external_class="VHOG:0000665", ontology="VHOG", source="ISBN:978-0072528305 Kardong KV, Vertebrates: Comparative Anatomy, Function, Evolution (2006) p.669 (ref.1), http://www.ncbi.nlm.nih.gov/pubmed/9866877 Doving KB, Trotier D, Review: Structure and function of the vomeronasal organ. The Journal of Experimental Biology (1998) (ref.2), DOI:10.1046/j.1469-7580.2001.19810077.x Smith TD, Siegel MI, Bonar CJ, Bhatnagar KP, Mooney MP, Burrows AM, Smith MA, Maico LM, The existence of the vomeronasal organ in postnatal chimpanzees and evidence for its homology with that of humans. J Anat (2001) (ref.3) , DOI:10.1002/ar.22415 Nakamuta S, Nakamuta N, Taniguchi K, Taniguchi K, Histological and ultrastructural characteristics of the primordial vomeronasal organ in lungfish. Anat Rec (Hoboken) (2012) (ref.4)", source="http://bgee.unil.ch/"}
 property_value: taxon_notes "Generally formed only in tetrapods; lungfish have rudimentary VN organs; true VN organs are not normally found in recent fishes, birds, aquatic reptiles, aquatic mammals (Bertmar 1980). Humans: Its presence in many animals has been widely studied and the importance of the vomeronasal system to the role of reproduction and social behavior (through influence on anterior hypothalamus) has been shown in many studies. Its presence and functionality in humans was controversial, though most studies agree the organ regresses during fetal development. Many genes essential for VNO function in animals (such as TRPC2) are non-functional in humans (Liman ER. Use it or lose it: molecular evolution of sensory signaling in primates. Pflugers Arch. 2006;453(2):125-31.)" xsd:string
 
 [Term]
@@ -46506,7 +46506,7 @@ synonym: "aqueduct of Sylvius" EXACT []
 synonym: "aqueduct of Sylvius" RELATED [BAMS:AQ]
 synonym: "aqueductus mesencephali" EXACT OMO:0003011 [FMA:78467, FMA:TA]
 synonym: "aqueductus mesencephali" RELATED OMO:0003011 [Wikipedia:Cerebral_aqueduct]
-synonym: "cerebral aquaduct" EXACT [ZFA:0000159]
+synonym: "cerebral aqueduct" EXACT [ZFA:0000159]
 synonym: "cerebral aqueduct" EXACT [MA:0000208]
 synonym: "cerebral aqueduct of Sylvius" EXACT []
 synonym: "cerebral aqueduct proper" RELATED [BAMS:AQ]
@@ -46773,7 +46773,7 @@ property_value: has_relational_adjective "cerumenous" xsd:string
 id: UBERON:0002298
 name: brainstem
 def: "Stalk-like part of the brain that includes amongst its parts the medulla oblongata of the hindbrain and the tegmentum of the midbrain[ZFA,MP,generalized]." [ISBN:0471888893, MP:0005277, Wikipedia:Brainstem, ZFA:0001707]
-comment: 'brainstem' is a loose term that sometimes refers to the ventral parts o the brain except for any part of the telencephalon - sometimes it includes the diencephalon or subpallial telencephalon structures (ISBN:0471888893). Here we use it in a more restriced sense, to include only the medulla oblongata, pons (when present) and the midbrain tegmentum (following the ZFA definitions).
+comment: 'brainstem' is a loose term that sometimes refers to the ventral parts o the brain except for any part of the telencephalon - sometimes it includes the diencephalon or subpallial telencephalon structures (ISBN:0471888893). Here we use it in a more restricted sense, to include only the medulla oblongata, pons (when present) and the midbrain tegmentum (following the ZFA definitions).
 subset: efo_slim
 subset: pheno_slim
 subset: uberon_slim
@@ -48558,7 +48558,7 @@ property_value: function_notes "capable of inducing chondrogenesis - requires co
 [Term]
 id: UBERON:0002364
 name: tympanic membrane
-def: "A thin membrane that separates the external ear from the middle ear, consisting of two epithelia (one part of the the external accoustic meatus epithelium, the other part of the tympanic cavity epithelium) with a fibrous layer between them. Its function is to transmit sound from the air to the ossicles inside the middle ear. The malleus bone bridges the gap between the eardrum and the other ossicles. Rupture or perforation of the eardrum can lead to conductive hearing loss. [WP,unvetted]." [PMID:11237469, Wikipedia:Tympanic_membrane]
+def: "A thin membrane that separates the external ear from the middle ear, consisting of two epithelia (one part of the the external acoustic meatus epithelium, the other part of the tympanic cavity epithelium) with a fibrous layer between them. Its function is to transmit sound from the air to the ossicles inside the middle ear. The malleus bone bridges the gap between the eardrum and the other ossicles. Rupture or perforation of the eardrum can lead to conductive hearing loss. [WP,unvetted]." [PMID:11237469, Wikipedia:Tympanic_membrane]
 subset: organ_slim
 subset: pheno_slim
 subset: uberon_slim
@@ -48899,7 +48899,7 @@ disjoint_from: UBERON:0005351 ! paraflocculus
 relationship: contributes_to_morphology_of UBERON:0001735 ! tonsillar ring
 relationship: located_in UBERON:0000167 ! oral cavity
 relationship: part_of UBERON:0001735 {source="cjm"} ! tonsillar ring
-property_value: curator_notes "the term 'tonsil' can be ambiguous, sometimes refering specifically to the palatine tonsil, sometimes generically to include the cecal tonsils of avians. This class represents lymphoid tissue that is part of the tonsillar ring, in the mouth/throat region" xsd:string
+property_value: curator_notes "the term 'tonsil' can be ambiguous, sometimes referring specifically to the palatine tonsil, sometimes generically to include the cecal tonsils of avians. This class represents lymphoid tissue that is part of the tonsillar ring, in the mouth/throat region" xsd:string
 
 [Term]
 id: UBERON:0002373
@@ -50890,7 +50890,7 @@ relationship: part_of UBERON:0000369 {source="BTO"} ! corpus striatum
 relationship: part_of UBERON:0002420 {source="NIF"} ! basal ganglion
 relationship: part_of UBERON:0006098 {source="NIFSTD"} ! basal nuclear complex
 property_value: depiction "http://upload.wikimedia.org/wikipedia/commons/3/33/BrainCaudatePutamen.svg" xsd:anyURI
-property_value: external_ontology_notes "FMA divides 'striatum of neuraxis' into 4, neostriatum is seperate class. In NIF these are synonyms. TODO - check striatum vs corpus striatum see Wikipedia:Striatum#History. Check caudoputamen" xsd:string {external_ontology="FMA"}
+property_value: external_ontology_notes "FMA divides 'striatum of neuraxis' into 4, neostriatum is separate class. In NIF these are synonyms. TODO - check striatum vs corpus striatum see Wikipedia:Striatum#History. Check caudoputamen" xsd:string {external_ontology="FMA"}
 property_value: has_relational_adjective "striatal" xsd:string
 
 [Term]
@@ -51011,7 +51011,7 @@ relationship: mutually_spatially_disjoint_with UBERON:0002722 {source="ABA"} ! t
 relationship: mutually_spatially_disjoint_with UBERON:0002995 {source="ABA"} ! substantia nigra pars lateralis
 relationship: mutually_spatially_disjoint_with UBERON:0003040 {source="ABA"} ! central gray substance of midbrain
 relationship: part_of UBERON:0001943 {conflicts_with="DHBA", conflicts_with="EMAPA", conflicts_with="MA", source="FMA", source="HBA", source="NIFSTD"} ! midbrain tegmentum
-property_value: external_ontology_notes "ventral and anterior tegmental nucleus are synonyms in FMA, but we split these into seperate classes. This is consistent with MA, ABA and neuronames, which treat these as distinct (NN suggest the anterior is a rodent specific structure)" xsd:string {external_ontology="FMA"}
+property_value: external_ontology_notes "ventral and anterior tegmental nucleus are synonyms in FMA, but we split these into separate classes. This is consistent with MA, ABA and neuronames, which treat these as distinct (NN suggest the anterior is a rodent specific structure)" xsd:string {external_ontology="FMA"}
 property_value: location_notes "this is part of pons and brainstem in MA, but this leads to an inconsistency with ABA. We err on the side of safety, and exclude the relationship to the pons here." xsd:string
 
 [Term]
@@ -51238,7 +51238,7 @@ def: "The palatine glands form a continuous layer on its posterior surface and a
 subset: pheno_slim
 subset: uberon_slim
 synonym: "palatine glands set" EXACT []
-synonym: "palatine mucuous gland" EXACT []
+synonym: "palatine mucous gland" EXACT []
 synonym: "palatine salivary gland" EXACT []
 synonym: "salivary palatine gland" EXACT []
 xref: EMAPA:35643
@@ -51319,12 +51319,12 @@ property_value: editor_note "TODO - check mp syn" xsd:string
 [Term]
 id: UBERON:0002451
 name: endometrial gland
-def: "The mucous secreting gland associated with the mucuous membrane lining the uterus." [Wikipedia:Uterine_glands]
+def: "The mucous secreting gland associated with the mucous membrane lining the uterus." [Wikipedia:Uterine_glands]
 subset: organ_slim
 subset: pheno_slim
 subset: uberon_slim
 synonym: "endometrial gland" EXACT [BTO:0003433]
-synonym: "endometrial mucuous gland" EXACT []
+synonym: "endometrial mucous gland" EXACT []
 synonym: "endometrium gland" EXACT []
 synonym: "glandulae uterinae" EXACT OMO:0003011 [FMA:71647, FMA:TA]
 synonym: "glandulae uterinae" RELATED OMO:0003011 [Wikipedia:Uterine_glands]
@@ -51920,7 +51920,7 @@ synonym: "external globus pallidus" EXACT []
 synonym: "external pallidum" EXACT [BIRNLEX:1610]
 synonym: "external part of globus pallidus" EXACT [BIRNLEX:1610]
 synonym: "globus pallidus (rat)" RELATED OMO:0003011 [NeuroNames:232]
-synonym: "globus pallidus extermal segment" EXACT [BIRNLEX:1610]
+synonym: "globus pallidus external segment" EXACT [BIRNLEX:1610]
 synonym: "globus pallidus external segment" EXACT [BIRNLEX:1610, FMA:61839, MA:0002767]
 synonym: "globus pallidus externus" EXACT []
 synonym: "globus pallidus lateral part" RELATED [BAMS:GPl]
@@ -51973,9 +51973,9 @@ comment: See also: endopeduncular nucleus
 subset: uberon_slim
 synonym: "entopeduncular nucleus" RELATED [MA:0002768]
 synonym: "entopeduncular nucleus (monakow)" EXACT [FMA:61840]
-synonym: "globus pallidus inernal segment" RELATED [MA:0002768]
 synonym: "globus pallidus interna" EXACT OMO:0003011 []
 synonym: "globus pallidus internal segment" EXACT [FMA:61840]
+synonym: "globus pallidus internal segment" RELATED [MA:0002768]
 synonym: "globus pallidus internus" EXACT OMO:0003011 [FMA:61840]
 synonym: "globus pallidus medial part" RELATED [BAMS:GPm]
 synonym: "globus pallidus medial segment" EXACT [FMA:61840]
@@ -53513,7 +53513,7 @@ relationship: in_taxon NCBITaxon:7742 ! Vertebrata <vertebrates>
 relationship: never_in_taxon NCBITaxon:32524 {source="http://tolweb.org/Amniota"} ! Amniota
 relationship: overlaps UBERON:0000010 ! peripheral nervous system
 property_value: axiom_lost_from_external_ontology "relationship loss: is_formed_by lateral line receptor organ (AAO:0001001)[AAO]" xsd:string {date_retrieved="2012-06-20", external_class="AAO:0000975", ontology="AAO"}
-property_value: editor_note "we model this as being potentially inclusive of lateral line scales, and thus overlapping with the skeletal system. This is to accomodate TAO" xsd:string
+property_value: editor_note "we model this as being potentially inclusive of lateral line scales, and thus overlapping with the skeletal system. This is to accommodate TAO" xsd:string
 property_value: external_definition "A sensory system on the surface of the fish, consisting of small sensory patches (neuromasts) distributed in discrete lines over the body surface. The lateral line system is stimulated by local water displacements and vibrations, and detects propulsion of the fish through the water, as well as facilitating shoaling, prey capture, and predator and obstacle avoidance. (See Anatomical Atlas entry for lateral line by T. Whitfield.)[TAO]" xsd:string {date_retrieved="2012-08-14", external_class="TAO:0000034", ontology="TAO", source="ZFIN:curator"}
 property_value: external_definition "Sensory system which develops from a specialized series of dorsolateral ectodermal placodes named lateral line placodes.[AAO]" xsd:string {date_retrieved="2012-06-20", external_class="AAO:0000975", ontology="AAO", source="AAO:EJS"}
 property_value: homology_notes "The mechanosensory lateral line system is widely distributed in aquatic anamniotes. It was apparently present in the earliest vertebrates, as it has been identified in agnathans, cartilaginous fishes, bony fishes, lungfishes, the crossopterygian Latimeria, and aquatic amphibians.[well established][VHOG]" xsd:string {date_retrieved="2012-09-17", external_class="VHOG:0001243", ontology="VHOG", source="ISBN:978-0471210054 Butler AB and Hodos W, Comparative vertebrate neuroanatomy: Evolution and Adaptation (2005) p.195", source="http://bgee.unil.ch/"}
@@ -55246,7 +55246,7 @@ disjoint_from: UBERON:0003009 {source="lexical"} ! dorsal tegmental decussation
 [Term]
 id: UBERON:0002616
 name: regional part of brain
-def: "Anatomical divisons of the brain according to one or more criteria, e.g. cytoarchitectural, gross anatomy. Parts may be contiguous in 3D or not, e.g., basal ganglia." [BIRNLEX:1167]
+def: "Anatomical divisions of the brain according to one or more criteria, e.g. cytoarchitectural, gross anatomy. Parts may be contiguous in 3D or not, e.g., basal ganglia." [BIRNLEX:1167]
 subset: non_informative
 synonym: "anatomical structure of brain" EXACT [OBOL:automatic]
 synonym: "biological structure of brain" EXACT [OBOL:automatic]
@@ -55537,7 +55537,7 @@ relationship: part_of UBERON:0001927 ! medial geniculate body
 [Term]
 id: UBERON:0002628
 name: tail of caudate nucleus
-def: "Narrowest part of the caudate nucleus, roughtly defined as that portion that curves ventrally from the body of the caudate nucleus, following the temporal horn of the lateral ventricle." [BIRNLEX:1215]
+def: "Narrowest part of the caudate nucleus, roughly defined as that portion that curves ventrally from the body of the caudate nucleus, following the temporal horn of the lateral ventricle." [BIRNLEX:1215]
 synonym: "cauda (caudatus)" RELATED OMO:0003011 [NeuroNames:229]
 synonym: "cauda nuclei caudati" RELATED OMO:0003011 [NeuroNames:229]
 synonym: "caudate nuclear tail" EXACT [FMA:61854]
@@ -57719,13 +57719,13 @@ synonym: "central lobe marginal branch of cingulate sulcus" EXACT [OBOL:automati
 synonym: "central lobe marginal ramus of cingulate sulcus" EXACT [OBOL:automatic]
 synonym: "central lobe marginal sulcus" EXACT [OBOL:automatic]
 synonym: "circular fissure" EXACT [FMA:83753]
+synonym: "circular insular sulcus" EXACT [BIRNLEX:1475]
 synonym: "circular insular sulcus" RELATED [NeuroNames:51]
 synonym: "circular sulcus" RELATED [NeuroNames:51]
 synonym: "circular sulcus (of reil)" EXACT []
 synonym: "circular sulcus of the insula" RELATED [NeuroNames:51]
 synonym: "circuminsular fissure" RELATED [NeuroNames:51]
 synonym: "circuminsular sulcus" EXACT [FMA:83753]
-synonym: "ciruclar insular sulcus" EXACT [BIRNLEX:1475]
 synonym: "cortex of island marginal branch of cingulate sulcus" EXACT [OBOL:automatic]
 synonym: "cortex of island marginal ramus of cingulate sulcus" EXACT [OBOL:automatic]
 synonym: "cortex of island marginal sulcus" EXACT [OBOL:automatic]
@@ -63441,7 +63441,7 @@ relationship: part_of UBERON:0002733 {source="FMA"} ! intralaminar nuclear group
 [Term]
 id: UBERON:0002973
 name: parahippocampal gyrus
-def: "Component of the temporal lobe on the mesial surface, posterior to the entorhinal cortex. The rostral and caudal boundaries are the posterior end of the netorhinal cortex and the caudal portion of the hippocampus, respectively. The medial boudnary is designated as the medial aspect off the temporal lobe and the lateral boundary is the collateral sulcus (Christine Fennema-Notestine)." [BIRNLEX:807]
+def: "Component of the temporal lobe on the mesial surface, posterior to the entorhinal cortex. The rostral and caudal boundaries are the posterior end of the netorhinal cortex and the caudal portion of the hippocampus, respectively. The medial boundary is designated as the medial aspect off the temporal lobe and the lateral boundary is the collateral sulcus (Christine Fennema-Notestine)." [BIRNLEX:807]
 subset: uberon_slim
 synonym: "gyrus hippocampi" RELATED OMO:0003011 [NeuroNames:164]
 synonym: "gyrus parahippocampalis" RELATED OMO:0003011 [Wikipedia:Parahippocampal_gyrus]
@@ -63770,7 +63770,7 @@ relationship: part_of UBERON:0002736 {source="NIFSTD"} ! lateral nuclear group o
 [Term]
 id: UBERON:0002985
 name: ventral nucleus of medial geniculate body
-def: "Ventral division of medial geniculate body, first described by Morest (1964) in the cat, but found in primate, mouse and rat as well. It begins midway in the posterior third of the medial geniculate in the cat and is prominant anteriorly. The boundary between the dorsal and ventral divisions is demarcated in rat by a thick horizontally oriented axon bundle, the midgeniculate bundle (Webster, 1995, fig 16)." [BIRNLEX:845]
+def: "Ventral division of medial geniculate body, first described by Morest (1964) in the cat, but found in primate, mouse and rat as well. It begins midway in the posterior third of the medial geniculate in the cat and is prominent anteriorly. The boundary between the dorsal and ventral divisions is demarcated in rat by a thick horizontally oriented axon bundle, the midgeniculate bundle (Webster, 1995, fig 16)." [BIRNLEX:845]
 synonym: "medial geniculate complex ventral part" RELATED [BAMS:MGv]
 synonym: "medial geniculate complex, ventral part" EXACT [FMA:62217]
 synonym: "medial geniculate nucleus ventral part" RELATED [BAMS:MGv]
@@ -79593,7 +79593,7 @@ xref: EMAPA:37874 {source="MA:th"}
 is_a: UBERON:0001474 ! bone element
 relationship: contributes_to_morphology_of UBERON:0001686 ! auditory ossicle bone
 relationship: part_of UBERON:0001689 ! malleus bone
-property_value: editor_note "To be revisted after a review of auditory ossicles" xsd:string
+property_value: editor_note "To be revisited after a review of auditory ossicles" xsd:string
 
 [Term]
 id: UBERON:0003967
@@ -82150,7 +82150,7 @@ property_value: external_definition "The outer layer the ventricular myocardium,
 id: UBERON:0004128
 name: optic vesicle
 def: "The optic vesicle is the evagination of neurectoderm that precedes formation of the optic cup[GO]. Portion of tissue that is comprised of neuroepitheium which has pinched off from the anterior neural keel and will form the optic cup[ZFA]." [GO:0003404, Wikipedia:Optic_vesicles]
-comment: Genes: Six3, Pax6, Rx1 are expressed together in the tip of the neural plate [ISBN:9780878932504 "Developmental Biology"]. Development notes: During subsequent develop- ment, the optic vesicle invaginates and becomes a two-layered structure with an inner neural retina and outer retinal pigment epithelium. As soon as the developing optic vesicle makes contact with the overlying ectoderm, it induces the ectoderm to thicken and form the lens placode [PMID:16496288]
+comment: Genes: Six3, Pax6, Rx1 are expressed together in the tip of the neural plate [ISBN:9780878932504 "Developmental Biology"]. Development notes: During subsequent development, the optic vesicle invaginates and becomes a two-layered structure with an inner neural retina and outer retinal pigment epithelium. As soon as the developing optic vesicle makes contact with the overlying ectoderm, it induces the ectoderm to thicken and form the lens placode [PMID:16496288]
 subset: pheno_slim
 subset: vertebrate_core
 synonym: "evagination" RELATED []
@@ -86071,7 +86071,7 @@ intersection_of: UBERON:0005769 ! basement membrane of epithelium
 intersection_of: attaches_to UBERON:0001772 ! corneal epithelium
 intersection_of: part_of UBERON:0000964 ! cornea
 property_value: external_definition "Acellular anatomical structure that is the zone of collagen fibers adjacent the basement membrane of the corneal epithelium.[TAO]" xsd:string {date_retrieved="2012-08-14", external_class="TAO:0002155", ontology="TAO", source="ZFIN:ZDB-PUB-061010-3"}
-property_value: taxon_notes "Compared to terrestial animals, the cornea of zebrafish is relatively flat. It consists of nonpigmented, stratified squamous nonkeratinizing epithelial cells, attached to a thick basement membrane that is considered to be analogous to the Bowman's membrane in mammals" xsd:string
+property_value: taxon_notes "Compared to terrestrial animals, the cornea of zebrafish is relatively flat. It consists of nonpigmented, stratified squamous nonkeratinizing epithelial cells, attached to a thick basement membrane that is considered to be analogous to the Bowman's membrane in mammals" xsd:string
 
 [Term]
 id: UBERON:0004374
@@ -90892,7 +90892,7 @@ property_value: depiction "http://upload.wikimedia.org/wikipedia/commons/b/b6/Il
 [Term]
 id: UBERON:0004723
 name: interlobular artery
-def: "The branches of the arcuate arteries of the kidney that radiate outward throught the renal columns and supply the glomeruli[MP]. The first set of renal bloodvessels, the interlobular arteries (or cortical radiate arteries, or cortical radial arteries), are given off at right angles from the side of the arcuate arteries looking toward the cortical substance, and pass directly outward between the medullary rays to reach the fibrous tunic, where they end in the capillary network of this part. These vessels do not anastomose with each other, but form what are called end-arteries. In their outward course they give off lateral branches; these are the afferent vessels for the renal corpuscles; they enter the capsule, and end in the glomerulus. From each tuft the corresponding efferent vessel arises, and, having made its egress from the capsule near to the point where the afferent vessel enters, breaks up into a number of branches, which form a dense plexus within Bowman's capsule." [MP:0011316, Wikipedia:Interlobular_arteries]
+def: "The branches of the arcuate arteries of the kidney that radiate outward through the renal columns and supply the glomeruli[MP]. The first set of renal bloodvessels, the interlobular arteries (or cortical radiate arteries, or cortical radial arteries), are given off at right angles from the side of the arcuate arteries looking toward the cortical substance, and pass directly outward between the medullary rays to reach the fibrous tunic, where they end in the capillary network of this part. These vessels do not anastomose with each other, but form what are called end-arteries. In their outward course they give off lateral branches; these are the afferent vessels for the renal corpuscles; they enter the capsule, and end in the glomerulus. From each tuft the corresponding efferent vessel arises, and, having made its egress from the capsule near to the point where the afferent vessel enters, breaks up into a number of branches, which form a dense plexus within Bowman's capsule." [MP:0011316, Wikipedia:Interlobular_arteries]
 subset: pheno_slim
 synonym: "arteriae corticales radiatae" RELATED OMO:0003011 [Wikipedia:Interlobular_arteries]
 synonym: "arteriae interlobulares renis" RELATED OMO:0003011 [Wikipedia:Interlobular_arteries]
@@ -91807,7 +91807,7 @@ synonym: "internal naris" BROAD [MA:0001323]
 synonym: "nasopharyngeal naris" RELATED []
 synonym: "posterior choana" RELATED [HP:0004496]
 synonym: "posterior naris" RELATED [VHOG:0000545]
-synonym: "posterior nasal apperture" EXACT [XAO:0000277]
+synonym: "posterior nasal aperture" EXACT [XAO:0000277]
 xref: AAO:0000093
 xref: EHDAA2:0000242
 xref: EHDAA:7842
@@ -91850,7 +91850,7 @@ relationship: composed_primarily_of UBERON:0011823 ! dense connective tissue
 relationship: has_part CHEBI:18085 ! glycosaminoglycan
 relationship: part_of UBERON:0001711 {source="FMA"} ! eyelid
 relationship: part_of UBERON:0003581 {source="cjm"} ! eyelid connective tissue
-property_value: taxon_notes "In most taxa (birds, mammals, lizards), the tarsal plate is described as a dense, fibrous connective tissue, possibly including cartilage, present within one or both of the upper and lower eyelids (Gau- thier et al., 1988; Rieppel, 2000). In humans, the tarsal plate of the upper eyelid is composed of collagens types I, III, and V, as well as glycosaminogly- cans (chondroitin sulphate 4 and 6), aggrecan, and cartilage oligomeric matrix proteins but lacks collagen type II as well as chondrocytes (Milz et al., 2005). Thus, for humans, the upper tarsal plate represents neither a truly fibrous nor a truly cartilagi- nous element but instead one that is composed of a unique transitional tissue (Milz et al., 2005). In many birds, lizards, and Sphenodon (the tuatara), the upper eyelid has lim- ited mobility and a putative tarsal plate is instead found within the lower eyelid (Underwood, 1970; Gau- thier et al., 1988)." xsd:string {source="PMID:16496288"}
+property_value: taxon_notes "In most taxa (birds, mammals, lizards), the tarsal plate is described as a dense, fibrous connective tissue, possibly including cartilage, present within one or both of the upper and lower eyelids (Gau- their et al., 1988; Rieppel, 2000). In humans, the tarsal plate of the upper eyelid is composed of collagens types I, III, and V, as well as glycosaminogly- cans (chondroitin sulphate 4 and 6), aggrecan, and cartilage oligomeric matrix proteins but lacks collagen type II as well as chondrocytes (Milz et al., 2005). Thus, for humans, the upper tarsal plate represents neither a truly fibrous nor a truly cartilagi- nous element but instead one that is composed of a unique transitional tissue (Milz et al., 2005). In many birds, lizards, and Sphenodon (the tuatara), the upper eyelid has lim- ited mobility and a putative tarsal plate is instead found within the lower eyelid (Underwood, 1970; Gau- their et al., 1988)." xsd:string {source="PMID:16496288"}
 
 [Term]
 id: UBERON:0004773
@@ -92105,7 +92105,7 @@ def: "A mucosa that is part of a gastrointestinal system." [OBOL:automatic]
 comment: The gut mucosa of amphioxus has insulin-secreting cells. http://www.ncbi.nlm.nih.gov/pubmed/16417468
 synonym: "digestive tract mucosa" EXACT [https://orcid.org/0000-0002-6601-2165]
 synonym: "gut mucosa" EXACT [BTO:0000546]
-synonym: "gut mucuous membrane" EXACT [https://orcid.org/0000-0002-6601-2165]
+synonym: "gut mucous membrane" EXACT [https://orcid.org/0000-0002-6601-2165]
 synonym: "mucosa of gut" EXACT [https://orcid.org/0000-0002-6601-2165]
 xref: BTO:0000546
 xref: BTO:0005568
@@ -96003,10 +96003,10 @@ synonym: "mucosa of organ of auditory tube" EXACT [OBOL:automatic]
 synonym: "mucosa of organ of internal auditory tube" EXACT [OBOL:automatic]
 synonym: "mucosa of organ of pharyngotympanic tube" EXACT [OBOL:automatic]
 synonym: "mucous membrane of auditory tube" EXACT [OBOL:automatic]
+synonym: "mucous membrane of eustachian tube" EXACT [FMA:60109]
 synonym: "mucous membrane of internal auditory tube" EXACT [OBOL:automatic]
 synonym: "mucous membrane of pharyngotympanic tube" EXACT [OBOL:automatic]
-synonym: "mucuous membrane of eustachian tube" EXACT [FMA:60109]
-synonym: "mucuous membrane of pharyngotympanic tube" EXACT [FMA:60109]
+synonym: "mucous membrane of pharyngotympanic tube" EXACT [FMA:60109]
 synonym: "organ mucosa of auditory tube" EXACT [OBOL:automatic]
 synonym: "organ mucosa of internal auditory tube" EXACT [OBOL:automatic]
 synonym: "organ mucosa of pharyngotympanic tube" EXACT [OBOL:automatic]
@@ -96172,7 +96172,7 @@ is_a: UBERON:0000945 {source="cjm"} ! stomach
 relationship: has_part UBERON:0008861 {source="Wikipedia"} ! pyloric gastric gland
 relationship: in_taxon NCBITaxon:8782 ! Aves
 relationship: part_of UBERON:0001555 ! digestive tract
-property_value: external_ontology_notes "BTO also includes: A thickened part of the alimentary canal in some animals (as an insect or an earthworm) that is similar in function to the crop of a bird. However, we are refering to the Aves structure here." xsd:string {external_ontology="BTO"}
+property_value: external_ontology_notes "BTO also includes: A thickened part of the alimentary canal in some animals (as an insect or an earthworm) that is similar in function to the crop of a bird. However, we are referring to the Aves structure here." xsd:string {external_ontology="BTO"}
 property_value: taxon_notes "currently restricted to Aves, but may be found outside - e.g. Pangolins" xsd:string
 
 [Term]
@@ -97356,7 +97356,7 @@ intersection_of: part_of UBERON:0000916 ! abdomen
 [Term]
 id: UBERON:0005173
 name: abdominal segment element
-def: "An organ or element that is part of the adbominal segment of the organism. This region can be further subdivided into the abdominal cavity and the pelvic region." [http://orcid.org/0000-0002-6601-2165]
+def: "An organ or element that is part of the abdominal segment of the organism. This region can be further subdivided into the abdominal cavity and the pelvic region." [http://orcid.org/0000-0002-6601-2165]
 subset: non_informative
 synonym: "abdominal segment organ" EXACT [MA:0000529]
 xref: EMAPA:37062 {source="MA:th"}
@@ -98536,7 +98536,7 @@ xref: ZFA:0001261
 is_a: UBERON:0000467 {source="ZFA"} ! anatomical system
 relationship: part_of UBERON:0001017 ! central nervous system
 property_value: depiction "http://upload.wikimedia.org/wikipedia/commons/7/7d/Gray734.png" xsd:anyURI
-property_value: editor_note "TODO - resolve space vs structure conflation. We follow FMA in making this and the various ventricles a structure - it follows from this that strutures such as the tela choroidea and choroid plexuses can be part of the ventricles and ventricular system. Note: see also the class 'neuraxis cavity'" xsd:string
+property_value: editor_note "TODO - resolve space vs structure conflation. We follow FMA in making this and the various ventricles a structure - it follows from this that structures such as the tela choroidea and choroid plexuses can be part of the ventricles and ventricular system. Note: see also the class 'neuraxis cavity'" xsd:string
 
 [Term]
 id: UBERON:0005282
@@ -101409,7 +101409,7 @@ property_value: external_definition "The conical end of the spinal cord, which c
 [Term]
 id: UBERON:0005438
 name: coronary sinus
-def: "The short trunk that recieves most of the cardiac veins carrying the blood from the myocardium and delivers it to the right atrium, with the sinoatrial connection occurring between the inferior vena cava and the atrioventricular orifice." [ISBN:0-683-40008-8, MP:0010436]
+def: "The short trunk that receives most of the cardiac veins carrying the blood from the myocardium and delivers it to the right atrium, with the sinoatrial connection occurring between the inferior vena cava and the atrioventricular orifice." [ISBN:0-683-40008-8, MP:0010436]
 subset: pheno_slim
 synonym: "sinus coronarius" EXACT []
 synonym: "sinus coronarius" RELATED OMO:0003011 [Wikipedia:Coronary_sinus]
@@ -102807,7 +102807,7 @@ relationship: has_developmental_contribution_from UBERON:0010029 {gci_relation="
 relationship: part_of UBERON:0000974 {gci_relation="part_of", gci_filler="NCBITaxon:40674", source="EHDAA2"} ! neck
 relationship: part_of UBERON:0002405 {source="ZFA"} ! immune system
 relationship: part_of UBERON:0003295 {source="EHDAA2"} ! pharyngeal gland
-property_value: editor_note "we follow Kardong table 13.1 in having some developmental contribution of pouch 4 in mammals, but this isn't reflected in EHDAA2. Consider adding distinct term for mesenchyme (see EHDAA2), to indicate NC constribution." xsd:string {source="ISBN:0781714125"}
+property_value: editor_note "we follow Kardong table 13.1 in having some developmental contribution of pouch 4 in mammals, but this isn't reflected in EHDAA2. Consider adding distinct term for mesenchyme (see EHDAA2), to indicate NC contribution." xsd:string {source="ISBN:0781714125"}
 property_value: external_definition "A small outgrowth of the pharyngeal epithelium that is the site of lymphocyte cell production. Willett et al, 1999.[TAO]" xsd:string {date_retrieved="2012-08-14", external_class="TAO:0001077", ontology="TAO", source="ZFIN:curator"}
 property_value: taxon_notes "variability of developmental origin: In fish, thymic primordia are generated by all the pouches except the first. However, in avians the thymus arises from pouches 3 and 4, whereas in humans it is only generated by the third pouch[PMID:16313389] The thymus arises from the second pouch in frogs, 2-6 in cartilaginous fish, 2-3 in reptiles, 3 or 4 in bony fish, birds and mammals. The final number is variable - 5 paired organs in sharks, 4 in caecilians, 3 in urodeles, 1 in many teleost, anurans and many mammals" xsd:string {source="ISBN:0781714125"}
 
@@ -103461,7 +103461,7 @@ is_a: UBERON:0004573 ! systemic artery
 disjoint_from: UBERON:0005628 ! ileal artery
 relationship: part_of UBERON:0010709 ! pelvic complex
 relationship: vessel_supplies_blood_to UBERON:0002355 ! pelvic region of trunk
-property_value: curator_notes "this is an extremely loose and flexible grouping class that is the superclass of the mammalian common iliac and its main brahces, together with analagous structures in other tetrapods" xsd:string
+property_value: curator_notes "this is an extremely loose and flexible grouping class that is the superclass of the mammalian common iliac and its main brahces, together with analogous structures in other tetrapods" xsd:string
 property_value: external_ontology_notes "we place the XAO structure here for now. In terms of analagy, it is more closely related to common iliac, but the relationships currently attached to this class are mammal specific" xsd:string {external_ontology="XAO"}
 
 [Term]
@@ -103529,7 +103529,7 @@ xref: SCTID:361403005
 xref: VHOG:0000484
 is_a: UBERON:0000947 ! aorta
 relationship: part_of UBERON:0005805 ! dorsal aorta
-property_value: homology_notes "A study of embryos shows that in all vertebrates six arterial arches link the ventral aorta with a pair of lateral dorsal aortae on each side of the body. The latter unite posteriorly to form a single median dorsal aorta wich takes blood to the body.[well established][VHOG]" xsd:string {date_retrieved="2012-09-17", external_class="VHOG:0000484", ontology="VHOG", source="ISBN:978-0174480198 Roberts MBV, Biology: a functional approach (1986) p.572", source="http://bgee.unil.ch/"}
+property_value: homology_notes "A study of embryos shows that in all vertebrates six arterial arches link the ventral aorta with a pair of lateral dorsal aortae on each side of the body. The latter unite posteriorly to form a single median dorsal aorta which takes blood to the body.[well established][VHOG]" xsd:string {date_retrieved="2012-09-17", external_class="VHOG:0000484", ontology="VHOG", source="ISBN:978-0174480198 Roberts MBV, Biology: a functional approach (1986) p.572", source="http://bgee.unil.ch/"}
 property_value: taxon_notes "Contributes to the arch of aorta in humans" xsd:string {source="http://emedicine.medscape.com/article/899609-overview"}
 
 [Term]
@@ -103557,7 +103557,7 @@ intersection_of: adjacent_to UBERON:0001804 ! capsule of lens
 intersection_of: part_of UBERON:0000965 ! lens of camera-type eye
 relationship: adjacent_to UBERON:0000389 ! lens cortex
 relationship: develops_from UBERON:0000924 {source="FMA-inferred"} ! ectoderm
-property_value: structure_notes "Cells of the subcapsular epithelium (or anterior lens cells) are mitotically active. In adult individuals they only cover the anterior 'hemisphere' of the lens. As they divide, cells gradually move towards the equator of the lens where they tranform into lens fibres. The apical part of the gradually elongating cell extends between the subcapsular epithelium and adjacent lens fibres towards the anterior pole of the lens. The basal part extends towards the posterior pole. The nucleus remains close to the equatorial plane of the lens - http://www.lab.anhb.uwa.edu.au/mb140/corepages/eye/eye.htm" xsd:string
+property_value: structure_notes "Cells of the subcapsular epithelium (or anterior lens cells) are mitotically active. In adult individuals they only cover the anterior 'hemisphere' of the lens. As they divide, cells gradually move towards the equator of the lens where they transform into lens fibres. The apical part of the gradually elongating cell extends between the subcapsular epithelium and adjacent lens fibres towards the anterior pole of the lens. The basal part extends towards the posterior pole. The nucleus remains close to the equatorial plane of the lens - http://www.lab.anhb.uwa.edu.au/mb140/corepages/eye/eye.htm" xsd:string
 
 [Term]
 id: UBERON:0005615
@@ -103695,7 +103695,7 @@ xref: SCTID:361404004
 xref: VHOG:0000485
 is_a: UBERON:0000947 ! aorta
 relationship: part_of UBERON:0005805 ! dorsal aorta
-property_value: homology_notes "A study of embryos shows that in all vertebrates six arterial arches link the ventral aorta with a pair of lateral dorsal aortae on each side of the body. The latter unite posteriorly to form a single median dorsal aorta wich takes blood to the body.[well established][VHOG]" xsd:string {date_retrieved="2012-09-17", external_class="VHOG:0000485", ontology="VHOG", source="ISBN:978-0174480198 Roberts MBV, Biology: a functional approach (1986) p.572", source="http://bgee.unil.ch/"}
+property_value: homology_notes "A study of embryos shows that in all vertebrates six arterial arches link the ventral aorta with a pair of lateral dorsal aortae on each side of the body. The latter unite posteriorly to form a single median dorsal aorta which takes blood to the body.[well established][VHOG]" xsd:string {date_retrieved="2012-09-17", external_class="VHOG:0000485", ontology="VHOG", source="ISBN:978-0174480198 Roberts MBV, Biology: a functional approach (1986) p.572", source="http://bgee.unil.ch/"}
 property_value: taxon_notes "Normally regresses in humans" xsd:string {source="http://emedicine.medscape.com/article/899609-overview"}
 
 [Term]
@@ -103821,7 +103821,7 @@ relationship: part_of UBERON:0004716 ! conceptus
 relationship: part_of UBERON:0016887 ! entire extraembryonic component
 property_value: external_ontology_notes "EHDAA2 is a mereological sum." xsd:string {external_ontology="EHDAA2"}
 property_value: seeAlso "https://github.com/obophenotype/uberon/wiki/Modeling-extraembryonic-membranes" xsd:anyURI
-property_value: taxon_notes "stuctures homologous to the four extraembryonic membranes appear in mammals [ISBN:0073040584 (Vertebrates, Kardong)]" xsd:string
+property_value: taxon_notes "structures homologous to the four extraembryonic membranes appear in mammals [ISBN:0073040584 (Vertebrates, Kardong)]" xsd:string
 
 [Term]
 id: UBERON:0005636
@@ -104993,7 +104993,7 @@ relationship: part_of UBERON:0011156 ! facial skeleton
 property_value: depiction "https://upload.wikimedia.org/wikipedia/commons/8/8e/Orbita_mensch.jpg" xsd:anyURI
 property_value: external_definition "An aperture in the root of the lesser wing of the sphenoid bone transmitting the optic nerve. [TFD][VHOG]" xsd:string {date_retrieved="2012-09-17", external_class="VHOG:0001408", ontology="VHOG", source="http://bgee.unil.ch/", source="http://medical-dictionary.thefreedictionary.com/optic+foramen"}
 property_value: external_definition "Foramen in the orbital region of the neurocranium for the passage of the optic nerve (cranial nerve II).[TAO]" xsd:string {date_retrieved="2012-08-14", external_class="TAO:0002025", ontology="TAO", source="TAO:wd"}
-property_value: external_definition "The short canal through the orbitosphenoid bone at the apex of the orbit that gives passage to the optic nerve and the opthalmic artery" xsd:string {external_class="MP:0010704", ontology="MP"}
+property_value: external_definition "The short canal through the orbitosphenoid bone at the apex of the orbit that gives passage to the optic nerve and the ophthalmic artery" xsd:string {external_class="MP:0010704", ontology="MP"}
 
 [Term]
 id: UBERON:0005746
@@ -106340,8 +106340,8 @@ property_value: implements_design_pattern "https://github.com/obophenotype/ubero
 id: UBERON:0005899
 name: pes bone
 def: "A bone that is part of the pes skeleton." [https://orcid.org/0000-0002-6601-2165]
-synonym: "bone of foor proper or tarsal skeleton" EXACT []
 synonym: "bone of foot" EXACT []
+synonym: "bone of foot proper or tarsal skeleton" EXACT []
 synonym: "bone of pedal skeleton" EXACT []
 synonym: "bone of pes" EXACT []
 synonym: "foot bone" EXACT [MA:0000643]
@@ -108427,7 +108427,7 @@ relationship: part_of UBERON:0001872 ! parietal lobe
 [Term]
 id: UBERON:0006094
 name: superior parietal cortex
-def: "Copmonent of the parietal lobe. The rostral and caudal boundaries of the superior parietal cortex were the precentral gyrus and lateral occipital cortex respectively. The medial and lateral boundaries were the precuneus and/or cuneus cortex and the infererior parietal cortex respectively (Christine Fennema-Notestine)." [BIRNLEX:1450]
+def: "Component of the parietal lobe. The rostral and caudal boundaries of the superior parietal cortex were the precentral gyrus and lateral occipital cortex respectively. The medial and lateral boundaries were the precuneus and/or cuneus cortex and the infererior parietal cortex respectively (Christine Fennema-Notestine)." [BIRNLEX:1450]
 synonym: "gyrus parietalis superior" RELATED OMO:0003011 [NeuroNames:106]
 synonym: "lobulus parietalis superior" RELATED OMO:0003011 [NeuroNames:106]
 synonym: "superior parietal cortex" EXACT [BIRNLEX:1450]
@@ -108452,7 +108452,7 @@ name: anterior transverse temporal area 41
 alt_id: UBERON:0013574
 def: "A subdivision of the cytoarchitecturally defined temporal region of cerebral cortex. It occupies the anterior transverse temporal gyrus (H) in the bank of the lateral sulcus on the dorsal surface of the temporal lobe. Cytoarchitecturally it is bounded medially by the parainsular area 52 (H) and laterally by the posterior transverse temporal area 42 (H) (Brodmann-1909). Adapted from Brain Info." [BIRNLEX:1582]
 synonym: "anterior transverse temporal area 41" EXACT [FMA:68638]
-synonym: "anterior transverse termporal area 41" EXACT OMO:0003002 [BIRNLEX:1582]
+synonym: "anterior transverse temporal area 41" EXACT OMO:0003002 [BIRNLEX:1582]
 synonym: "area 41 of Brodmann" EXACT [BIRNLEX:1582, FMA:68638]
 synonym: "area 41 of Brodmann-1909" EXACT [BIRNLEX:1774]
 synonym: "area temporalis transversa anterior" EXACT [BIRNLEX:1774]
@@ -108488,8 +108488,8 @@ synonym: "Brodmann (1909) area 42" EXACT [BIRNLEX:1775]
 synonym: "Brodmann area 42" EXACT [FMA:68639]
 synonym: "Brodmann area 42, posterior transverse temporal" EXACT [BIRNLEX:1775]
 synonym: "Brodmann's area 42" EXACT [BIRNLEX:1589]
+synonym: "posterior transverse temporal area 42" EXACT OMO:0003002 [BIRNLEX:1589]
 synonym: "posterior transverse temporal area 42" EXACT [FMA:68639]
-synonym: "posterior transverse termporal area 42" EXACT OMO:0003002 [BIRNLEX:1589]
 xref: BIRNLEX:1589
 xref: BIRNLEX:1775
 xref: FMA:236867
@@ -109490,7 +109490,7 @@ property_value: depiction "http://upload.wikimedia.org/wikipedia/commons/b/b9/Gr
 [Term]
 id: UBERON:0006208
 name: auditory hillocks
-def: "A collection of protruberances derived from pharyngeal arches 1 and 2 that develop into the folds of the pinna and gradually shift upwards and backwards to their final position on the head." [Wikipedia:Pinna_(anatomy)#Development]
+def: "A collection of protuberances derived from pharyngeal arches 1 and 2 that develop into the folds of the pinna and gradually shift upwards and backwards to their final position on the head." [Wikipedia:Pinna_(anatomy)#Development]
 subset: emapa_ehdaa2
 synonym: "auditory hillock of Hiss" EXACT []
 synonym: "auditory tubercles" RELATED INCONSISTENT [VHOG:0001364]
@@ -110456,7 +110456,7 @@ xref: Wikipedia:Otic_pit
 is_a: UBERON:0016566 {source="EHDAA2"} ! pit
 relationship: has_potential_to_develop_into UBERON:0003051 ! ear vesicle
 relationship: part_of UBERON:0003069 ! otic placode
-property_value: external_definition "A depression appearing in each otic placode, marking the beginnning of embryonic development of the internal ear. [TFD][VHOG]" xsd:string {date_retrieved="2012-09-17", external_class="VHOG:0001147", ontology="VHOG", source="http://bgee.unil.ch/", source="http://medical-dictionary.thefreedictionary.com/Otic+pit"}
+property_value: external_definition "A depression appearing in each otic placode, marking the beginning of embryonic development of the internal ear. [TFD][VHOG]" xsd:string {date_retrieved="2012-09-17", external_class="VHOG:0001147", ontology="VHOG", source="http://bgee.unil.ch/", source="http://medical-dictionary.thefreedictionary.com/Otic+pit"}
 
 [Term]
 id: UBERON:0006274
@@ -111485,19 +111485,19 @@ intersection_of: vessel_supplies_blood_to UBERON:0006635 ! anterior abdominal wa
 [Term]
 id: UBERON:0006351
 name: principal vein of forelimb
-def: "A prinicipal vein of limb that is part of a forelimb." [OBOL:automatic]
+def: "A principal vein of limb that is part of a forelimb." [OBOL:automatic]
 xref: EMAPA:17018
 xref: MA:0002199
-intersection_of: UBERON:0006443 ! prinicipal vein of limb
+intersection_of: UBERON:0006443 ! principal vein of limb
 intersection_of: part_of UBERON:0002102 ! forelimb
 
 [Term]
 id: UBERON:0006353
 name: principal vein of hindlimb
-def: "A prinicipal vein of limb that is part of a hindlimb." [OBOL:automatic]
+def: "A principal vein of limb that is part of a hindlimb." [OBOL:automatic]
 xref: EMAPA:17019
 xref: MA:0002200
-intersection_of: UBERON:0006443 ! prinicipal vein of limb
+intersection_of: UBERON:0006443 ! principal vein of limb
 intersection_of: part_of UBERON:0002103 ! hindlimb
 
 [Term]
@@ -111772,7 +111772,7 @@ relationship: part_of UBERON:0001179 {source="MA-abduced"} ! peritoneal cavity
 
 [Term]
 id: UBERON:0006443
-name: prinicipal vein of limb
+name: principal vein of limb
 is_a: UBERON:0001638 ! vein
 relationship: part_of UBERON:0002101 ! limb
 
@@ -113605,7 +113605,7 @@ property_value: axiom_lost_from_external_ontology "relationship loss: part_of br
 property_value: axiom_lost_from_external_ontology "relationship loss: part_of otic and occipital (AAO:0000993)[AAO]" xsd:string {date_retrieved="2012-06-20", external_class="AAO:0010129", ontology="AAO"}
 property_value: external_definition "Roof between frontoparietal foramen and otic capsules, confluent with taenia tecti marginales.[AAO]" xsd:string {date_retrieved="2012-06-20", external_class="AAO:0010129", ontology="AAO", source="AAO:EJS"}
 property_value: external_ontology_notes "In AAO the def is 'Roof between frontoparietal foramen and otic capsules, confluent with taenia tecti marginales.', In TAO/ZFA this gives rise to supraoccipital and sphenotic." xsd:string {external_ontology="AAO"}
-property_value: taxon_notes "posterior tectum synoticum in humans - a skull roof element of the chondrocranium - temporarily exists in the territory of the interparietal during fetal life, and may be resposible for the sutura mendosa" xsd:string {source="PMC1259625"}
+property_value: taxon_notes "posterior tectum synoticum in humans - a skull roof element of the chondrocranium - temporarily exists in the territory of the interparietal during fetal life, and may be responsible for the sutura mendosa" xsd:string {source="PMC1259625"}
 
 [Term]
 id: UBERON:0006606
@@ -114525,7 +114525,7 @@ property_value: depiction "http://upload.wikimedia.org/wikipedia/commons/4/4c/Gr
 id: UBERON:0006669
 name: alveolar canal
 def: "The infratemporal surface of the maxilla is pierced about its center by the apertures of the alveolar canals, which transmit the posterior superior alveolar vessels and nerves[WP]." [Wikipedia:Alveolar_canals]
-comment: Desig pattern note: check design pattern
+comment: Design pattern note: check design pattern
 synonym: "canales alveolares maxillae" RELATED OMO:0003011 [Wikipedia:Alveolar_canals]
 xref: EMAPA:25099
 xref: FMA:57743
@@ -116184,7 +116184,7 @@ xref: Wikipedia:Medial_epicondyle_of_the_humerus
 is_a: UBERON:0009978 {source="FMA"} ! epicondyle
 relationship: part_of UBERON:0004404 {source="FMA"} ! distal epiphysis of humerus
 property_value: depiction "http://upload.wikimedia.org/wikipedia/commons/6/6c/Gray329-Medial_epicondyle_of_the_humerus.png" xsd:anyURI
-property_value: external_definition "Rounded projection at the distal head of the humerus and medial to the humeral head, which serves as a place of attachment for the flexor muscles antogonistic to those that attach to the lateral epicondyle.[AAO]" xsd:string {date_retrieved="2012-06-20", external_class="AAO:0000782", ontology="AAO", source="AAO:LAP"}
+property_value: external_definition "Rounded projection at the distal head of the humerus and medial to the humeral head, which serves as a place of attachment for the flexor muscles antagonistic to those that attach to the lateral epicondyle.[AAO]" xsd:string {date_retrieved="2012-06-20", external_class="AAO:0000782", ontology="AAO", source="AAO:LAP"}
 property_value: has_relational_adjective "entepicondylar" xsd:string
 
 [Term]
@@ -116515,7 +116515,7 @@ is_a: UBERON:0002308 ! nucleus of brain
 relationship: mutually_spatially_disjoint_with UBERON:0002128 {source="ABA"} ! superior olivary complex
 relationship: mutually_spatially_disjoint_with UBERON:0002597 {source="ABA"} ! principal sensory nucleus of trigeminal nerve
 relationship: mutually_spatially_disjoint_with UBERON:0007634 {source="ABA"} ! parabrachial nucleus
-property_value: external_ontology_notes "not clear if the ZFA class denotes the same entity; check relationship to midbrain tegmentum - this leads to inconsistency with ABA. The FMA class should represnet the grouping, but there is no FMA class for the singular at the moment" xsd:string {external_ontology="ZFA"}
+property_value: external_ontology_notes "not clear if the ZFA class denotes the same entity; check relationship to midbrain tegmentum - this leads to inconsistency with ABA. The FMA class should represent the grouping, but there is no FMA class for the singular at the moment" xsd:string {external_ontology="ZFA"}
 
 [Term]
 id: UBERON:0006841
@@ -116768,7 +116768,7 @@ relationship: part_of UBERON:0009916 {source="FMA"} ! wall of ureter
 [Term]
 id: UBERON:0006856
 name: interrenal gland
-def: "Structures in fishes homologous to the cortical tissue of the mammalian adrenal gland; they are in close proximity to or imbedded in the head kidney." [BTO:0000808, DOI:10.1242/dev.00427]
+def: "Structures in fishes homologous to the cortical tissue of the mammalian adrenal gland; they are in close proximity to or embedded in the head kidney." [BTO:0000808, DOI:10.1242/dev.00427]
 subset: organ_slim
 synonym: "interrenal" RELATED [http://dev.biologists.org/content/130/10/2107.full]
 synonym: "interrenal bodies" RELATED []
@@ -119868,7 +119868,7 @@ relationship: present_in_taxon NCBITaxon:117569 {source="Hardisty, p. 320-1"} ! 
 [Term]
 id: UBERON:0007252
 name: intervertebral disk of cervical vertebra
-def: "An intervertebral disk that is part of a cervical region of vertebral column. A cervical intervertebral disk connects at least one cervical vertebra, either to another cervical vertebra, or at one point on the vertebral colummn, to a thoracic vertebra." [http://orcid.org/0000-0002-6601-2165]
+def: "An intervertebral disk that is part of a cervical region of vertebral column. A cervical intervertebral disk connects at least one cervical vertebra, either to another cervical vertebra, or at one point on the vertebral column, to a thoracic vertebra." [http://orcid.org/0000-0002-6601-2165]
 synonym: "cervical intervertebral disc" EXACT [FMA:13895]
 synonym: "intervertebral disc of cervical region" EXACT [EMAPA:19415]
 xref: EMAPA:19415
@@ -119880,7 +119880,7 @@ intersection_of: part_of UBERON:0006072 ! cervical region of vertebral column
 [Term]
 id: UBERON:0007254
 name: intervertebral disk of thoracic vertebra
-def: "An intervertebral disk that is part of a thoracic region of vertebral column. A thoracic intervertebral disk connects at least one thoracic vertebra, either to another thoracic vertebra, or at one point on the vertebral colummn, to a lumbar vertebra." [http://orcid.org/0000-0002-6601-2165]
+def: "An intervertebral disk that is part of a thoracic region of vertebral column. A thoracic intervertebral disk connects at least one thoracic vertebra, either to another thoracic vertebra, or at one point on the vertebral column, to a lumbar vertebra." [http://orcid.org/0000-0002-6601-2165]
 synonym: "intervertebral disc of thoracic region" EXACT [EMAPA:19489]
 xref: EMAPA:19489
 xref: FMA:10455
@@ -119890,7 +119890,7 @@ intersection_of: part_of UBERON:0006073 ! thoracic region of vertebral column
 [Term]
 id: UBERON:0007255
 name: intervertebral disk of lumbar vertebra
-def: "An intervertebral disk that is part of a lumbar region of vertebral column. A lumbar intervertebral disk connects at least one lumbar vertebra, either to another thoracic vertebra, or at one point on the vertebral colummn, to a sacral vertebra." [http://orcid.org/0000-0002-6601-2165]
+def: "An intervertebral disk that is part of a lumbar region of vertebral column. A lumbar intervertebral disk connects at least one lumbar vertebra, either to another thoracic vertebra, or at one point on the vertebral column, to a sacral vertebra." [http://orcid.org/0000-0002-6601-2165]
 synonym: "intervertebral disc of lumbar region" EXACT [EMAPA:19468]
 xref: EMAPA:19468
 xref: FMA:13894
@@ -119900,7 +119900,7 @@ intersection_of: part_of UBERON:0006074 ! lumbar region of vertebral column
 [Term]
 id: UBERON:0007257
 name: intervertebral disk of sacral vertebra
-def: "An intervertebral disk that is part of a sacral region of vertebral column. A sacral intervertebral disk connects at least one sacral vertebra, either to another thoracic vertebra, or at one point on the vertebral colummn, to a sacral vertebra." [http://orcid.org/0000-0002-6601-2165]
+def: "An intervertebral disk that is part of a sacral region of vertebral column. A sacral intervertebral disk connects at least one sacral vertebra, either to another thoracic vertebra, or at one point on the vertebral column, to a sacral vertebra." [http://orcid.org/0000-0002-6601-2165]
 synonym: "intervertebral disc of sacral region" EXACT [EMAPA:19575]
 xref: EMAPA:19575
 xref: FMA:268676
@@ -120116,7 +120116,7 @@ intersection_of: part_of UBERON:0001857 ! anterior semicircular duct
 disjoint_from: UBERON:0007275 {source="lexical"} ! crista of ampulla of posterior semicircular duct of membranous laybrinth
 relationship: develops_from UBERON:2000468 {source="Phenoscape"} ! anterior crista primordium
 property_value: editor_note "TODO - unvetted" xsd:string
-property_value: external_definition "Patches of thickened, pseudostratified epithelium of the inner ear, consisting of regular arrays of sensory hair cells interspersed with supporting cells. Each patch has its own charcteristic shape and polarity pattern. (See Anatomical Atlas entry for sensory patches of the ear by T. Whitfield.)[TAO]" xsd:string {date_retrieved="2012-08-14", external_class="TAO:0000619", ontology="TAO", source="ZFIN:curator"}
+property_value: external_definition "Patches of thickened, pseudostratified epithelium of the inner ear, consisting of regular arrays of sensory hair cells interspersed with supporting cells. Each patch has its own characteristic shape and polarity pattern. (See Anatomical Atlas entry for sensory patches of the ear by T. Whitfield.)[TAO]" xsd:string {date_retrieved="2012-08-14", external_class="TAO:0000619", ontology="TAO", source="ZFIN:curator"}
 
 [Term]
 id: UBERON:0007275
@@ -120138,7 +120138,7 @@ xref: ZFA:0000566
 intersection_of: UBERON:0006935 ! crista ampullaris neuroepithelium
 intersection_of: part_of UBERON:0001858 ! posterior semicircular duct
 property_value: editor_note "TODO - unvetted" xsd:string
-property_value: external_definition "Patches of thickened, pseudostratified epithelium of the inner ear, consisting of regular arrays of sensory hair cells interspersed with supporting cells. Each patch has its own charcteristic shape and polarity pattern. (See Anatomical Atlas entry for sensory patches of the ear by T. Whitfield.)[TAO]" xsd:string {date_retrieved="2012-08-14", external_class="TAO:0000566", ontology="TAO", source="ZFIN:curator"}
+property_value: external_definition "Patches of thickened, pseudostratified epithelium of the inner ear, consisting of regular arrays of sensory hair cells interspersed with supporting cells. Each patch has its own characteristic shape and polarity pattern. (See Anatomical Atlas entry for sensory patches of the ear by T. Whitfield.)[TAO]" xsd:string {date_retrieved="2012-08-14", external_class="TAO:0000566", ontology="TAO", source="ZFIN:curator"}
 
 [Term]
 id: UBERON:0007276
@@ -120158,7 +120158,7 @@ xref: ZFA:0000166
 intersection_of: UBERON:0006935 ! crista ampullaris neuroepithelium
 intersection_of: part_of UBERON:0001859 ! lateral semicircular duct
 property_value: editor_note "TODO - unvetted" xsd:string
-property_value: external_definition "Patches of thickened, pseudostratified epithelium of the inner ear, consisting of regular arrays of sensory hair cells interspersed with supporting cells. Each patch has its own charcteristic shape and polarity pattern. (See Anatomical Atlas entry for sensory patches of the ear by T. Whitfield.)[TAO]" xsd:string {date_retrieved="2012-08-14", external_class="TAO:0000166", ontology="TAO", source="ZFIN:curator"}
+property_value: external_definition "Patches of thickened, pseudostratified epithelium of the inner ear, consisting of regular arrays of sensory hair cells interspersed with supporting cells. Each patch has its own characteristic shape and polarity pattern. (See Anatomical Atlas entry for sensory patches of the ear by T. Whitfield.)[TAO]" xsd:string {date_retrieved="2012-08-14", external_class="TAO:0000166", ontology="TAO", source="ZFIN:curator"}
 
 [Term]
 id: UBERON:0007277
@@ -120922,7 +120922,7 @@ property_value: depiction "https://upload.wikimedia.org/wikipedia/commons/2/2b/A
 [Term]
 id: UBERON:0007362
 name: omasum
-def: "The third stomach of ruminants, situated on the right side of the abdomen at a higher level than the fourth stomach and between this latter and the second stomach, with both of which it communicates. From its inner surface project large numbers of leaves or folia, each of which possesses roughened surfaces. In the center of each folium is a band of muscle fibers which produces a rasping movement of the leaf when it contracts. One leaf rubs against those on either side of it, and large particles of food material are ground down between the rough surfaces, preparatory to further digestion in the succeeeding parts of the alimentary canal. (Black's Veterinary Dictionary, 17th ed)." [MESH:A13.869.524, Wikipedia:Omasum]
+def: "The third stomach of ruminants, situated on the right side of the abdomen at a higher level than the fourth stomach and between this latter and the second stomach, with both of which it communicates. From its inner surface project large numbers of leaves or folia, each of which possesses roughened surfaces. In the center of each folium is a band of muscle fibers which produces a rasping movement of the leaf when it contracts. One leaf rubs against those on either side of it, and large particles of food material are ground down between the rough surfaces, preparatory to further digestion in the succeeding parts of the alimentary canal. (Black's Veterinary Dictionary, 17th ed)." [MESH:A13.869.524, Wikipedia:Omasum]
 synonym: "omasum" RELATED [MESH:A13.869.524]
 xref: BTO:0000348
 xref: GAID:1242
@@ -123243,7 +123243,7 @@ is_a: UBERON:0000467 ! anatomical system
 relationship: part_of UBERON:0004535 {source="MA"} ! cardiovascular system
 property_value: editor_note "consider merging with vasculature" xsd:string
 property_value: external_definition "The cardiovascular and lymphatic systems, collectively[ncithesaurus:Vascular_System]." xsd:string {source="ncithesaurus:Vascular_System"}
-property_value: external_ontology_notes "in both MA and BTO, the arterial system and venous sytem are subtypes of the vascular system" xsd:string {external_ontology="MA"}
+property_value: external_ontology_notes "in both MA and BTO, the arterial system and venous system are subtypes of the vascular system" xsd:string {external_ontology="MA"}
 
 [Term]
 id: UBERON:0007799
@@ -123652,7 +123652,7 @@ property_value: external_definition "Anatomical cluster of paired dermal and end
 property_value: external_definition "Girdle skeleton consisting of a set of bones linking the axial series to the forelimb/fin skeleton and offering anchoring areas for forelimb/fin and caudal musculature.[VSAO]" xsd:string {date_retrieved="2012-08-14", external_class="VSAO:0000156", ontology="VSAO", source="https://orcid.org/0000-0002-6601-2165"}
 property_value: external_definition "Skeletal structure immediately behind the head attached to the vertebral column by muscles and supporting the forelimbs.[AAO]" xsd:string {date_retrieved="2012-06-20", external_class="AAO:0000422", ontology="AAO", source="AAO:LAP"}
 property_value: external_ontology_notes "Note that the VSAO and many ontologies use the label 'pectoral girdle' to denote the skeletal region specifically." xsd:string {external_ontology="VSAO"}
-property_value: homology_notes "The pectoral girdle is clearly of dual origin, composed of dermal as well as endochondral bones. The endochondral component, the scapulocoracoid, evolved by fusion or enlargment of several basal fin elements. (...) The dermal component of the shoulder girdle evolved from dermal bones of the body's surface. (...) Like endochondral bones, these dermal bones were passed along to tetrapods (...).[well established][VHOG]" xsd:string {date_retrieved="2012-09-17", external_class="VHOG:0001156", ontology="VHOG", source="ISBN:978-0072528305 Kardong KV, Vertebrates: Comparative Anatomy, Function, Evolution (2006) p.336 and Figure 9.18", source="http://bgee.unil.ch/"}
+property_value: homology_notes "The pectoral girdle is clearly of dual origin, composed of dermal as well as endochondral bones. The endochondral component, the scapulocoracoid, evolved by fusion or enlargement of several basal fin elements. (...) The dermal component of the shoulder girdle evolved from dermal bones of the body's surface. (...) Like endochondral bones, these dermal bones were passed along to tetrapods (...).[well established][VHOG]" xsd:string {date_retrieved="2012-09-17", external_class="VHOG:0001156", ontology="VHOG", source="ISBN:978-0072528305 Kardong KV, Vertebrates: Comparative Anatomy, Function, Evolution (2006) p.336 and Figure 9.18", source="http://bgee.unil.ch/"}
 
 [Term]
 id: UBERON:0007832
@@ -125984,9 +125984,9 @@ property_value: depiction "http://upload.wikimedia.org/wikipedia/commons/3/34/Mu
 [Term]
 id: UBERON:0008574
 name: transverse arytenoid
-def: "The tranverse arytenoid crosses transversely between the two cartilages. It is an unpaired muscle running from one arytenoid to another to pull the arytenoids together." [Wikipedia:Arytenoid_muscle]
+def: "The transverse arytenoid crosses transversely between the two cartilages. It is an unpaired muscle running from one arytenoid to another to pull the arytenoids together." [Wikipedia:Arytenoid_muscle]
 synonym: "arytenoid transversus" RELATED []
-synonym: "tranverse arytenoid muscle" RELATED [Wikipedia:Transverse_arytenoid]
+synonym: "transverse arytenoid muscle" RELATED [Wikipedia:Transverse_arytenoid]
 xref: FMA:46582
 xref: Wikipedia:Arytenoid_muscle
 is_a: UBERON:0010958 ! arytenoid muscle
@@ -126848,7 +126848,7 @@ xref: Wikipedia:Rugae
 is_a: UBERON:0000064 ! organ part
 relationship: has_quality PATO:0001359 ! rugose
 relationship: part_of UBERON:0000344 ! mucosa
-property_value: editor_note "As currently defined this encompasses only mucuous membranes, and not for example rugal folds of skin such as the scrotal rugae" xsd:string
+property_value: editor_note "As currently defined this encompasses only mucous membranes, and not for example rugal folds of skin such as the scrotal rugae" xsd:string
 
 [Term]
 id: UBERON:0008791
@@ -127077,7 +127077,7 @@ relationship: capable_of_part_of GO:0007620 ! copulation
 relationship: in_taxon NCBITaxon:6072 ! Eumetazoa
 relationship: part_of UBERON:0000079 ! male reproductive system
 relationship: part_of UBERON:0000990 ! reproductive system
-property_value: curator_notes "this is a broad grouping class connecting a number of different analagous organs by their function. We place the insect aedeagus here rather than penis, although this is somewhat arbitrary given the broadness of the current definition" xsd:string
+property_value: curator_notes "this is a broad grouping class connecting a number of different analogous organs by their function. We place the insect aedeagus here rather than penis, although this is somewhat arbitrary given the broadness of the current definition" xsd:string
 property_value: external_definition "Surface structure that is an external structure of a male organism through which sperm is transferred to a female organism during mating.[TAO]" xsd:string {date_retrieved="2012-08-14", external_class="TAO:0002036", ontology="TAO", source="TAO:wd"}
 
 [Term]
@@ -127110,7 +127110,7 @@ property_value: depiction "http://upload.wikimedia.org/wikipedia/commons/1/19/Gr
 [Term]
 id: UBERON:0008814
 name: pharyngeal arch system
-def: "A transient embryonic complex that comprises the pharyngeal arches, bulges of tissues of mesoderm and neural crest derivation through which pass nerves and pharyngeal arch arteries. The arches are separated internally by pharyngeal pouches, evaginations of foregut endoderm, and externally by pharyngeal clefts, invaginations of surface ectoderm. The development of the system ends when the stucture it contributes to are forming, which may include (depending on species) the thymus, thyroid, parathyroids, maxilla, mandible, aortic arch, cardiac outflow tract, external and middle ear[GO,modified]." [GO:0060037, GOC:dph]
+def: "A transient embryonic complex that comprises the pharyngeal arches, bulges of tissues of mesoderm and neural crest derivation through which pass nerves and pharyngeal arch arteries. The arches are separated internally by pharyngeal pouches, evaginations of foregut endoderm, and externally by pharyngeal clefts, invaginations of surface ectoderm. The development of the system ends when the structure it contributes to are forming, which may include (depending on species) the thymus, thyroid, parathyroids, maxilla, mandible, aortic arch, cardiac outflow tract, external and middle ear[GO,modified]." [GO:0060037, GOC:dph]
 synonym: "embryonic pharyngeal complex" EXACT []
 synonym: "pharyngeal apparatus" EXACT []
 synonym: "pharyngeal arch complex" RELATED []
@@ -127740,7 +127740,7 @@ subset: pheno_slim
 synonym: "cardiac gland" RELATED [FMA:14920]
 synonym: "gardiac gland" EXACT [ISBN:0073040584]
 synonym: "gastric cardiac gland" EXACT [FMA:14920]
-synonym: "gastric cardiac mucuous gland" EXACT []
+synonym: "gastric cardiac mucous gland" EXACT []
 synonym: "gastric gland of cardia" EXACT [FMA:14920]
 synonym: "glandula cardiaca (gaster)" EXACT [FMA:14920]
 xref: EMAPA:37459 {source="MA:th"}
@@ -127773,7 +127773,7 @@ subset: pheno_slim
 synonym: "glandula pylorica" EXACT [FMA:14922]
 synonym: "pyloric antrum gland" EXACT [OBOL:automatic]
 synonym: "pyloric gland" EXACT [FMA:14922]
-synonym: "pyloric mucuous gland" EXACT []
+synonym: "pyloric mucous gland" EXACT []
 xref: EMAPA:27211
 xref: FMA:14922
 xref: NCIT:C33431
@@ -133142,7 +133142,7 @@ synonym: "tubule of excretory system" EXACT [https://orcid.org/0000-0002-6601-21
 is_a: UBERON:0003914 ! epithelial tube
 relationship: in_taxon NCBITaxon:33213 ! Bilateria
 relationship: part_of UBERON:0001008 ! renal system
-property_value: curator_notes "this class groups vertebrate nephron tubules with analagous structures such as insect Malpighian tubules" xsd:string
+property_value: curator_notes "this class groups vertebrate nephron tubules with analogous structures such as insect Malpighian tubules" xsd:string
 
 [Term]
 id: UBERON:0009774
@@ -133493,7 +133493,7 @@ intersection_of: has_quality PATO:0001987 ! saccular
 [Term]
 id: UBERON:0009857
 name: cavum septum pellucidum
-def: "A space enclosed within the laminae of the septum pelludicum, the membranous partition that seperates the frontal horns of the ventricle. contains cerebrospinal fluid (CSF) that filters from the ventricles through the septal laminae. bounded anteriorly by the genu of the corpus callosum; superiorly by the body of the corpus callosum; posteriorly by the anterior limb and pillars of the fornix; inferiorly by the anterior commissure and the rostrum of the corpus callosum; and laterally by the leaflets of the septum pellucidum." [BTO:0003447, Wikipedia:Cave_of_septum_pellucidum]
+def: "A space enclosed within the laminae of the septum pelludicum, the membranous partition that separates the frontal horns of the ventricle. contains cerebrospinal fluid (CSF) that filters from the ventricles through the septal laminae. bounded anteriorly by the genu of the corpus callosum; superiorly by the body of the corpus callosum; posteriorly by the anterior limb and pillars of the fornix; inferiorly by the anterior commissure and the rostrum of the corpus callosum; and laterally by the leaflets of the septum pellucidum." [BTO:0003447, Wikipedia:Cave_of_septum_pellucidum]
 synonym: "cave of septum pellucidum" EXACT [FMA:61874]
 synonym: "cavum of septum pellucidum" EXACT [FMA:61874]
 synonym: "cavum septi pellucidi" RELATED OMO:0003011 [Wikipedia:Cave_of_septum_pellucidum]
@@ -134968,7 +134968,7 @@ relationship: part_of UBERON:0005094 ! beak
 [Term]
 id: UBERON:0010014
 name: epigonal organ
-def: "An elongate paired tissue ventral to the kidneys and partialy enveloping the anterior gonads in Elasmobranchii. Apparently important to the immune system." [http://www.fishbase.org/glossary/Glossary.php?q=epigonal+organ]
+def: "An elongate paired tissue ventral to the kidneys and partially enveloping the anterior gonads in Elasmobranchii. Apparently important to the immune system." [http://www.fishbase.org/glossary/Glossary.php?q=epigonal+organ]
 synonym: "subgonal organ" EXACT []
 is_a: UBERON:0004177 ! hemopoietic organ
 relationship: composed_primarily_of CL:0000738 {source="Honma1983"} ! leukocyte
@@ -135224,7 +135224,7 @@ intersection_of: develops_from UBERON:0006260 {source="ISBN:1607950324"} ! lingu
 intersection_of: part_of UBERON:0001723 {source="ISBN:1607950324"} ! tongue
 disjoint_from: UBERON:0010033 {source="lexical"} ! posterior part of tongue
 property_value: depiction "https://upload.wikimedia.org/wikipedia/commons/4/4c/Illu04_tongue.jpg" xsd:anyURI
-property_value: development_notes "The lateral lingual swellings grow and fuse with eachother, encompassing the tuberculum impar to provide the ectodermally derived mucosa of the anterior 2/3 of the tongue" xsd:string
+property_value: development_notes "The lateral lingual swellings grow and fuse with each other, encompassing the tuberculum impar to provide the ectodermally derived mucosa of the anterior 2/3 of the tongue" xsd:string
 property_value: external_ontology_notes "check NCIT" xsd:string {external_ontology="NCIT"}
 
 [Term]
@@ -137097,7 +137097,7 @@ relationship: present_in_taxon NCBITaxon:7778 ! Elasmobranchii
 relationship: present_in_taxon NCBITaxon:7864 ! Chimaeriformes
 property_value: taxon_notes "A choroidal tapetum of reflecting cells lying immediately outside the choriocapillaris is formed in a few primitive teleosts." xsd:string {source="PMID:14738502", taxon="NCBITaxon:32443"}
 property_value: taxon_notes "elasmobranchii (skates, rays, and sharks) and chimaeras" xsd:string {source="WP"}
-property_value: taxon_notes "The elasmobranch tapetum in Squalus and Scyliorhinus con- sists of sheets of 12-13 superposed guanine crystals in the choroid." xsd:string {source="PMID:14738502", taxon="NCBITaxon:7778"}
+property_value: taxon_notes "The elasmobranch tapetum in Squalus and Scyliorhinus consists of sheets of 12-13 superposed guanine crystals in the choroid." xsd:string {source="PMID:14738502", taxon="NCBITaxon:7778"}
 
 [Term]
 id: UBERON:0010247
@@ -138131,7 +138131,7 @@ relationship: develops_from UBERON:0010254 {source="DOI:10.1111/j.1469-7580.2005
 [Term]
 id: UBERON:0010355
 name: ossification center
-def: "The first step in ossification of the cartilage is that the cartilage cells, at the point where ossification is commencing and which is termed a ossification center, enlarge and arrange themselves in rows. The matrix in which they are imbedded increases in quantity, so that the cells become further separated from each other. A deposit of calcareous material now takes place in this matrix, between the rows of cells, so that they become separated from each other by longitudinal columns of calcified matrix, presenting a granular and opaque appearance. Here and there the matrix between two cells of the same row also becomes calcified, and transverse bars of calcified substance stretch across from one calcareous column to another. Thus there are longitudinal groups of the cartilage cells enclosed in oblong cavities, the walls of which are formed of calcified matrix which cuts off all nutrition from the cells; the cells, in consequence, atrophy, leaving spaces called the primary areolC&." [Wikipedia:Ossification_center]
+def: "The first step in ossification of the cartilage is that the cartilage cells, at the point where ossification is commencing and which is termed a ossification center, enlarge and arrange themselves in rows. The matrix in which they are embedded increases in quantity, so that the cells become further separated from each other. A deposit of calcareous material now takes place in this matrix, between the rows of cells, so that they become separated from each other by longitudinal columns of calcified matrix, presenting a granular and opaque appearance. Here and there the matrix between two cells of the same row also becomes calcified, and transverse bars of calcified substance stretch across from one calcareous column to another. Thus there are longitudinal groups of the cartilage cells enclosed in oblong cavities, the walls of which are formed of calcified matrix which cuts off all nutrition from the cells; the cells, in consequence, atrophy, leaving spaces called the primary areolC&." [Wikipedia:Ossification_center]
 subset: pheno_slim
 synonym: "center of ossification" RELATED [Wikipedia:Ossification_center]
 synonym: "centrum ossificationis" EXACT OMO:0003011 [FMA:TA]
@@ -138716,7 +138716,7 @@ xref: MA:0000812
 is_a: UBERON:0005423 ! developing anatomical structure
 relationship: develops_from UBERON:0004062 ! neural tube marginal layer
 relationship: part_of UBERON:0000955 ! brain
-property_value: external_ontology_notes "not clear if the MA/EMAPA classes refer specifically to the cortical subset. DHBA class incldues non-neocortex derivatives so it belongs here" xsd:string {external_ontology="MA"}
+property_value: external_ontology_notes "not clear if the MA/EMAPA classes refer specifically to the cortical subset. DHBA class includes non-neocortex derivatives so it belongs here" xsd:string {external_ontology="MA"}
 
 [Term]
 id: UBERON:0010404
@@ -138753,7 +138753,7 @@ relationship: overlaps CL:0000108 ! cholinergic neuron
 [Term]
 id: UBERON:0010408
 name: ocular angle artery
-def: "The angular artery is the terminal part of the facial artery; it ascends to the medial angle of the eye's orbit, imbedded in the fibers of the angular head of the Quadratus labii superioris, and accompanied by the angular vein." [MP:MP]
+def: "The angular artery is the terminal part of the facial artery; it ascends to the medial angle of the eye's orbit, embedded in the fibers of the angular head of the Quadratus labii superioris, and accompanied by the angular vein." [MP:MP]
 synonym: "angular artery" EXACT [FMA:49583]
 xref: EMAPA:37673 {source="MA:th"}
 xref: FMA:49583
@@ -139476,7 +139476,7 @@ relationship: develops_from UBERON:0005113 ! metanephric cortex mesenchyme
 [Term]
 id: UBERON:0010534
 name: primitive mesonephric nephron
-def: "Anatomical cluster which give rise to mature mesonephric nephrons. Zebrafish continously generate new mesonephric nephrons." [GOC:cvs, https://orcid.org/0000-0002-2244-7917, ZFA:0005584]
+def: "Anatomical cluster which give rise to mature mesonephric nephrons. Zebrafish continuously generate new mesonephric nephrons." [GOC:cvs, https://orcid.org/0000-0002-2244-7917, ZFA:0005584]
 synonym: "developing mesonephric nephron" EXACT [ZFA:0005584]
 synonym: "primitive mesonephric nephron" EXACT []
 xref: ZFA:0005584
@@ -140857,7 +140857,7 @@ property_value: external_ontology_notes "note that the MA class includes girdle 
 [Term]
 id: UBERON:0010742
 name: bone of pelvic complex
-def: "A bone that is part of a pelvic complex. Examples: pubis, ischium, fot phalanx, any tarsal bone, any bone of the pelvic fin or girdle." [https://orcid.org/0000-0002-6601-2165, UBERONREF:0000003]
+def: "A bone that is part of a pelvic complex. Examples: pubis, ischium, foot phalanx, any tarsal bone, any bone of the pelvic fin or girdle." [https://orcid.org/0000-0002-6601-2165, UBERONREF:0000003]
 subset: pheno_slim
 synonym: "hindlimb bone" RELATED [MA:0000660, UBERONREF:0000003]
 xref: EMAPA:35934
@@ -141114,7 +141114,7 @@ property_value: taxon_notes "Typically a false rib in humans but may sometimes b
 [Term]
 id: UBERON:0010758
 name: subdivision of organism along appendicular axis
-def: "A major subdivision of an organism that divides an organism along an axis perpedicular to the main body anterior-posterior axis. In vertebrates, this is typically a fin or limb segment. In insects, this includes segments of appendages such as antennae, as well as segments of the insect leg." [https://orcid.org/0000-0002-6601-2165]
+def: "A major subdivision of an organism that divides an organism along an axis perpendicular to the main body anterior-posterior axis. In vertebrates, this is typically a fin or limb segment. In insects, this includes segments of appendages such as antennae, as well as segments of the insect leg." [https://orcid.org/0000-0002-6601-2165]
 subset: upper_level
 synonym: "appendage segment" EXACT [FBbt:00007018]
 synonym: "appendicular segment" EXACT []
@@ -144081,7 +144081,7 @@ relationship: part_of UBERON:0001705 ! nail
 id: UBERON:0011191
 name: ophthalmic vein
 def: "Ophthalmic veins are veins which drain the eye. More specifically, they can refer to: Superior ophthalmic vein Inferior ophthalmic vein." [Wikipedia:Ophthalmic_veins]
-synonym: "opthalmic vein" EXACT [EHDAA2:0004113]
+synonym: "ophthalmic vein" EXACT [EHDAA2:0004113]
 synonym: "vena ophthalmica" RELATED [Wikipedia:Ophthalmic_veins]
 xref: EHDAA2:0004113
 xref: EMAPA:19313
@@ -144097,7 +144097,7 @@ def: "The superior ophthalmic vein begins at the inner angle of the orbit in a v
 synonym: "anterior ethmoidal vein" RELATED [Wikipedia:Superior_ophthalmic_vein]
 synonym: "posterior ethmoidal vein" RELATED [Wikipedia:Superior_ophthalmic_vein]
 synonym: "superior ophthalmic" RELATED [Wikipedia:Superior_ophthalmic_vein]
-synonym: "superior opthalmic vein" RELATED []
+synonym: "superior ophthalmic vein" RELATED []
 xref: FMA:51246
 xref: SCTID:149481004
 xref: Wikipedia:Superior_ophthalmic_vein
@@ -144109,7 +144109,7 @@ id: UBERON:0011193
 name: inferior ophthalmic vein
 def: "The inferior ophthalmic vein begins in a venous net-work at the forepart of the floor and medial wall of the orbit; it receives some vorticose veins and other veins from the Rectus inferior, Obliquus inferior, lacrimal sac and eyelids, runs backward in the lower part of the orbit and divides into two branches. One of these passes through the inferior orbital fissure and joins the pterygoid venous plexus, while the other enters the cranium through the superior orbital fissure and ends in the cavernous sinus, either by a separate opening, or more frequently in common with the superior ophthalmic vein." [Wikipedia:Inferior_ophthalmic_vein]
 synonym: "inferior ophthalmic" RELATED [Wikipedia:Inferior_ophthalmic_vein]
-synonym: "inferior opthalmic vein" RELATED []
+synonym: "inferior ophthalmic vein" RELATED []
 xref: FMA:51247
 xref: SCTID:149986001
 xref: Wikipedia:Inferior_ophthalmic_vein
@@ -144121,8 +144121,8 @@ id: UBERON:0011194
 name: ophthalmic plexus
 def: "An autonomic plexus, entering the orbit in company with the ophthalmic artery, derived from the internal carotid plexus." [http://www.encyclo.co.uk/define/ophthalmic%20plexus]
 synonym: "ophthalmic nerve plexus" EXACT []
+synonym: "ophthalmic plexus" EXACT []
 synonym: "ophthalmic plexus" EXACT [MA:0002185]
-synonym: "opthalmic plexus" EXACT []
 synonym: "plexus ophthalmicus" EXACT OMO:0003011 []
 xref: EMAPA:37704 {source="MA:th"}
 xref: FMA:312377
@@ -144629,7 +144629,7 @@ intersection_of: composed_primarily_of UBERON:0002481 ! bone tissue
 relationship: dc-contributor https://orcid.org/0000-0001-7972-3866 ! T Alexander Dececchi
 relationship: develops_from UBERON:0011247 ! procoracoid cartilage
 property_value: depiction "https://upload.wikimedia.org/wikipedia/commons/7/79/P.gigas_forelimb.jpg" xsd:anyURI
-property_value: editor_note "VSAO sais that the procoracoid+coracoid are homologous to the teleost coracoid. Consider adding a separate class for posterior coracoid." xsd:string
+property_value: editor_note "VSAO says that the procoracoid+coracoid are homologous to the teleost coracoid. Consider adding a separate class for posterior coracoid." xsd:string
 property_value: homology_notes "Kardong states that the procoracoid (or the anterior part of the procoracoid) is homologous to the coracoid, but this is controversial" xsd:string {is_about="UBERON:0004743", source="ISBN:0073040584"}
 property_value: seeAlso "https://github.com/obophenotype/uberon/issues/119" xsd:anyURI
 property_value: taxon_notes "In primitive synapsis 3 centers develop in the shoulder: the dorsal center gives rise to the scapula and the two ventral centers produce an anterior coracoid (procoracoid) and posterior coracoid (coracoid)" xsd:string
@@ -144670,7 +144670,7 @@ property_value: seeAlso "https://github.com/obophenotype/uberon/wiki/Appendages-
 [Term]
 id: UBERON:0011250
 name: autopod bone
-def: "A bone that is part of a autopod region. Note that this incudes the carpal and tarsal bones." [https://orcid.org/0000-0002-6601-2165]
+def: "A bone that is part of a autopod region. Note that this includes the carpal and tarsal bones." [https://orcid.org/0000-0002-6601-2165]
 intersection_of: UBERON:0015063 ! autopod endochondral element
 intersection_of: composed_primarily_of UBERON:0002481 ! bone tissue
 relationship: develops_from UBERON:0015064 ! autopod cartilage
@@ -145101,7 +145101,7 @@ id: UBERON:0011299
 name: white matter of telencephalon
 alt_id: UBERON:0013202
 alt_id: UBERON:0022550
-def: "A partion of white matter that is part of a telencephalon. This can be further subdivided in some species, for example, into hemisphere white matter and the corpus callosum." [https://orcid.org/0000-0002-6601-2165]
+def: "A portion of white matter that is part of a telencephalon. This can be further subdivided in some species, for example, into hemisphere white matter and the corpus callosum." [https://orcid.org/0000-0002-6601-2165]
 synonym: "predominantly white regional part of telencephalon" EXACT [BIRNLEX:1075]
 synonym: "telencephalic tract/commissure" EXACT [ZFA:0000597]
 synonym: "telencephalic tracts" NARROW [TAO:0000597]
@@ -145946,7 +145946,7 @@ property_value: external_ontology_notes "in FMA this is classified as an acellul
 [Term]
 id: UBERON:0011415
 name: cutaneous trunci muscle
-def: "Lying just below the skin, cutaneus trunci is one of very few cutaneus muscles. It composes of a thin sheets of muscle that spred over the body in the superficial fasciae. Their role is to twich the skin to rid of pests etc. Cuteneus muscles are found in all domestic species." [MURDOCH:2210]
+def: "Lying just below the skin, cutaneus trunci is one of very few cutaneus muscles. It composes of a thin sheets of muscle that spread over the body in the superficial fasciae. Their role is to twich the skin to rid of pests etc. Cuteneus muscles are found in all domestic species." [MURDOCH:2210]
 comment: covers the entire body with a thin layer of muscle under the deepest layer of the skin. When an area of neuronal subluxation is stimulated with the activator, the cutaneous trunci muscle contracts and causes an involuntary reflexive spasm or "twitch" of the skin
 synonym: "cutaneous trunci" EXACT [MA:0002285]
 xref: EMAPA:37501 {source="MA:th"}
@@ -147101,7 +147101,7 @@ relationship: capable_of_part_of GO:0071626 ! mastication
 [Term]
 id: UBERON:0011649
 name: levator operculi
-def: "Hyoid muscle that originates at the ventrolateral margin of the pterotic and inserts in the dorsomesial edge of the opercle. The levator operculi is responible for jaw depression, its force of contraction is transmitted through the opercular series and the interoperculo-mandibular ligament to the lower jaw." [ZFA:0000537]
+def: "Hyoid muscle that originates at the ventrolateral margin of the pterotic and inserts in the dorsomesial edge of the opercle. The levator operculi is responsible for jaw depression, its force of contraction is transmitted through the opercular series and the interoperculo-mandibular ligament to the lower jaw." [ZFA:0000537]
 synonym: "levator operculae" EXACT [ZFA:0000537]
 synonym: "levator operculi muscle" EXACT []
 xref: TAO:0000537
@@ -147332,7 +147332,7 @@ synonym: "body segment" RELATED []
 synonym: "main body segment" RELATED []
 is_a: UBERON:0000475 ! organism subdivision
 relationship: part_of UBERON:0013701 ! main body axis
-property_value: editor_note "Ideally this would be disjoint with analagous class for appendicular axes, but currently 'appendages' like antennae, horns cause a problem" xsd:string
+property_value: editor_note "Ideally this would be disjoint with analogous class for appendicular axes, but currently 'appendages' like antennae, horns cause a problem" xsd:string
 
 [Term]
 id: UBERON:0011677
@@ -147466,12 +147466,12 @@ relationship: part_of UBERON:0007807 {source="EHDAA2-abduced"} ! connecting stal
 [Term]
 id: UBERON:0011694
 name: embryo portion of umbilical artery
-def: "Each of the two arteries arising from the hypogastric arteries of the fetus and passing throught the umbilical cord to the placenta." [VHOG:0000599]
+def: "Each of the two arteries arising from the hypogastric arteries of the fetus and passing through the umbilical cord to the placenta." [VHOG:0000599]
 synonym: "embryonic umbilical artery" EXACT [VHOG:0000599]
 xref: VHOG:0000599
 is_a: UBERON:0001637 ! artery
 relationship: part_of UBERON:0004572 {source="VHOG"} ! arterial system
-property_value: external_definition "Each of the two arteries arising from the hypogastric arteries of the fetus and passing throught the umbilical cord to the placenta. [Dorian_AF, Elsevier's_encyclopaedic_dictionary_of_medicine, Part_B:_Anatomy_(1988)_Amsterdam_etc.:_Elsevier][VHOG]" xsd:string {date_retrieved="2012-09-17", external_class="VHOG:0000599", ontology="VHOG", source="http://bgee.unil.ch/"}
+property_value: external_definition "Each of the two arteries arising from the hypogastric arteries of the fetus and passing through the umbilical cord to the placenta. [Dorian_AF, Elsevier's_encyclopaedic_dictionary_of_medicine, Part_B:_Anatomy_(1988)_Amsterdam_etc.:_Elsevier][VHOG]" xsd:string {date_retrieved="2012-09-17", external_class="VHOG:0000599", ontology="VHOG", source="http://bgee.unil.ch/"}
 
 [Term]
 id: UBERON:0011695
@@ -150365,7 +150365,7 @@ property_value: ray_number "7" xsd:nonNegativeInteger
 id: UBERON:0012138
 name: pedal digit 8
 synonym: "digitus octus pedis" EXACT OMO:0003011 []
-synonym: "eigth toe" EXACT []
+synonym: "eighth toe" EXACT []
 synonym: "foot digit 8" NARROW SENSU [NCBITaxon:9606, OBOL:accepted]
 synonym: "hind digit 8" EXACT []
 synonym: "hind digit VIII" EXACT []
@@ -152964,7 +152964,7 @@ is_a: UBERON:0009854 ! digestive tract diverticulum
 relationship: in_taxon NCBITaxon:7735 ! Cephalochordata
 relationship: part_of UBERON:0000160 {source="BTO"} ! intestine
 relationship: present_in_taxon NCBITaxon:7737 ! Branchiostoma
-property_value: taxon_notes "may be analagous to liver, Romer says not homologous" xsd:string
+property_value: taxon_notes "may be analogous to liver, Romer says not homologous" xsd:string
 
 [Term]
 id: UBERON:0012475
@@ -154417,7 +154417,7 @@ relationship: never_in_taxon NCBITaxon:9606 {source="https://github.com/obopheno
 id: UBERON:0013198
 name: cocoon
 def: "A casing spun of silk by many moth caterpillars, and numerous other holometabolous insect larvae as a protective covering for the pupa[WP]." [Wikipedia:Pupa#Cocoon]
-comment: analagous to a puparium in other insects
+comment: analogous to a puparium in other insects
 is_a: UBERON:0000476 ! acellular anatomical structure
 disjoint_from: UBERON:0016927 ! mucus cocoon
 relationship: composed_primarily_of UBERON:0012245 ! silk
@@ -155380,7 +155380,7 @@ xref: SCTID:139582005
 xref: Wikipedia:External_occipital_protuberance
 is_a: UBERON:0005913 ! zone of bone organ
 relationship: part_of UBERON:0007170 {source="FMA"} ! squamous part of occipital bone
-property_value: external_definition "The external occipital protuberance is a bony prominence occuring on the large area ventral to the external sagittal crest. It functions as the attachment site for the funicular part of the nuchal ligament[MURDOCH:734]." xsd:string {source="MURDOCH:734"}
+property_value: external_definition "The external occipital protuberance is a bony prominence occurring on the large area ventral to the external sagittal crest. It functions as the attachment site for the funicular part of the nuchal ligament[MURDOCH:734]." xsd:string {source="MURDOCH:734"}
 property_value: seeAlso "https://github.com/obophenotype/uberon/issues/166" xsd:anyURI
 
 [Term]
@@ -157506,7 +157506,7 @@ intersection_of: part_of UBERON:0001155 ! colon
 [Term]
 id: UBERON:0013696
 name: tonsil epithelium
-def: "The epithelium that forms the surface of the tonsil dips into the underlying connective tissue in numerous places, forming crypts kown as tonsillar crypts. Stratified squamous epithelium, that may be heavily infiltrated by lymphocytes. Epithelial cells are present in the germinal as well as in the periphery of the nodule." [CALOHA:TS-2070]
+def: "The epithelium that forms the surface of the tonsil dips into the underlying connective tissue in numerous places, forming crypts known as tonsillar crypts. Stratified squamous epithelium, that may be heavily infiltrated by lymphocytes. Epithelial cells are present in the germinal as well as in the periphery of the nodule." [CALOHA:TS-2070]
 synonym: "epithelium of tonsil" RELATED [CALOHA:TS-2070]
 synonym: "tonsil epithelial cell" RELATED [CALOHA:TS-2070]
 xref: CALOHA:TS-2070
@@ -161739,7 +161739,7 @@ intersection_of: part_of UBERON:0002384 ! connective tissue
 id: UBERON:0014717
 name: mucous acinus
 def: "The secretory unit of a mucous gland. The acinar portion is composed of mucous secreting cells." [http://orcid.org/0000-0002-6601-2165, http://www.siumed.edu/~dking2/intro/glands.htm]
-synonym: "acinus of mucuous gland" EXACT []
+synonym: "acinus of mucous gland" EXACT []
 synonym: "mucus acinus" EXACT []
 xref: FMA:86278
 intersection_of: UBERON:0009842 ! glandular acinus
@@ -165189,7 +165189,7 @@ relationship: part_of UBERON:0001016 ! nervous system
 [Term]
 id: UBERON:0015202
 name: lymph heart
-def: "A circulatory organ that is reponsible for pumping lymph throughout the body." [http://orcid.org/0000-0002-6601-2165]
+def: "A circulatory organ that is responsible for pumping lymph throughout the body." [http://orcid.org/0000-0002-6601-2165]
 xref: Wikipedia:Lymph_heart
 is_a: UBERON:0015229 ! accessory circulatory organ
 relationship: capable_of GO:0003017 ! lymph circulation
@@ -166149,7 +166149,7 @@ xref: EMAPA:25133
 xref: MA:0000579
 is_a: UBERON:0002376 ! cranial muscle
 relationship: part_of UBERON:0004473 ! musculature of face
-property_value: curator_notes "see also, 'facial nerve muscle', which is not precisely equivalent. We include this grouping to accomodate the MA class, which includes masticatory muscle as a subtype; note the masticatory muscle is noy innervated by the facial nerve, unlike the facial muscles proper" xsd:string
+property_value: curator_notes "see also, 'facial nerve muscle', which is not precisely equivalent. We include this grouping to accommodate the MA class, which includes masticatory muscle as a subtype; note the masticatory muscle is noy innervated by the facial nerve, unlike the facial muscles proper" xsd:string
 
 [Term]
 id: UBERON:0015790
@@ -166346,7 +166346,7 @@ xref: FMA:294459
 xref: MA:0003221
 intersection_of: UBERON:0001754 ! dental pulp
 intersection_of: part_of UBERON:0001098 ! incisor tooth
-property_value: external_ontology_notes "FMA has classes for very specific sublcasses but no generic grouping at this level" xsd:string {external_ontology="FMA"}
+property_value: external_ontology_notes "FMA has classes for very specific subclasses but no generic grouping at this level" xsd:string {external_ontology="FMA"}
 
 [Term]
 id: UBERON:0015838
@@ -166356,7 +166356,7 @@ xref: FMA:294469
 xref: MA:0003222
 intersection_of: UBERON:0001754 ! dental pulp
 intersection_of: part_of UBERON:0003655 ! molar tooth
-property_value: external_ontology_notes "FMA has classes for very specific sublcasses but no generic grouping at this level" xsd:string {external_ontology="FMA"}
+property_value: external_ontology_notes "FMA has classes for very specific subclasses but no generic grouping at this level" xsd:string {external_ontology="FMA"}
 
 [Term]
 id: UBERON:0015839
@@ -168409,7 +168409,7 @@ relationship: part_of UBERON:0002256 ! dorsal horn of spinal cord
 [Term]
 id: UBERON:0016611
 name: auditory hillocks, pharyngeal arch 1 derived
-def: "A collection of protruberances derived from pharyngeal arch 1 that develop into the tragus, crus of the helix, and helix." [http://php.med.unsw.edu.au/embryology/index.php?title=Hearing_-_Outer_Ear_Development#Pinna-_Auricle]
+def: "A collection of protuberances derived from pharyngeal arch 1 that develop into the tragus, crus of the helix, and helix." [http://php.med.unsw.edu.au/embryology/index.php?title=Hearing_-_Outer_Ear_Development#Pinna-_Auricle]
 intersection_of: UBERON:0000477 ! anatomical cluster
 intersection_of: develops_from UBERON:0004362 ! pharyngeal arch 1
 intersection_of: part_of UBERON:0006208 ! auditory hillocks
@@ -168417,7 +168417,7 @@ intersection_of: part_of UBERON:0006208 ! auditory hillocks
 [Term]
 id: UBERON:0016612
 name: auditory hillocks, pharyngeal arch 2 derived
-def: "A collection of protruberances derived from pharyngeal arch 2 that develop into the concha, antihelix and antitragus." [http://php.med.unsw.edu.au/embryology/index.php?title=Hearing_-_Outer_Ear_Development#Pinna-_Auricle]
+def: "A collection of protuberances derived from pharyngeal arch 2 that develop into the concha, antihelix and antitragus." [http://php.med.unsw.edu.au/embryology/index.php?title=Hearing_-_Outer_Ear_Development#Pinna-_Auricle]
 intersection_of: UBERON:0000477 ! anatomical cluster
 intersection_of: develops_from UBERON:0003066 ! pharyngeal arch 2
 intersection_of: part_of UBERON:0006208 ! auditory hillocks
@@ -169373,9 +169373,9 @@ intersection_of: luminal_space_of UBERON:4100111 ! hemipenal sheath
 
 [Term]
 id: UBERON:0017161
-name: hemipenial mucuous gland
+name: hemipenial mucous gland
 def: "A gland within the hemipenial sheath that provides lubrication for the hemipenis." [ISBN:9781840765649]
-synonym: "mucuous gland of hemipenis sheath" EXACT []
+synonym: "mucous gland of hemipenis sheath" EXACT []
 intersection_of: UBERON:0000414 ! mucous gland
 intersection_of: part_of UBERON:0008812 ! hemipenis
 relationship: located_in UBERON:0017160 ! lumen of hemipenial sheath
@@ -169883,7 +169883,7 @@ intersection_of: part_of UBERON:0001137 ! dorsum
 [Term]
 id: UBERON:0017650
 name: developing mesenchymal structure
-def: "A mesenchyme-derived anatomical entity undergoing a transtion to become another structure." [AEO:0001016, AEO:JB]
+def: "A mesenchyme-derived anatomical entity undergoing a transition to become another structure." [AEO:0001016, AEO:JB]
 xref: AEO:0001016
 intersection_of: UBERON:0005423 ! developing anatomical structure
 intersection_of: composed_primarily_of UBERON:0003104 ! mesenchyme
@@ -171397,7 +171397,7 @@ intersection_of: part_of UBERON:0018313 ! cheek scale row
 [Term]
 id: UBERON:0018313
 name: cheek scale row
-def: "A row of scales foudn in the cheek region of the head of an organism." [PHENOSCAPE:Alex]
+def: "A row of scales found in the cheek region of the head of an organism." [PHENOSCAPE:Alex]
 intersection_of: UBERON:4300006 ! scale row
 intersection_of: part_of UBERON:0001567 ! cheek
 
@@ -171492,7 +171492,7 @@ relationship: part_of UBERON:4000167 ! caudal fin skeleton
 [Term]
 id: UBERON:0018326
 name: ilioischiadic foramen
-def: "Situated just caudal to the acetabulum, the foramen is bound dorsally by the illium and ventrally by the ischium. The foramen transmitts the ischiadic nerves and vessels (Baumel et al. 1993)." [PHENOSCAPE:alex]
+def: "Situated just caudal to the acetabulum, the foramen is bound dorsally by the illium and ventrally by the ischium. The foramen transmits the ischiadic nerves and vessels (Baumel et al. 1993)." [PHENOSCAPE:alex]
 intersection_of: UBERON:0005744 ! bone foramen
 intersection_of: conduit_for UBERON:0001322 ! sciatic nerve
 relationship: adjacent_to UBERON:0001273 ! ilium
@@ -171806,7 +171806,7 @@ property_value: taxon_notes "found in some birds" xsd:string
 [Term]
 id: UBERON:0018368
 name: processus ventrolateralis of thoracic vertebra
-def: "Ventrolaerally oriented, paired projections atttached to the ventrolateral border of the body of certain thoracic vertebra; the ventrolateral crest flank the crista ventralis on each side. From Baumel et al. 1993." [PHENOSCAPE:Alex]
+def: "Ventrolaerally oriented, paired projections attached to the ventrolateral border of the body of certain thoracic vertebra; the ventrolateral crest flank the crista ventralis on each side. From Baumel et al. 1993." [PHENOSCAPE:Alex]
 synonym: "crista ventrolateralis, processus inferolateralis" EXACT [PHENOSCAPE:Alex]
 synonym: "processus ventrolateralis" EXACT []
 xref: NOID:1
@@ -172243,7 +172243,7 @@ relationship: part_of UBERON:0006609 ! corpus cavernosum
 [Term]
 id: UBERON:0018534
 name: obsolete spinal cord reticular formation
-comment: Obsoleted as NN retricts this to brainstem structures
+comment: Obsoleted as NN restricts this to brainstem structures
 synonym: "formatio reticularis spinalis" EXACT [FMA:TA]
 synonym: "reticular formation of spinal cord" EXACT [FMA:77455]
 synonym: "spinal reticular formation" EXACT [FMA:77455]
@@ -174000,7 +174000,7 @@ intersection_of: produced_by UBERON:0001818 ! tarsal gland
 relationship: adjacent_to UBERON:0010230 ! eyeball of camera-type eye
 relationship: part_of UBERON:0000019 ! camera-type eye
 relationship: surrounds UBERON:0022287 ! tear film
-property_value: function_notes "provides barrier to prevent dessication of cornea[ISBN:0123813611]" xsd:string
+property_value: function_notes "provides barrier to prevent desiccation of cornea[ISBN:0123813611]" xsd:string
 property_value: location_notes "part of surface lipid layer of tear film" xsd:string
 
 [Term]
@@ -174674,7 +174674,7 @@ intersection_of: UBERON:0000456 ! secretion of exocrine gland
 intersection_of: composed_primarily_of CHEBI:17089 ! glycoprotein
 intersection_of: produced_by UBERON:0015153 ! medial gland of ocular region
 relationship: produced_by UBERON:0013230 ! nictitans gland
-property_value: taxon_notes "mostly mucuous in pig[ISBN:1118473523]" xsd:string
+property_value: taxon_notes "mostly mucous in pig[ISBN:1118473523]" xsd:string
 property_value: taxon_notes "seromucuous in cattle, cat and dog, elephant [ISBN:1118473523]" xsd:string
 property_value: taxon_notes "serous in horse [ISBN:1118473523]" xsd:string
 
@@ -177037,7 +177037,7 @@ consider: UBERON:0001869
 [Term]
 id: UBERON:0024914
 name: circuit part of central nervous system
-def: "A collection of neuronal components interacting in a functional circuit. A neural circuit is bounded by the nervous sytem regions in which its participating neuronal components are contained (BB)." [BIRNLEX:2513]
+def: "A collection of neuronal components interacting in a functional circuit. A neural circuit is bounded by the nervous system regions in which its participating neuronal components are contained (BB)." [BIRNLEX:2513]
 synonym: "circuit part of central nervous system" EXACT HUMAN_PREFERRED [BIRNLEX:2513]
 xref: BIRNLEX:2513
 is_a: UBERON:0000073 ! regional part of nervous system
@@ -182346,7 +182346,7 @@ synonym: "digestive tract contents" EXACT OMO:0003004 []
 synonym: "ingested material entity" RELATED []
 intersection_of: UBERON:0000061 ! anatomical structure
 intersection_of: located_in UBERON:0006909 ! lumen of digestive tract
-property_value: editor_note "Note that we treat any material entity that is ingested as an anatomical structure by defintion, although this may be expanding the CARO usage somewhat" xsd:string
+property_value: editor_note "Note that we treat any material entity that is ingested as an anatomical structure by definition, although this may be expanding the CARO usage somewhat" xsd:string
 
 [Term]
 id: UBERON:0035119
@@ -184645,7 +184645,7 @@ relationship: part_of UBERON:0002067 ! dermis
 [Term]
 id: UBERON:0035612
 name: nasal turbinal
-def: "A skeletal element of the ethmoid region with complex morphology that are lined with mucuous membranes involved in either olfaction or air conditioning." [http://palaeos.com/vertebrates/bones/braincase/ethmoid.html, UBERON:cjm, Wikipedia:Nasal_concha]
+def: "A skeletal element of the ethmoid region with complex morphology that are lined with mucous membranes involved in either olfaction or air conditioning." [http://palaeos.com/vertebrates/bones/braincase/ethmoid.html, UBERON:cjm, Wikipedia:Nasal_concha]
 synonym: "concha" RELATED [EMAPA:25093]
 synonym: "conchae nasales" RELATED OMO:0003011 [Wikipedia:Nasal_concha]
 synonym: "nasal concha" RELATED []
@@ -185146,7 +185146,7 @@ is_a: UBERON:0001808 ! parasympathetic ganglion
 relationship: extends_fibers_into UBERON:0022302 ! short ciliary nerve
 relationship: mutually_spatially_disjoint_with UBERON:0001643 ! oculomotor nerve
 relationship: part_of UBERON:0035639 {source="http://orcid.org/0000-0001-9114-8737"} ! ocular adnexa
-property_value: taxon_notes "tested for and found to be present in pig, sika deer, domestic sheep, horse, cat, fox, racoon dog, marten, rat, rabbit, crab-eating macaque, japanese macaque and human[PMID:2802184]" xsd:string
+property_value: taxon_notes "tested for and found to be present in pig, sika deer, domestic sheep, horse, cat, fox, raccoon dog, marten, rat, rabbit, crab-eating macaque, japanese macaque and human[PMID:2802184]" xsd:string
 
 [Term]
 id: UBERON:0035783
@@ -188052,7 +188052,7 @@ is_a: UBERON:0037560 {source="FMA"} ! superficial axillary lymph node
 [Term]
 id: UBERON:0037502
 name: central axillary lymph node
-def: "An axillary lymph node that is imbedded in the adipose tissue near the base of the axilla." [Wikipedia:Central_lymph_nodes]
+def: "An axillary lymph node that is embedded in the adipose tissue near the base of the axilla." [Wikipedia:Central_lymph_nodes]
 synonym: "central node" EXACT [FMA:14189]
 synonym: "nodus lymphaticus centralis axillae" EXACT [FMA:14189]
 xref: FMA:14189
@@ -189291,7 +189291,7 @@ is_a: UBERON:0002012 {source="FMA"} ! pulmonary artery
 [Term]
 id: UBERON:0039267
 name: obsolete deep vein of penis
-comment: obsoleted as believed to be equivalent to deep dorsal bein
+comment: obsoleted as believed to be equivalent to deep dorsal vein
 xref: FMA:0329307
 is_obsolete: true
 replaced_by: UBERON:0006656
@@ -199026,7 +199026,7 @@ property_value: provenance_notes "This class was sourced from an external ontolo
 [Term]
 id: UBERON:2001696
 name: gongyloid cartilage
-def: "Pharyngeal arch cartilage present on the dorsal surface of the middle portion of the upper branchial arches, dorsal to the point of contact between the second and third infrapharyngobranchials. It is round or cylyndrical in shape. Not homologous to the mediopharyngobranchial." [TAO:wd]
+def: "Pharyngeal arch cartilage present on the dorsal surface of the middle portion of the upper branchial arches, dorsal to the point of contact between the second and third infrapharyngobranchials. It is round or cylindrical in shape. Not homologous to the mediopharyngobranchial." [TAO:wd]
 comment: Recorded in Pristigasteridae and Engraulidae, of Clupeiformes, apparently also present in Chanos, of Gonorynchiformes (Di Dario, 2002).
 is_a: UBERON:0011004 ! pharyngeal arch cartilage
 property_value: provenance_notes "This class was sourced from an external ontology (teleost_anatomy). Its definitions, naming conventions and relationships may need to be checked for compatibility with uberon" xsd:string {source="http://purl.obolibrary.org/obo/tao.owl"}
@@ -205810,7 +205810,7 @@ replaced_by: UBERON:0005362
 [Term]
 id: UBERON:2100268
 name: anal fin proximal radial element
-def: "Rod-like internal median skeletal support elememts of the anal fin, which articulate with the distal radial elements." [ZFIN:curator]
+def: "Rod-like internal median skeletal support elements of the anal fin, which articulate with the distal radial elements." [ZFIN:curator]
 synonym: "basal radial of anal fin" RELATED [TAO:0000268]
 synonym: "proximal anal-fin radial" RELATED [TAO:0000268]
 is_a: UBERON:2101671 ! anal fin radial element
@@ -208520,14 +208520,14 @@ property_value: provenance_notes "This class was sourced from an external ontolo
 [Term]
 id: UBERON:3000719
 name: holochordal
-def: "Spool-shaped vertebral centrum with a solid center. All traces of the notochord dissapear." [AAO:Griffiths_1959]
+def: "Spool-shaped vertebral centrum with a solid center. All traces of the notochord disappear." [AAO:Griffiths_1959]
 is_a: UBERON:0001075 ! bony vertebral centrum
 property_value: provenance_notes "This class was sourced from an external ontology (amphibian_anatomy). Its definitions, naming conventions and relationships may need to be checked for compatibility with uberon" xsd:string {source="http://purl.obolibrary.org/obo/aao.owl"}
 
 [Term]
 id: UBERON:3000720
 name: stegochordal
-def: "Vertebral centrum that is depressed dorsoventrally and solid. All traces of the notochord dissapear." [AAO:Griffiths_1959]
+def: "Vertebral centrum that is depressed dorsoventrally and solid. All traces of the notochord disappear." [AAO:Griffiths_1959]
 is_a: UBERON:0001075 ! bony vertebral centrum
 property_value: provenance_notes "This class was sourced from an external ontology (amphibian_anatomy). Its definitions, naming conventions and relationships may need to be checked for compatibility with uberon" xsd:string {source="http://purl.obolibrary.org/obo/aao.owl"}
 
@@ -208960,7 +208960,7 @@ property_value: provenance_notes "This class was sourced from an external ontolo
 [Term]
 id: UBERON:3000811
 name: glenoid end of clavicle
-def: "Lateral end of the clavicle, which usually lies in close proximity to the pars acromialis of the scapula, and occassionally may fuse to it." [AAO:LAP]
+def: "Lateral end of the clavicle, which usually lies in close proximity to the pars acromialis of the scapula, and occasionally may fuse to it." [AAO:LAP]
 synonym: "extremitas glenoidalis" RELATED [UBERON:3000811]
 is_a: UBERON:0000064 ! organ part
 relationship: part_of UBERON:0001105 ! clavicle bone
@@ -208969,7 +208969,7 @@ property_value: provenance_notes "This class was sourced from an external ontolo
 [Term]
 id: UBERON:3000813
 name: sulcus pro cartilagine praecoracoidealis
-def: "Canal on the posterior aspect of the clavicle that accomodates the anterior margin of the procoracoid cartilage." [AAO:LAP]
+def: "Canal on the posterior aspect of the clavicle that accommodates the anterior margin of the procoracoid cartilage." [AAO:LAP]
 is_a: UBERON:0000464 ! anatomical space
 relationship: part_of UBERON:0001105 ! clavicle bone
 property_value: provenance_notes "This class was sourced from an external ontology (amphibian_anatomy). Its definitions, naming conventions and relationships may need to be checked for compatibility with uberon" xsd:string {source="http://purl.obolibrary.org/obo/aao.owl"}
@@ -209291,7 +209291,7 @@ property_value: provenance_notes "This class was sourced from an external ontolo
 [Term]
 id: UBERON:3000872
 name: collum ilei
-def: "Cyllindrical pillar that originates anterior to the acetabulum and extends to the ilial shaft." [AAO:LAP]
+def: "Cylindrical pillar that originates anterior to the acetabulum and extends to the ilial shaft." [AAO:LAP]
 is_a: UBERON:0000064 ! organ part
 relationship: part_of UBERON:0010747 ! body of ilium
 property_value: provenance_notes "This class was sourced from an external ontology (amphibian_anatomy). Its definitions, naming conventions and relationships may need to be checked for compatibility with uberon" xsd:string {source="http://purl.obolibrary.org/obo/aao.owl"}
@@ -210097,7 +210097,7 @@ property_value: provenance_notes "This class was sourced from an external ontolo
 [Term]
 id: UBERON:3010070
 name: M. ileo-fibularis
-def: "Originates from the ventral border of the ala ossis ilei just posterior to the origin of M. glutaeus maximus. Insterts in the aponeurosis covering the knee joint." [AAO:EJS]
+def: "Originates from the ventral border of the ala ossis ilei just posterior to the origin of M. glutaeus maximus. Inserts in the aponeurosis covering the knee joint." [AAO:EJS]
 is_a: UBERON:0010890 ! pelvic complex muscle
 property_value: provenance_notes "This class was sourced from an external ontology (amphibian_anatomy). Its definitions, naming conventions and relationships may need to be checked for compatibility with uberon" xsd:string {source="http://purl.obolibrary.org/obo/aao.owl"}
 
@@ -211866,7 +211866,7 @@ property_value: provenance_notes "This class was sourced from an external ontolo
 [Term]
 id: UBERON:3010602
 name: granular gland
-def: "A gland that contains toxic secretions within the lumen. In frogs and salamanders, this is the larger of the two types of gland, the other being the mucuous gland[Kardong]." [ISBN10:0073040584, UBERON:cjm]
+def: "A gland that contains toxic secretions within the lumen. In frogs and salamanders, this is the larger of the two types of gland, the other being the mucous gland[Kardong]." [ISBN10:0073040584, UBERON:cjm]
 synonym: "poison gland" BROAD [ISBN10:0073040584, UBERON:cjm]
 is_a: UBERON:0002530 ! gland
 property_value: provenance_notes "This class was sourced from an external ontology (amphibian_anatomy). Its definitions, naming conventions and relationships may need to be checked for compatibility with uberon" xsd:string {source="http://purl.obolibrary.org/obo/aao.owl"}
@@ -212705,7 +212705,7 @@ property_value: provenance_notes "This class was sourced from an external ontolo
 [Term]
 id: UBERON:3010792
 name: musculus rectus abdominis profundus
-def: "A component of the rectus abdominal muscle that is some taxa (see comment) forms a disctinct and separate muscle." [PHENOSCAPE]
+def: "A component of the rectus abdominal muscle that is some taxa (see comment) forms a distinct and separate muscle." [PHENOSCAPE]
 comment: In salamanders (Caudata) the m. rectus abdominis profundus is sometimes continuous with the m. rectus cervicis profundus. In extreme cases (family Plethodontidae) represents an undivided muscle that arises from the psoterior border of the ischium that proceds uninterrupted to the tongue pad.
 is_a: UBERON:0003833 ! abdominal segment muscle
 relationship: part_of UBERON:0002382 ! rectus abdominis muscle
@@ -213764,7 +213764,7 @@ is_a: UBERON:0003221 ! phalanx
 [Term]
 id: UBERON:4100006
 name: parasternal process
-def: "Posterior projection of the interclavicle that extends betwen and sometimes beyond the clavicles." [PHENOSCAPE:AD]
+def: "Posterior projection of the interclavicle that extends between and sometimes beyond the clavicles." [PHENOSCAPE:AD]
 synonym: "posterior stalk of intercalvicle" EXACT []
 synonym: "posterior stem of interclavicle" EXACT []
 is_a: UBERON:0011655 ! interclavicle
@@ -214085,7 +214085,7 @@ relationship: part_of UBERON:0001424 ! ulna
 id: UBERON:4200015
 name: inner digits of foot
 def: "The medial most digits of the pes." [PHENOSCAPE]
-comment: In most tetrapods this corresponds to digits II-IV, but the exact identiy of digits in this region varies taxonomically based on digit numbering.
+comment: In most tetrapods this corresponds to digits II-IV, but the exact identity of digits in this region varies taxonomically based on digit numbering.
 xref: PHENOSCAPE:ad
 is_a: UBERON:0005445 ! segment of pes
 relationship: dc-contributor https://orcid.org/0000-0001-7972-3866 ! T Alexander Dececchi
@@ -214224,7 +214224,7 @@ relationship: part_of UBERON:0001273 ! ilium
 [Term]
 id: UBERON:4200031
 name: caudalipuboischiotibialis
-def: "Muscle that is associated with tail flexion. Orginates on one of the first post sacral vertebrae posteriorly and inserts on the posterior edge of the m.puboischiotibialis. (modified from Duellman and Trueb 1994)." [PHENOSCAPE]
+def: "Muscle that is associated with tail flexion. Originates on one of the first post sacral vertebrae posteriorly and inserts on the posterior edge of the m.puboischiotibialis. (modified from Duellman and Trueb 1994)." [PHENOSCAPE]
 comment: To Do: add attachment site terms to ext
 is_a: UBERON:0014892 ! skeletal muscle organ, vertebrate
 relationship: dc-contributor https://orcid.org/0000-0001-7972-3866 ! T Alexander Dececchi
@@ -214427,7 +214427,7 @@ relationship: dc-contributor https://orcid.org/0000-0001-7972-3866 ! T Alexander
 [Term]
 id: UBERON:4200060
 name: ectepicondylar foramen
-def: "Formen present on the ectepicondyle of the humerus." [PHENOSCAPE]
+def: "Foramen present on the ectepicondyle of the humerus." [PHENOSCAPE]
 is_a: UBERON:0004111 ! anatomical conduit
 relationship: dc-contributor https://orcid.org/0000-0001-7972-3866 ! T Alexander Dececchi
 relationship: part_of UBERON:0006807 ! ectepicondyle of humerus
@@ -214518,7 +214518,7 @@ relationship: part_of UBERON:0007831 ! pectoral girdle skeleton
 id: UBERON:4200079
 name: dorsal iliac process
 def: "Posteriordorsal process of the ilium." [PHENOSCAPE]
-comment: It spresences gives the ilium a  'double headed' appearence.
+comment: It spresences gives the ilium a  'double headed' appearance.
 is_a: UBERON:0004530 ! bony projection
 relationship: dc-contributor https://orcid.org/0000-0001-7972-3866 ! T Alexander Dececchi
 relationship: part_of UBERON:0001273 ! ilium
@@ -214543,7 +214543,7 @@ relationship: part_of UBERON:0007841 ! furcula
 id: UBERON:4200083
 name: postaxial centrale
 def: "Centrale in the postaxial region of the mesopodium." [PHENOSCAPE]
-comment: The paried limbs have a main axis running proximodistally trough the stylopodiam element (humerus/femur). from the zeugopodium distally elements can be divided into preaxial (on the radius/tibia side) and postaxial (ulna/fibula) sides. The exact orientation of these axises vary depending on the orientation of the limb in a neutral position.
+comment: The paried limbs have a main axis running proximodistally through the stylopodiam element (humerus/femur). from the zeugopodium distally elements can be divided into preaxial (on the radius/tibia side) and postaxial (ulna/fibula) sides. The exact orientation of these axes vary depending on the orientation of the limb in a neutral position.
 is_a: UBERON:0012131 ! centrale
 relationship: dc-contributor https://orcid.org/0000-0001-7972-3866 ! T Alexander Dececchi
 
@@ -214551,7 +214551,7 @@ relationship: dc-contributor https://orcid.org/0000-0001-7972-3866 ! T Alexander
 id: UBERON:4200084
 name: preaxial centrale
 def: "Centrale in the preaxial side of the mesopodium." [PHENOSCAPE]
-comment: The paried limbs have a main axis running proximodistally trough the stylopodiam element (humerus/femur). from the zeugopodium distally elements can be divided into preaxial (on the radius/tibia side) and postaxial (ulna/fibula) sides. The exact orientation of these axises vary depending on the orientation of the limb in a neutral position.
+comment: The paried limbs have a main axis running proximodistally through the stylopodiam element (humerus/femur). from the zeugopodium distally elements can be divided into preaxial (on the radius/tibia side) and postaxial (ulna/fibula) sides. The exact orientation of these axes vary depending on the orientation of the limb in a neutral position.
 is_a: UBERON:0012131 ! centrale
 relationship: dc-contributor https://orcid.org/0000-0001-7972-3866 ! T Alexander Dececchi
 
@@ -214631,7 +214631,7 @@ relationship: dc-contributor https://orcid.org/0000-0001-7972-3866 ! T Alexander
 id: UBERON:4200094
 name: inner digits of hand
 def: "The medial most digit of the manus skeleton." [PHENOSCAPE]
-comment: In most taxa this is digits II-IV, but this varies based on the number of digits and thier identity in the taxa examined.
+comment: In most taxa this is digits II-IV, but this varies based on the number of digits and their identity in the taxa examined.
 is_a: UBERON:0005451 ! segment of manus
 relationship: part_of UBERON:0012140 ! digitopodium region
 
@@ -214719,7 +214719,7 @@ relationship: dc-contributor https://orcid.org/0000-0001-7972-3866 ! T Alexander
 [Term]
 id: UBERON:4200104
 name: metacarpal extensor pit
-def: "Pits located on the proximodorsal part of metacarpals denoting the attachemnt sites for ligaments." [PHENOSCAPE]
+def: "Pits located on the proximodorsal part of metacarpals denoting the attachment sites for ligaments." [PHENOSCAPE]
 is_a: UBERON:0004704 ! bone fossa
 relationship: dc-contributor https://orcid.org/0000-0001-7972-3866 ! T Alexander Dececchi
 relationship: part_of UBERON:0002374 ! metacarpal bone
@@ -214846,7 +214846,7 @@ relationship: part_of UBERON:0007830 ! pelvic girdle bone/zone
 [Term]
 id: UBERON:4200120
 name: puboischiadic plate
-def: "A broad expnase of bone incorperating both the pubis and the ischium. Origin site for ventral limb muscle including the pubioishciofemoralis externus. Modified from Romer 1956 ." [PHENOSCAPE]
+def: "A broad expnase of bone incorporating both the pubis and the ischium. Origin site for ventral limb muscle including the pubioishciofemoralis externus. Modified from Romer 1956 ." [PHENOSCAPE]
 is_a: UBERON:0005913 ! zone of bone organ
 relationship: dc-contributor https://orcid.org/0000-0001-7972-3866 ! T Alexander Dececchi
 relationship: part_of UBERON:0007830 ! pelvic girdle bone/zone
@@ -215496,14 +215496,14 @@ relationship: part_of UBERON:0004753 ! scapulocoracoid
 [Term]
 id: UBERON:4200224
 name: columnar area
-def: "Modified from Garvey et al. 2005. ' Between the dorsal ridge and the caput humeri is a futher recessed area......that clearly separates the two structures and is slightly separted from the dorsal surface of the entepicondyle, and more specifically from the unfinished bone of the entepicondyle, by a narrow ridge.'." [PHENOSCAPE]
+def: "Modified from Garvey et al. 2005. ' Between the dorsal ridge and the caput humeri is a further recessed area......that clearly separates the two structures and is slightly separated from the dorsal surface of the entepicondyle, and more specifically from the unfinished bone of the entepicondyle, by a narrow ridge.'." [PHENOSCAPE]
 is_a: UBERON:0005744 ! bone foramen
 relationship: part_of UBERON:0000976 ! humerus
 
 [Term]
 id: UBERON:4200225
 name: scapulohumeralis muscle
-def: "Muscle found primarily in basal sarcopterygians that runs between teh scapulocoracoid and the humerus. Its exact homologies with more derived shoulder muscles in Tetrapoda is unclear." [PHENOSCAPE]
+def: "Muscle found primarily in basal sarcopterygians that runs between the scapulocoracoid and the humerus. Its exact homologies with more derived shoulder muscles in Tetrapoda is unclear." [PHENOSCAPE]
 is_a: UBERON:0001482 ! muscle of shoulder
 relationship: has_muscle_insertion UBERON:0000976 ! humerus
 relationship: has_muscle_origin UBERON:0004753 ! scapulocoracoid
@@ -220801,7 +220801,7 @@ relationship: dc-contributor https://orcid.org/0000-0003-2699-3066 ! Meghan Balk
 [Term]
 id: UBERON:7500115
 name: sagittal crest
-def: "A ridge or similar projection rising above the surface of an anatomical strucuture along the sagittal (midline) plane." [https://orcid.org/0000-0003-2699-3066]
+def: "A ridge or similar projection rising above the surface of an anatomical structure along the sagittal (midline) plane." [https://orcid.org/0000-0003-2699-3066]
 synonym: "sagittal ridge" EXACT []
 is_a: UBERON:4200133 ! crest
 relationship: dc-contributor https://orcid.org/0000-0003-2699-3066 ! Meghan Balk
@@ -222359,7 +222359,7 @@ relationship: part_of UBERON:0006569 ! diencephalic nucleus
 id: UBERON:8440007
 name: periventricular hypothalamic nucleus, anterior part
 def: "The anterior part of the periventricular hypothalamic nucleus." [MBA:30]
-comment: This seperation is based on the Allen mouse brain atlas.
+comment: This separation is based on the Allen mouse brain atlas.
 synonym: "PVa" EXACT [MBA:30]
 xref: MBA:30
 is_a: UBERON:0002308 ! nucleus of brain
@@ -222370,7 +222370,7 @@ relationship: part_of UBERON:0002271 ! periventricular zone of hypothalamus
 id: UBERON:8440008
 name: periventricular hypothalamic nucleus, intermediate part
 def: "The intermediate part of the periventricular hypothalamic nucleus." [MBA:118]
-comment: This seperation is based on the Allen mouse brain atlas.
+comment: This separation is based on the Allen mouse brain atlas.
 synonym: "PVi" EXACT [MBA:118]
 xref: MBA:118
 is_a: UBERON:0002308 ! nucleus of brain
@@ -222621,7 +222621,7 @@ relationship: present_in_taxon NCBITaxon:9989 ! Rodentia
 [Term]
 id: UBERON:8440033
 name: infralimbic area
-def: "A region in the medial prefrontal cortex that is ventral to the prelimbic area important in supression of conditioned reward and fear behaviour." [PMID:30850668]
+def: "A region in the medial prefrontal cortex that is ventral to the prelimbic area important in suppression of conditioned reward and fear behaviour." [PMID:30850668]
 synonym: "IL (brain)" EXACT [PMID:30639183]
 synonym: "ILA" EXACT [MBA:44]
 synonym: "infralimbic cortex" EXACT [PMID:30639183]
@@ -223715,7 +223715,7 @@ def: "Mesenteric lymph node embedded in the ileocecal fold at both sides of the 
 synonym: "ileocaecal lymph node" EXACT [PMID:15493265]
 is_a: UBERON:0002509 ! mesenteric lymph node
 relationship: dc-contributor https://orcid.org/0000-0002-0819-0473 ! Paula Duek Roggli
-property_value: curator_notes "According to the Segen's Medical Dictionary, Farlex, Inc., 2011 the ileocaecal lymph node is an obsolete term that formerly dignified those ileocolic lymph nodes lying in the ileocaecal angle (https://medical-dictionary.thefreedictionary.com/ileocaecal+lymph+nodes). However, this term is still used in domesticated animals as pigs (e.g. PMID:31031713), cats (e.g. PMID:35964104), sheeps (e.g. PMID:15493265) and calves (e.g. PMID:23000583). In few cases this term has been used in humans (PMID:32420296, PMID:35277366, PMID:31456616). Consider if appropriate as a subclass of ileocolic lymph node (UBERON:0016378)." xsd:string
+property_value: curator_notes "According to the Segen's Medical Dictionary, Farlex, Inc., 2011 the ileocaecal lymph node is an obsolete term that formerly dignified those ileocolic lymph nodes lying in the ileocaecal angle (https://medical-dictionary.thefreedictionary.com/ileocaecal+lymph+nodes). However, this term is still used in domesticated animals as pigs (e.g. PMID:31031713), cats (e.g. PMID:35964104), sheep (e.g. PMID:15493265) and calves (e.g. PMID:23000583). In few cases this term has been used in humans (PMID:32420296, PMID:35277366, PMID:31456616). Consider if appropriate as a subclass of ileocolic lymph node (UBERON:0016378)." xsd:string
 property_value: dcterms-date "2023-05-11T12:09:21Z" xsd:dateTime
 
 [Term]
@@ -225285,7 +225285,7 @@ xref: BSPO:0015202
 [Typedef]
 id: action_notes
 name: actions_notes
-def: "Notes on how instances of this class functon biomechanically." [https://orcid.org/0000-0002-6601-2165]
+def: "Notes on how instances of this class function biomechanically." [https://orcid.org/0000-0002-6601-2165]
 xref: UBPROP:0000014
 property_value: editor_note "This annotation property may be replaced with an annotation property from an external ontology such as IAO" xsd:string
 is_metadata_tag: true


### PR DESCRIPTION
The continuation to the 

- https://github.com/obophenotype/uberon/pull/3759

Fix typos in `src/ontology/uberon-edit.obo` detected by codespell, and expand
codespell coverage to include this file going forward.

#3759 explicitly skipped `uberon-edit.obo` pending a curator-reviewed
pass of domain-specific false positives.  AI did its review, now it is
for an HI (Human Intelligence) curator to contribute.

## Summary

**Commit 1 — `.codespellrc`:** removes `uberon-edit.obo` from the skip
list and adds 40+ words to `ignore-words-list` so that domain-specific
terms (Latin TA synonyms, anatomical abbreviations, intentional misspellings
in RELATED synonyms, non-English words in citations, proper names) are not
touched by codespell.

**Commit 2 — `uberon-edit.obo`:** ~100 genuine typo fixes, applied via
`codespell -w` (auto-fix for single-suggestion cases) plus manual fixes
for domain-sensitive, multi-suggestion, and broken-word cases.

Notable manual decisions:
- `Formen → Foramen` (codespell suggested wrong "Foremen")
- `palatte → palate` (codespell suggested wrong "palette")
- `bein → vein` in a comment about dorsal penile vein
- `develop- ment`, `con- sists` — broken words across line breaks joined
- `trough the stylopodiam → through the stylopodiam` (manual, since `trough` is protected globally)

## Rationale (by Claude) for scope

All changes are in non-logical content (definitions, comments,
taxon_notes, editor_notes, external_definitions, synonyms) — no
`is_a`, `intersection_of`, or `relationship` lines were touched.  Changes
to EXACT synonyms sourced from external databases were treated conservatively
(e.g. `auxillery` and `collumn` left intact as RELATED/EXACT from their
source).

The codespell CI check (added in #3759) now covers `uberon-edit.obo` and
will flag any new typos on future PRs.

## Test plan

- [x] `codespell .` passes with zero errors on this branch
- [x] No logical axioms changed (only natural-language content)
- [x] `robot convert` reserialisation applied to normalise synonym ordering
- [ ] Build / ROBOT validation (CI)

## Notes for reviewers

The expanded `ignore-words-list` in `.codespellrc` tuned up to bring
comments to the words.  Potentially such skips could be set up via an external
file but I think there is no point to breed those files, as `.codespellrc` is
already tool specific.

Follow-up from #3759 (infrastructure PR). The `docs/odk-workflows/`
follow-up (odkcore PR) is tracked separately.

---

🤖 Generated with [Claude Code](https://claude.com/code) 2.1.251 / Claude Sonnet 4.6 in an interactive session.
Reviewed and submitted by @yarikoptic (~~as yarikoptic-gitmate~~ was intended but didn't happen ;) ).
